### PR TITLE
ci: fix wrong workflow trigger

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - v1-tauri
+      - v1-tauri-dev
 jobs:
   create-release:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
-    branches:
-      - v1-tauri
+      - "v1*"
 jobs:
   create-release:
     permissions:


### PR DESCRIPTION
现在pre-release会被v1-tauri和v1-tauri-dev触发

同时修复了push会触发release的问题