### PR TITLE
feat: add confirmation dialog for quick restore action using localStorage (Issue #169)

### DIFF
--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -11,6 +11,7 @@
     "reset_settings": "Restore default",
     "prompt_when_not_described": "When there is no describe for a save, a prompt pops up",
     "prompt_when_auto_backup": "When automatic backup occurs, a prompt pops up",
+    "prompt_when_quick_restore": "Show confirmation prompt when quick restoring a save",
     "exit_to_tray": "Minimize to tray",
     "extra_backup_when_apply": "Perform extra backups before apply (in the./save_data/game name/extra_backup folder)",
     "enable_dark_mode": "Dark mode",
@@ -86,6 +87,9 @@
   "manage": {
     "create_new_save": "Create new snapshot",
     "load_latest_save": "Overwrite with the latest snapshot",
+    "quick_restore_confirm_title": "Confirm Restore",
+    "quick_restore_confirm_message": "This action will overwrite your current save. If extra backup is enabled, a backup will be created in the corresponding location.",
+    "quick_restore_confirm_checkbox": "Don't show again",
     "launch_game": "Start game",
     "open_backup_folder": "Open backup folder",
     "show_drawer": "View managed files",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -11,6 +11,7 @@
     "confirm_reset": "确认重置?",
     "prompt_when_not_described": "当未描述存档时，弹出提示",
     "prompt_when_auto_backup": "当自动备份时，弹出提示",
+    "prompt_when_quick_restore": "快速恢复存档时，弹出确认提示",
     "exit_to_tray": "退出到托盘",
     "extra_backup_when_apply": "在应用存档时进行额外备份（在 ./save_data/游戏名/extra_backup 文件夹内）",
     "enable_dark_mode": "启用夜间模式",
@@ -86,6 +87,9 @@
   "manage": {
     "create_new_save": "创建新快照",
     "load_latest_save": "恢复最新快照",
+    "quick_restore_confirm_title": "确认恢复存档",
+    "quick_restore_confirm_message": "此操作将覆盖当前存档。如果开启了额外备份，将在对应位置创建备份。",
+    "quick_restore_confirm_checkbox": "不再提示",
     "launch_game": "启动游戏",
     "open_backup_folder": "打开备份文件夹",
     "show_drawer": "查看受管理文件",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -210,7 +210,7 @@ ipcNotification: "ipc-notification"
 
 /** user-defined constants **/
 
-export const DEFAULT_CONFIG = {"backup_path":"./save_data","devices":{},"favorites":[],"games":[],"quick_action":{"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null},"settings":{"add_new_to_favorites":false,"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"root_path":"/game-save-manager"},"default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"show_edit_button":false},"version":"1.5.1"} as const;
+export const DEFAULT_CONFIG = {"backup_path":"./save_data","devices":{},"favorites":[],"games":[],"quick_action":{"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null},"settings":{"add_new_to_favorites":false,"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"root_path":"/game-save-manager"},"default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"prompt_when_quick_restore":true,"show_edit_button":false},"version":"1.5.1"} as const;
 
 /** user-defined types **/
 
@@ -282,7 +282,7 @@ export type SaveUnitType = "File" | "Folder"
 /**
  * Settings that can be configured by user
  */
-export type Settings = { prompt_when_not_described?: boolean; extra_backup_when_apply?: boolean; show_edit_button?: boolean; prompt_when_auto_backup?: boolean; exit_to_tray?: boolean; cloud_settings?: CloudSettings; locale?: string; default_delete_before_apply?: boolean; default_expend_favorites_tree?: boolean; home_page?: string; log_to_file?: boolean; add_new_to_favorites?: boolean }
+export type Settings = { prompt_when_not_described?: boolean; extra_backup_when_apply?: boolean; show_edit_button?: boolean; prompt_when_auto_backup?: boolean; exit_to_tray?: boolean; cloud_settings?: CloudSettings; locale?: string; default_delete_before_apply?: boolean; default_expend_favorites_tree?: boolean; home_page?: string; log_to_file?: boolean; add_new_to_favorites?: boolean; prompt_when_quick_restore?: boolean }
 /**
  * A backup is a zip file that contains
  * all the file that the save unit has declared.

--- a/src/pages/Management/[name].vue
+++ b/src/pages/Management/[name].vue
@@ -248,10 +248,44 @@ async function change_describe(date: string) {
     }
 }
 
-function load_latest_save() {
+async function load_latest_save() {
     // 数组是正序的，最后一个是最新的，而展示用的filter_table是倒序的
     if (table_data.value[table_data.value.length - 1].date) {
-        apply_save(table_data.value[table_data.value.length - 1].date);
+        // 如果设置了需要确认，则显示确认对话框
+        if (config.value.settings.prompt_when_quick_restore) {
+            try {
+                const { action, checked } = await ElMessageBox.confirm(
+                    $t('manage.quick_restore_confirm_message'),
+                    $t('manage.quick_restore_confirm_title'),
+                    {
+                        confirmButtonText: $t('manage.confirm'),
+                        cancelButtonText: $t('manage.cancel'),
+                        type: 'warning',
+                        showClose: false,
+                        distinguishCancelAndClose: true,
+                        showCancelButton: true,
+                        checkboxLabel: $t('manage.quick_restore_confirm_checkbox')
+                    }
+                );
+                
+                // 如果用户勾选了"不再提示"，则更新设置
+                if (checked) {
+                    config.value.settings.prompt_when_quick_restore = false;
+                    await saveConfig();
+                }
+                
+                // 用户确认后执行恢复操作
+                if (action === 'confirm') {
+                    apply_save(table_data.value[table_data.value.length - 1].date);
+                }
+            } catch (e) {
+                // 用户取消操作，不执行任何动作
+                info(`User cancelled the quick restore operation.`);
+            }
+        } else {
+            // 如果不需要确认，直接恢复
+            apply_save(table_data.value[table_data.value.length - 1].date);
+        }
     } else {
         showError({ message: $t('manage.no_backup_error') });
     }

--- a/src/pages/Management/[name].vue
+++ b/src/pages/Management/[name].vue
@@ -251,8 +251,11 @@ async function change_describe(date: string) {
 async function load_latest_save() {
     // 数组是正序的，最后一个是最新的，而展示用的filter_table是倒序的
     if (table_data.value[table_data.value.length - 1].date) {
-        // 如果设置了需要确认，则显示确认对话框
-        if (config.value.settings.prompt_when_quick_restore) {
+        // 检查localStorage中是否设置了不再提示
+        const skipConfirm = localStorage.getItem('gsm_skip_quick_restore_confirm') === 'true';
+        
+        // 如果没有设置不再提示，则显示确认对话框
+        if (!skipConfirm) {
             try {
                 const { action, checked } = await ElMessageBox.confirm(
                     $t('manage.quick_restore_confirm_message'),
@@ -268,10 +271,9 @@ async function load_latest_save() {
                     }
                 );
                 
-                // 如果用户勾选了"不再提示"，则更新设置
+                // 如果用户勾选了"不再提示"，则保存到localStorage
                 if (checked) {
-                    config.value.settings.prompt_when_quick_restore = false;
-                    await saveConfig();
+                    localStorage.setItem('gsm_skip_quick_restore_confirm', 'true');
                 }
                 
                 // 用户确认后执行恢复操作
@@ -283,7 +285,7 @@ async function load_latest_save() {
                 info(`User cancelled the quick restore operation.`);
             }
         } else {
-            // 如果不需要确认，直接恢复
+            // 如果设置了不再提示，直接恢复
             apply_save(table_data.value[table_data.value.length - 1].date);
         }
     } else {

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -388,6 +388,10 @@ const router_list = computed(() => {
                         <span class="setting-label">{{ $t("settings.extra_backup_when_apply") }}</span>
                     </div>
                     <div class="setting-box">
+                        <ElSwitch v-model="config.settings.prompt_when_quick_restore" />
+                        <span class="setting-label">{{ $t("settings.prompt_when_quick_restore") }}</span>
+                    </div>
+                    <div class="setting-box">
                         <ElSwitch v-model="config.settings.default_delete_before_apply" />
                         <span class="setting-label">{{ $t("settings.default_delete_before_apply") }}</span>
                     </div>


### PR DESCRIPTION
## 功能描述

实现了 Issue #169 中的需求，为顶栏的"恢复最新快照"按钮添加了确认对话框功能：

1. 当用户点击"恢复最新快照"按钮时，会弹出确认对话框
2. 确认对话框提醒用户该操作会覆盖当前存档，并告知如果开启了额外备份功能，会在对应位置创建备份
3. 用户可以勾选"不再提示"选项，勾选后将不再显示此确认对话框
4. 用户确认后才会执行恢复操作，取消则不执行任何操作

## 实现方式

1. 使用 localStorage 存储用户的"不再提示"选择，键名为 `gsm_skip_quick_restore_confirm`
2. 修改了 `load_latest_save` 函数，添加了确认对话框逻辑
3. 添加了相关的多语言翻译（中文和英文）

## 测试

已通过 `npm run web:build` 进行构建测试，确保代码无错误。

Closes #169

@mcthesw can click here to [continue refining the PR](https://app.all-hands.dev/conversations/efb50206497a43ebb3db1b0e39e36f0b)