### PR TITLE
Fix Issue #191: Propagate WebDAV test errors to frontend

### DIFF
--- a/src/pages/SyncSettings.vue
+++ b/src/pages/SyncSettings.vue
@@ -73,7 +73,7 @@ async function check() {
         await commands.checkCloudBackend(webdav_settings.value)
         showSuccess({ message: $t("sync_settings.test_success") })
       } catch (err) {
-        showError({ message: $t("sync_settings.test_failed") })
+        showError({ message: `${$t("sync_settings.test_failed")}: ${err}` })
         error(`WebDAV test error: ${err}`)
       }
       break
@@ -86,7 +86,7 @@ async function check() {
         await commands.checkCloudBackend(s3_settings.value)
         showSuccess({ message: $t("sync_settings.test_success") })
       } catch (err) {
-        showError({ message: $t("sync_settings.test_failed") })
+        showError({ message: `${$t("sync_settings.test_failed")}: ${err}` })
         error(`S3 test error: ${err}`)
       }
       break;
@@ -137,7 +137,7 @@ async function submit_settings() {
     await load_config();
   } catch (e) {
     error(`Failed to set config: ${e}`);
-    showError({ message: $t("error.set_config_failed") });
+    showError({ message: `${$t("error.set_config_failed")}: ${e}` });
   }
 }
 function abort_change() {
@@ -163,7 +163,7 @@ async function upload_all() {
     showSuccess({ message: $t("sync_settings.upload_success") });
   } catch (err) {
     if (err instanceof Error) {
-      showError({ message: $t("sync_settings.upload_failed") });
+      showError({ message: `${$t("sync_settings.upload_failed")}: ${err.message}` });
       console.error("Upload error:", err);
     } else {
       showInfo({ message: $t("sync_settings.canceled") });
@@ -188,7 +188,7 @@ async function download_all() {
     showSuccess({ message: $t("sync_settings.download_success") });
   } catch (e) {
     if (e instanceof Error) {
-      showError({ message: $t("sync_settings.download_failed") });
+      showError({ message: `${$t("sync_settings.download_failed")}: ${e.message}` });
       error(`Download error: ${e}`);
     } else {
       showInfo({ message: $t("sync_settings.canceled") });
@@ -200,7 +200,7 @@ function open_manual() {
   try { commands.openUrl("https://help.sworld.club/docs/extras/cloud") }
   catch (e) {
     error(`open manual error: ${e}`)
-    showError({ message: $t("error.open_url_failed") })
+    showError({ message: `${$t("error.open_url_failed")}: ${e}` })
   }
 }
 </script>


### PR DESCRIPTION
## Description

This PR fixes Issue #191 where WebDAV test errors were not being properly displayed to users in the UI. Previously, when WebDAV connection tests failed, users would only see a generic "test failed" message while the actual error details were only visible in the logs.

## Changes Made

- **Modified error handling in `SyncSettings.vue`** to display actual error messages from the backend
- **Updated error handlers for**:
  - WebDAV connection testing
  - S3 connection testing  
  - Cloud upload operations
  - Cloud download operations
  - Configuration saving
  - URL opening

## Before vs After

**Before**: Users saw generic messages like "Test failed" 
**After**: Users see specific error details like "Test failed: Failed to create test directory"

## Example

When a WebDAV test fails due to connection issues, users will now see:
```
Test failed: OperatorCheck("Failed to create test directory.")
```

Instead of just:
```
Test failed
```

## Technical Details

The fix was simple but effective - instead of showing only localized generic error messages, the error handlers now concatenate the localized message with the actual error details from the backend:

```typescript
// Before
showError({ message: $t("sync_settings.test_failed") })

// After  
showError({ message: `${$t("sync_settings.test_failed")}: ${err}` })
```

## Testing

The error propagation works correctly as the backend already returns proper error messages through the IPC layer. The issue was purely in the frontend error display logic.

Closes #191