### PR TITLE
feat: add configurable quick action audio notifications

### DIFF
--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -44,6 +44,18 @@
     "log_to_file": "Generate file log",
     "add_new_to_favorites": "New games are automatically added to favorites",
     "quick_action_hotkeys": "Quick backup/restore hotkey settings (settings need to be saved)",
+    "quick_action_notification_title": "Quick action notifications",
+    "quick_action_notify_success": "Notify when quick actions succeed",
+    "quick_action_notify_error": "Notify when quick actions fail",
+    "quick_action_success_sound_title": "Success sound",
+    "quick_action_error_sound_title": "Failure sound",
+    "quick_action_sound_toggle": "Enable sound",
+    "quick_action_sound_source_success_tone": "Default success tone",
+    "quick_action_sound_source_error_tone": "Default error tone",
+    "quick_action_sound_source_file": "Custom file",
+    "quick_action_sound_choose": "Choose file",
+    "quick_action_sound_preview": "Preview/Stop",
+    "quick_action_sound_no_file": "No file selected",
     "hotkey": {
       "quick_backup": "Quick backup",
       "hint": "Note that the settings here are the same as other settings with an asterisk. They need to be saved and restarted to take effect. Setting it to empty will disable this function.",
@@ -305,7 +317,9 @@
     "change_description_failed": "Failed to edit description",
     "open_log_folder_failed": "Cannot open log folder",
     "game_not_found": "The corresponding game cannot be found",
-    "save_config_failed": "Game settings failed to update"
+    "save_config_failed": "Game settings failed to update",
+    "choose_sound_failed": "Failed to choose sound file",
+    "preview_sound_failed": "Failed to play preview"
   },
   "backend": {
     "config": {

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -44,6 +44,18 @@
     "log_to_file": "生成文件日志",
     "add_new_to_favorites": "新游戏自动加入收藏夹",
     "quick_action_hotkeys": "快捷备份/恢复热键设置（需要保存设置）",
+    "quick_action_notification_title": "快捷操作通知",
+    "quick_action_notify_success": "快捷操作成功时通知",
+    "quick_action_notify_error": "快捷操作失败时通知",
+    "quick_action_success_sound_title": "成功音效",
+    "quick_action_error_sound_title": "失败音效",
+    "quick_action_sound_toggle": "启用音效",
+    "quick_action_sound_source_success_tone": "默认成功音",
+    "quick_action_sound_source_error_tone": "默认失败音",
+    "quick_action_sound_source_file": "自定义文件",
+    "quick_action_sound_choose": "选择文件",
+    "quick_action_sound_preview": "试听/终止",
+    "quick_action_sound_no_file": "尚未选择文件",
     "hotkey": {
       "hint": "注意，此处设置和其他带有星号设置一样，需要保存并且重启生效，设置为全空即禁用该功能",
       "quick_backup": "快速备份",
@@ -312,7 +324,9 @@
     "save_config_failed": "游戏设置更新失败",
     "update_device_failed": "更新设备信息失败",
     "get_devices_failed": "获取设备列表失败",
-    "import_paths_failed": "导入路径失败"
+    "import_paths_failed": "导入路径失败",
+    "choose_sound_failed": "选择音频文件失败",
+    "preview_sound_failed": "试听音效失败"
   },
   "backend": {
     "config": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -70,6 +70,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +394,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.91",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,7 +762,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -725,6 +774,23 @@ dependencies = [
  "crypto-common",
  "inout",
 ]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "combine"
@@ -831,6 +897,49 @@ dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -998,6 +1107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1240,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1227,6 +1342,15 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1959,6 +2083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2465,6 +2595,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lewton"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
+dependencies = [
+ "byteorder",
+ "ogg",
+ "tinyvec",
+]
+
+[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,7 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2502,6 +2643,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2602,6 +2753,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "machine-uid"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2672,6 +2832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,6 +2881,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.6.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2722,7 +2902,7 @@ dependencies = [
  "bitflags 2.6.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2733,6 +2913,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -2781,6 +2970,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "normpath"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +3007,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.91",
+]
 
 [[package]]
 name = "num-traits"
@@ -3137,6 +3347,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -3981,6 +4223,7 @@ dependencies = [
  "notify-rust",
  "open",
  "opendal",
+ "rodio",
  "rust-i18n",
  "semver",
  "serde",
@@ -4043,6 +4286,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rodio"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+dependencies = [
+ "claxon",
+ "cpal",
+ "hound",
+ "lewton",
+ "symphonia",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4701,6 +4958,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01c2aae70f0f1fb096b6f0ff112a930b1fb3626178fba3ae68b09dce71706d4"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "798306779e3dc7d5231bd5691f5a813496dc79d3f56bf82e25789f2094e022c3"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc622b9841a10089c5b18e99eb904f4341615d5aa55bbf4eedde1be721a4023c"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4787,9 +5093,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2 0.6.0",
  "objc2-app-kit 0.3.0",
  "objc2-foundation 0.3.0",
@@ -6080,6 +6386,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de69df01bdf1ead2f4ac895dc77c9351aefff65b2f3db429a343f9cbf05e132"
@@ -6097,7 +6413,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.60.1",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-numerics",
 ]
 
@@ -6121,6 +6437,16 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
@@ -6139,7 +6465,7 @@ checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
 dependencies = [
  "windows-implement 0.59.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.1",
  "windows-result 0.3.2",
  "windows-strings 0.3.1",
 ]
@@ -6151,7 +6477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
 dependencies = [
  "windows-core 0.60.1",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6205,13 +6531,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-numerics"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
 dependencies = [
  "windows-core 0.60.1",
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6249,7 +6581,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6268,7 +6600,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6572,7 +6904,7 @@ dependencies = [
  "jni",
  "kuchikiki",
  "libc",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.6.0",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ hostname = "0.4.0"
 dirs = "6.0.0"
 whoami = "1.6.0"
 machine-uid = "0.5.3"
+rodio = { version = "0.19.0", features = ["wav", "flac", "mp3"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-global-shortcut = "2.2.0"

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,0 +1,239 @@
+use std::{
+    f32::consts::PI,
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use log::{error, warn};
+use rodio::{OutputStream, OutputStreamHandle, Sink, decoder::Decoder};
+use tokio::sync::mpsc;
+
+use crate::config::{
+    QuickActionSoundKind, QuickActionSoundProfile, QuickActionSoundSettings, QuickActionSoundSource,
+};
+
+const COMMAND_BUFFER: usize = 8;
+const SAMPLE_RATE: u32 = 44_100;
+const PREVIEW_VOLUME: f32 = 0.6;
+
+#[derive(Clone, Debug)]
+pub enum SoundRequest {
+    PlayEffect {
+        kind: QuickActionSoundKind,
+        profile: QuickActionSoundProfile,
+    },
+    TogglePreview {
+        kind: QuickActionSoundKind,
+        profile: QuickActionSoundProfile,
+    },
+    Stop,
+}
+
+pub struct AudioManager {
+    command_tx: mpsc::Sender<SoundRequest>,
+}
+
+impl AudioManager {
+    pub fn new() -> Self {
+        let (command_tx, command_rx) = mpsc::channel(COMMAND_BUFFER);
+        AudioWorker::spawn(command_rx);
+        Self { command_tx }
+    }
+
+    pub fn play_effect(&self, kind: QuickActionSoundKind, profile: QuickActionSoundProfile) {
+        self.enqueue(SoundRequest::PlayEffect { kind, profile });
+    }
+
+    pub fn toggle_preview(&self, kind: QuickActionSoundKind, profile: QuickActionSoundProfile) {
+        self.enqueue(SoundRequest::TogglePreview { kind, profile });
+    }
+
+    pub fn stop(&self) {
+        self.enqueue(SoundRequest::Stop);
+    }
+
+    fn enqueue(&self, request: SoundRequest) {
+        let tx = self.command_tx.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(err) = tx.send(request).await {
+                warn!(
+                    target: "rgsm::audio",
+                    "Failed to send audio request: {err}"
+                );
+            }
+        });
+    }
+}
+
+struct AudioDevice {
+    _stream: OutputStream,
+    handle: OutputStreamHandle,
+}
+
+struct AudioWorker {
+    device: Option<AudioDevice>,
+    current_sink: Option<Sink>,
+    current_preview: Option<QuickActionSoundKind>,
+    command_rx: mpsc::Receiver<SoundRequest>,
+}
+
+impl AudioWorker {
+    fn spawn(command_rx: mpsc::Receiver<SoundRequest>) {
+        let device = match OutputStream::try_default() {
+            Ok((stream, handle)) => Some(AudioDevice {
+                _stream: stream,
+                handle,
+            }),
+            Err(err) => {
+                error!(target: "rgsm::audio", "Failed to initialize audio output: {err}");
+                None
+            }
+        };
+
+        let worker = Self {
+            device,
+            current_sink: None,
+            current_preview: None,
+            command_rx,
+        };
+
+        tauri::async_runtime::spawn(async move { worker.run().await });
+    }
+
+    async fn run(mut self) {
+        while let Some(request) = self.command_rx.recv().await {
+            if let Err(err) = self.handle_request(request) {
+                error!(target: "rgsm::audio", "Audio request failed: {err:?}");
+            }
+        }
+
+        self.stop_current();
+    }
+
+    fn handle_request(&mut self, request: SoundRequest) -> Result<()> {
+        match request {
+            SoundRequest::Stop => {
+                self.stop_current();
+                self.current_preview = None;
+            }
+            SoundRequest::PlayEffect { kind: _, profile } => {
+                self.stop_current();
+                self.current_preview = None;
+                if profile.enabled {
+                    self.play_profile(&profile)?;
+                }
+            }
+            SoundRequest::TogglePreview { kind, profile } => {
+                if self.current_preview == Some(kind) {
+                    self.stop_current();
+                    self.current_preview = None;
+                } else {
+                    self.stop_current();
+                    self.play_profile(&profile)?;
+                    self.current_preview = Some(kind);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn stop_current(&mut self) {
+        if let Some(sink) = self.current_sink.take() {
+            sink.stop();
+        }
+    }
+
+    fn play_profile(&mut self, profile: &QuickActionSoundProfile) -> Result<()> {
+        let Some(device) = self.device.as_ref() else {
+            return Ok(());
+        };
+
+        let mut sink = Sink::try_new(&device.handle)
+            .context("failed to create rodio sink for quick action sound")?;
+        sink.set_volume(PREVIEW_VOLUME);
+
+        match &profile.source {
+            QuickActionSoundSource::SuccessTone => {
+                sink.append(synthesize_success_tone());
+            }
+            QuickActionSoundSource::ErrorTone => {
+                sink.append(synthesize_error_tone());
+            }
+            QuickActionSoundSource::File { path } => {
+                let resolved = resolve_path(path)?;
+                let file = File::open(&resolved).with_context(|| {
+                    format!("failed to open sound file: {}", resolved.display())
+                })?;
+                let decoder =
+                    Decoder::new(BufReader::new(file)).context("failed to decode sound file")?;
+                sink.append(decoder);
+            }
+        }
+
+        sink.play();
+        self.current_sink = Some(sink);
+        Ok(())
+    }
+}
+
+fn resolve_path(path: &str) -> Result<PathBuf> {
+    let buf = PathBuf::from(path);
+    if buf.is_absolute() {
+        return Ok(buf);
+    }
+
+    let exe_dir = std::env::current_exe()
+        .context("failed to determine executable path when resolving sound file")?
+        .parent()
+        .map(Path::to_path_buf)
+        .context("executable has no parent directory")?;
+
+    Ok(exe_dir.join(buf))
+}
+
+fn synthesize_success_tone() -> rodio::buffer::SamplesBuffer<f32> {
+    synthesize_sequence(&[(987.77, 0.12), (1318.51, 0.16), (1567.98, 0.18)])
+}
+
+fn synthesize_error_tone() -> rodio::buffer::SamplesBuffer<f32> {
+    synthesize_sequence(&[(392.0, 0.16), (311.13, 0.2), (196.0, 0.22)])
+}
+
+fn synthesize_sequence(notes: &[(f32, f32)]) -> rodio::buffer::SamplesBuffer<f32> {
+    let mut samples = Vec::new();
+
+    for (idx, (frequency, duration)) in notes.iter().enumerate() {
+        let total_samples = (SAMPLE_RATE as f32 * duration) as usize;
+        for n in 0..total_samples {
+            let progress = n as f32 / total_samples as f32;
+            let envelope = fade_envelope(progress);
+            let sample = (2.0 * PI * frequency * n as f32 / SAMPLE_RATE as f32).sin();
+            samples.push(sample * envelope * 0.4);
+        }
+
+        if idx + 1 != notes.len() {
+            samples.extend(std::iter::repeat(0.0).take((SAMPLE_RATE as f32 * 0.04) as usize));
+        }
+    }
+
+    rodio::buffer::SamplesBuffer::new(1, SAMPLE_RATE, samples)
+}
+
+fn fade_envelope(progress: f32) -> f32 {
+    let fade_in = (progress / 0.1).clamp(0.0, 1.0);
+    let fade_out = ((1.0 - progress) / 0.2).clamp(0.0, 1.0);
+    fade_in * fade_out
+}
+
+pub fn resolve_profile<'a>(
+    settings: &'a QuickActionSoundSettings,
+    kind: QuickActionSoundKind,
+) -> &'a QuickActionSoundProfile {
+    match kind {
+        QuickActionSoundKind::Success => &settings.success,
+        QuickActionSoundKind::Error => &settings.error,
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -4,6 +4,9 @@ mod settings;
 mod utils;
 
 pub use app_config::{Config, FavoriteTreeNode};
-pub use quick_actions_settings::QuickActionsSettings;
+pub use quick_actions_settings::{
+    QuickActionNotificationSettings, QuickActionSoundKind, QuickActionSoundProfile,
+    QuickActionSoundSettings, QuickActionSoundSource, QuickActionsSettings,
+};
 pub use settings::{SaveListExpandBehavior, Settings};
 pub use utils::*;

--- a/src-tauri/src/config/quick_actions_settings.rs
+++ b/src-tauri/src/config/quick_actions_settings.rs
@@ -3,6 +3,89 @@ use specta::Type;
 
 use crate::{backup::Game, default_value};
 
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum QuickActionSoundKind {
+    Success,
+    Error,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum QuickActionSoundSource {
+    SuccessTone,
+    ErrorTone,
+    File { path: String },
+}
+
+impl QuickActionSoundSource {
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            QuickActionSoundSource::File { path } => Some(path.as_str()),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+pub struct QuickActionSoundProfile {
+    pub enabled: bool,
+    pub source: QuickActionSoundSource,
+}
+
+impl QuickActionSoundProfile {
+    pub fn success_default() -> Self {
+        Self {
+            enabled: default_value::default_true(),
+            source: QuickActionSoundSource::SuccessTone,
+        }
+    }
+
+    pub fn error_default() -> Self {
+        Self {
+            enabled: default_value::default_true(),
+            source: QuickActionSoundSource::ErrorTone,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+pub struct QuickActionNotificationSettings {
+    #[serde(default = "default_value::default_true")]
+    pub on_success: bool,
+    #[serde(default = "default_value::default_true")]
+    pub on_error: bool,
+}
+
+impl Default for QuickActionNotificationSettings {
+    fn default() -> Self {
+        Self {
+            on_success: default_value::default_true(),
+            on_error: default_value::default_true(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+pub struct QuickActionSoundSettings {
+    #[serde(default = "QuickActionSoundProfile::success_default")]
+    pub success: QuickActionSoundProfile,
+    #[serde(default = "QuickActionSoundProfile::error_default")]
+    pub error: QuickActionSoundProfile,
+    #[serde(default)]
+    pub notifications: QuickActionNotificationSettings,
+}
+
+impl Default for QuickActionSoundSettings {
+    fn default() -> Self {
+        Self {
+            success: QuickActionSoundProfile::success_default(),
+            error: QuickActionSoundProfile::error_default(),
+            notifications: QuickActionNotificationSettings::default(),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct QuickActionHotkeys {
     pub apply: Vec<String>,
@@ -24,4 +107,6 @@ pub struct QuickActionsSettings {
     pub quick_action_game: Option<Game>,
     #[serde(default = "default_value::default")]
     pub hotkeys: QuickActionHotkeys,
+    #[serde(default)]
+    pub sound: QuickActionSoundSettings,
 }

--- a/src-tauri/src/ipc_handler.rs
+++ b/src-tauri/src/ipc_handler.rs
@@ -1,6 +1,7 @@
+use crate::audio::AudioManager;
 use crate::backup::{Game, GameSnapshots};
 use crate::cloud_sync::{self, Backend, upload_all};
-use crate::config::{Config, get_config};
+use crate::config::{Config, QuickActionSoundKind, QuickActionSoundProfile, get_config};
 use crate::device::{Device, get_current_device_id};
 use crate::path_resolver;
 use crate::preclude::*;
@@ -81,6 +82,22 @@ pub async fn choose_save_dir(app: AppHandle) -> Result<String, String> {
         Ok(path.to_string())
     } else {
         warn!(target:"rgsm::ipc", "Failed to open dialog or user close the dialog.");
+        Err("Failed to open dialog.".to_string())
+    }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn choose_sound_file(app: AppHandle) -> Result<String, String> {
+    info!(target:"rgsm::ipc", "Opening sound file dialog.");
+    let mut builder = app.dialog().file();
+    builder = builder.add_filter("Audio", &["wav", "mp3", "ogg", "flac", "aac", "m4a"]);
+
+    if let Some(path) = builder.blocking_pick_file() {
+        info!(target:"rgsm::ipc", "Picked sound file: {path:?}");
+        Ok(path.to_string())
+    } else {
+        warn!(target:"rgsm::ipc", "Sound file dialog cancelled");
         Err("Failed to open dialog.".to_string())
     }
 }
@@ -333,6 +350,21 @@ pub async fn resolve_path(path: String) -> Result<String, String> {
 
     info!(target:"rgsm::ipc", "Successfully resolved path: {} -> {}", path, path_str);
     Ok(path_str.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn toggle_quick_action_sound_preview(
+    app: AppHandle,
+    kind: QuickActionSoundKind,
+    profile: QuickActionSoundProfile,
+) -> Result<(), String> {
+    let audio_state = app
+        .try_state::<AudioManager>()
+        .ok_or_else(|| "Audio manager not initialized".to_string())?;
+
+    audio_state.toggle_preview(kind, profile);
+    Ok(())
 }
 
 /// Returns the current device, if not found, returns a default device

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 
 use crate::config::config_check;
 
+mod audio;
 mod backup;
 mod cloud_sync;
 mod config;
@@ -59,6 +60,7 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::open_file_or_folder,
             ipc_handler::choose_save_file,
             ipc_handler::choose_save_dir,
+            ipc_handler::choose_sound_file,
             ipc_handler::get_local_config,
             ipc_handler::add_game,
             ipc_handler::restore_snapshot,
@@ -77,6 +79,7 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::apply_all,
             ipc_handler::set_quick_backup_game,
             ipc_handler::resolve_path,
+            ipc_handler::toggle_quick_action_sound_preview,
             ipc_handler::get_current_device_info,
         ])
         .events(tauri_specta::collect_events![ipc_handler::IpcNotification])
@@ -113,6 +116,7 @@ pub fn run() -> anyhow::Result<()> {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .invoke_handler(command_builder.invoke_handler())
         .setup(move |app| {
+            app.manage(audio::AudioManager::new());
             // 处理快捷备份，包括托盘、定时、快捷键
             quick_actions::setup(app).expect("Cannot setup quick actions");
             // 注册命令

--- a/src-tauri/src/quick_actions/manager.rs
+++ b/src-tauri/src/quick_actions/manager.rs
@@ -13,11 +13,12 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Sleep};
 
 use crate::{
+    audio::{AudioManager, resolve_profile},
     backup::Game,
-    config::{get_config, set_config},
+    config::{QuickActionSoundKind, get_config, set_config},
 };
 
-use super::{QuickActionType, quick_apply, quick_backup};
+use super::{QuickActionOutcome, QuickActionResult, QuickActionType, quick_apply, quick_backup};
 
 const COMMAND_BUFFER: usize = 32;
 const TIMER_TICK_SECONDS: u64 = 60;
@@ -211,10 +212,12 @@ impl QuickActionWorker {
                 self.handle_update_interval(minutes).await;
             }
             QuickActionCommand::TriggerBackup(trigger) => {
-                quick_backup(trigger).await;
+                let outcome = quick_backup(trigger).await;
+                self.handle_action_outcome(outcome).await;
             }
             QuickActionCommand::TriggerApply(trigger) => {
-                quick_apply(trigger).await;
+                let outcome = quick_apply(trigger).await;
+                self.handle_action_outcome(outcome).await;
             }
         }
     }
@@ -291,7 +294,8 @@ impl QuickActionWorker {
         };
 
         if should_trigger {
-            quick_backup(QuickActionType::Timer).await;
+            let outcome = quick_backup(QuickActionType::Timer).await;
+            self.handle_action_outcome(outcome).await;
         }
 
         if self.timer_sleep.is_some() {
@@ -337,5 +341,22 @@ impl QuickActionWorker {
                 );
             }
         }
+    }
+}
+
+impl QuickActionWorker {
+    async fn handle_action_outcome(&self, outcome: QuickActionOutcome) {
+        let kind = match outcome.result {
+            QuickActionResult::Success => QuickActionSoundKind::Success,
+            QuickActionResult::Failed => QuickActionSoundKind::Error,
+            QuickActionResult::Skipped => return,
+        };
+
+        let Some(audio_state) = self.manager.app_handle().try_state::<AudioManager>() else {
+            return;
+        };
+
+        let profile = resolve_profile(&outcome.sound_settings, kind).clone();
+        audio_state.play_effect(kind, profile);
     }
 }

--- a/src-tauri/src/quick_actions/mod.rs
+++ b/src-tauri/src/quick_actions/mod.rs
@@ -4,7 +4,7 @@ mod tray;
 mod utils;
 
 pub use manager::QuickActionManager;
-pub use utils::{QuickActionType, quick_apply, quick_backup};
+pub use utils::{QuickActionResult, QuickActionType, quick_apply, quick_backup};
 
 use hotkeys::setup_hotkeys;
 use tauri::Manager;

--- a/src-tauri/src/quick_actions/utils.rs
+++ b/src-tauri/src/quick_actions/utils.rs
@@ -1,4 +1,7 @@
-use crate::{backup::Game, config::get_config, preclude::*};
+use crate::{
+    config::{QuickActionSoundSettings, get_config},
+    preclude::*,
+};
 use log::{error, info, warn};
 use rust_i18n::t;
 
@@ -19,16 +22,46 @@ impl QuickActionType {
     }
 }
 
-pub async fn quick_apply(t: QuickActionType) {
-    info!(target:"rgsm::quick_action", "Auto apply triggered: {:#?}", t.generate_describe());
-    let game = get_quick_action_game();
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuickActionResult {
+    Success,
+    Failed,
+    Skipped,
+}
 
-    // 检查游戏是否已选择
-    let game = match game {
+#[derive(Debug, Clone)]
+pub struct QuickActionOutcome {
+    pub result: QuickActionResult,
+    pub sound_settings: QuickActionSoundSettings,
+}
+
+pub async fn quick_apply(t: QuickActionType) -> QuickActionOutcome {
+    info!(target:"rgsm::quick_action", "Auto apply triggered: {:#?}", t.generate_describe());
+    let config = match get_config() {
+        Ok(config) => config,
+        Err(err) => {
+            error!(target:"rgsm::quick_action", "Failed to load config for quick apply: {err:?}");
+            return QuickActionOutcome {
+                result: QuickActionResult::Failed,
+                sound_settings: QuickActionSoundSettings::default(),
+            };
+        }
+    };
+
+    let sound_settings = config.quick_action.sound.clone();
+    let notify_success = sound_settings.notifications.on_success;
+    let notify_error = sound_settings.notifications.on_error;
+
+    let game = match config.quick_action.quick_action_game.clone() {
         Some(game) => game,
         None => {
-            show_no_game_selected_error();
-            return;
+            if notify_error {
+                show_no_game_selected_error();
+            }
+            return QuickActionOutcome {
+                result: QuickActionResult::Skipped,
+                sound_settings,
+            };
         }
     };
 
@@ -51,38 +84,64 @@ pub async fn quick_apply(t: QuickActionType) {
     match result {
         Err(e) => {
             error!(target:"rgsm::quick_action", "Quick apply failed: {:#?}", &e);
-            show_notification(
-                t!("backend.tray.error"),
-                format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
-            );
+            if notify_error {
+                show_notification(
+                    t!("backend.tray.error"),
+                    format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
+                );
+            }
+            QuickActionOutcome {
+                result: QuickActionResult::Failed,
+                sound_settings,
+            }
         }
         Ok(_) => {
-            show_notification(
-                t!("backend.tray.success"),
-                format!(
-                    "{:#?} {} {}",
-                    game.name,
-                    t!("backend.tray.quick_apply"),
-                    t!("backend.tray.success")
-                ),
-            );
+            if notify_success {
+                show_notification(
+                    t!("backend.tray.success"),
+                    format!(
+                        "{:#?} {} {}",
+                        game.name,
+                        t!("backend.tray.quick_apply"),
+                        t!("backend.tray.success")
+                    ),
+                );
+            }
+            QuickActionOutcome {
+                result: QuickActionResult::Success,
+                sound_settings,
+            }
         }
     }
 }
 
-pub async fn quick_backup(t: QuickActionType) {
+pub async fn quick_backup(t: QuickActionType) -> QuickActionOutcome {
     info!(target:"rgsm::quick_action", "Auto backup triggered: {:#?}", t.generate_describe());
-    let show_info = get_config()
-        .expect("Cannot get config")
-        .settings
-        .prompt_when_auto_backup;
+    let config = match get_config() {
+        Ok(config) => config,
+        Err(err) => {
+            error!(target:"rgsm::quick_action", "Failed to load config for quick backup: {err:?}");
+            return QuickActionOutcome {
+                result: QuickActionResult::Failed,
+                sound_settings: QuickActionSoundSettings::default(),
+            };
+        }
+    };
 
-    // 检查游戏是否已选择
-    let game = match get_quick_action_game() {
+    let sound_settings = config.quick_action.sound.clone();
+    let notify_success = should_notify_backup_success(&sound_settings, &config, t);
+    let notify_error = sound_settings.notifications.on_error;
+
+    let game = match config.quick_action.quick_action_game.clone() {
         Some(game) => game,
         None => {
-            show_no_game_selected_error();
-            return;
+            if notify_error {
+                show_no_game_selected_error();
+            }
+            return QuickActionOutcome {
+                result: QuickActionResult::Skipped,
+                sound_settings,
+            };
         }
     };
 
@@ -93,28 +152,50 @@ pub async fn quick_backup(t: QuickActionType) {
     match result {
         Err(e) => {
             error!(target:"rgsm::quick_action", "Quick backup failed: {:#?}", &e);
-            show_notification(
-                t!("backend.tray.error"),
-                format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
-            );
+            if notify_error {
+                show_notification(
+                    t!("backend.tray.error"),
+                    format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
+                );
+            }
+            QuickActionOutcome {
+                result: QuickActionResult::Failed,
+                sound_settings,
+            }
         }
         Ok(_) => {
-            // 根据设置决定是否显示通知
-            if !show_info && (t == QuickActionType::Timer) {
-                // 设置中该选项控制是否在按间隔备份时发出通知
-                // 若不启用，则不进行通知，其余情况则产生通知
-                return;
+            if notify_success {
+                show_notification(
+                    t!("backend.tray.success"),
+                    format!(
+                        "{:#?} {} {}",
+                        game.name,
+                        t!("backend.tray.quick_backup"),
+                        t!("backend.tray.success")
+                    ),
+                );
             }
-            show_notification(
-                t!("backend.tray.success"),
-                format!(
-                    "{:#?} {} {}",
-                    game.name,
-                    t!("backend.tray.quick_backup"),
-                    t!("backend.tray.success")
-                ),
-            );
+            QuickActionOutcome {
+                result: QuickActionResult::Success,
+                sound_settings,
+            }
         }
+    }
+}
+
+fn should_notify_backup_success(
+    sound_settings: &QuickActionSoundSettings,
+    config: &crate::config::Config,
+    trigger: QuickActionType,
+) -> bool {
+    if !sound_settings.notifications.on_success {
+        return false;
+    }
+
+    if trigger == QuickActionType::Timer {
+        config.settings.prompt_when_auto_backup
+    } else {
+        true
     }
 }
 
@@ -124,12 +205,4 @@ fn show_no_game_selected_error() {
         t!("backend.tray.error"),
         t!("backend.tray.no_game_selected"),
     );
-}
-
-pub fn get_quick_action_game() -> Option<Game> {
-    get_config()
-        .expect("Cannot get config")
-        .quick_action
-        .quick_action_game
-        .clone()
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -37,6 +37,14 @@ async chooseSaveDir() : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async chooseSoundFile() : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("choose_sound_file") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async getLocalConfig() : Promise<Result<Config, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_local_config") };
@@ -186,6 +194,14 @@ async resolvePath(path: string) : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async toggleQuickActionSoundPreview(kind: QuickActionSoundKind, profile: QuickActionSoundProfile) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("toggle_quick_action_sound_preview", { kind, profile }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Returns the current device, if not found, returns a default device
  */
@@ -210,7 +226,7 @@ ipcNotification: "ipc-notification"
 
 /** user-defined constants **/
 
-export const DEFAULT_CONFIG = {"backup_path":"./save_data","devices":{},"favorites":[],"games":[],"quick_action":{"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null},"settings":{"add_new_to_favorites":false,"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"root_path":"/game-save-manager"},"default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"save_list_expand_behavior":"always_closed","save_list_last_expanded":false,"show_edit_button":false},"version":"1.5.3"} as const;
+export const DEFAULT_CONFIG = {"backup_path":"./save_data","devices":{},"favorites":[],"games":[],"quick_action":{"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null,"sound":{"error":{"enabled":true,"source":{"type":"error_tone"}},"notifications":{"on_error":true,"on_success":true},"success":{"enabled":true,"source":{"type":"success_tone"}}}},"settings":{"add_new_to_favorites":false,"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"root_path":"/game-save-manager"},"default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"save_list_expand_behavior":"always_closed","save_list_last_expanded":false,"show_edit_button":false},"version":"1.5.3"} as const;
 
 /** user-defined types **/
 
@@ -268,8 +284,24 @@ export type Game = { name: string; save_paths: SaveUnit[]; game_paths?: Partial<
 export type GameSnapshots = { name: string; backups: Snapshot[] }
 export type IpcNotification = { level: NotificationLevel; title: string; msg: string }
 export type NotificationLevel = "info" | "warning" | "error"
+export type QuickActionSoundKind = "success" | "error"
+export type QuickActionSoundSource =
+  | { type: "success_tone" }
+  | { type: "error_tone" }
+  | { type: "file"; path: string }
+export type QuickActionSoundProfile = { enabled: boolean; source: QuickActionSoundSource }
+export type QuickActionNotificationSettings = { on_success: boolean; on_error: boolean }
+export type QuickActionSoundSettings = {
+  success: QuickActionSoundProfile
+  error: QuickActionSoundProfile
+  notifications: QuickActionNotificationSettings
+}
 export type QuickActionHotkeys = { apply: string[]; backup: string[] }
-export type QuickActionsSettings = { quick_action_game?: Game | null; hotkeys?: QuickActionHotkeys }
+export type QuickActionsSettings = {
+  quick_action_game?: Game | null
+  hotkeys?: QuickActionHotkeys
+  sound?: QuickActionSoundSettings
+}
 /**
  * Settings that can be configured by user
  */

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -10,7 +10,12 @@ import HotkeySelector from "../components/HotkeySelector.vue";
 import { useDark } from '@vueuse/core'
 import { commands } from "~/bindings";
 import { error, info } from "@tauri-apps/plugin-log";
-import type { Device } from "../bindings";
+import type {
+    Device,
+    QuickActionSoundKind,
+    QuickActionSoundProfile,
+    QuickActionSoundSource,
+} from "../bindings";
 
 const isDark = useDark()
 const { config, refreshConfig, saveConfig } = useConfig()
@@ -21,6 +26,25 @@ const activeTab = ref('general')
 const hotkeysChanged = ref(false)
 const gameOrderChanged = ref(false)
 const { withLoading } = useGlobalLoading()
+
+type SoundSourceType = QuickActionSoundSource["type"]
+const QUICK_ACTION_SUCCESS: QuickActionSoundKind = "success"
+const QUICK_ACTION_ERROR: QuickActionSoundKind = "error"
+
+const successSourceType = computed<SoundSourceType>({
+    get: () =>
+        config.value.quick_action?.sound?.success?.source.type ?? "success_tone",
+    set: (value) => setSoundSource(QUICK_ACTION_SUCCESS, value),
+})
+
+const errorSourceType = computed<SoundSourceType>({
+    get: () =>
+        config.value.quick_action?.sound?.error?.source.type ?? "error_tone",
+    set: (value) => setSoundSource(QUICK_ACTION_ERROR, value),
+})
+
+const successSoundPath = computed(() => getSoundPath(QUICK_ACTION_SUCCESS))
+const errorSoundPath = computed(() => getSoundPath(QUICK_ACTION_ERROR))
 
 // 设备管理相关
 const currentDevice = ref<Device>({ id: "", name: "" })
@@ -146,6 +170,74 @@ async function translate_website() {
     } catch (e) {
         error(`open translate website error: ${e}`)
         showError({ message: $t('error.open_url_failed') })
+    }
+}
+
+function getSoundProfile(kind: QuickActionSoundKind): QuickActionSoundProfile | undefined {
+    const sound = config.value.quick_action?.sound
+    if (!sound) {
+        return undefined
+    }
+    return kind === QUICK_ACTION_SUCCESS ? sound.success : sound.error
+}
+
+function setSoundSource(kind: QuickActionSoundKind, value: SoundSourceType) {
+    const profile = getSoundProfile(kind)
+    if (!profile) {
+        return
+    }
+
+    if (value === "file") {
+        const existing =
+            profile.source.type === "file" ? profile.source.path : ""
+        profile.source = { type: "file", path: existing }
+    } else {
+        profile.source = { type: value } as QuickActionSoundSource
+    }
+}
+
+function getSoundPath(kind: QuickActionSoundKind): string {
+    const profile = getSoundProfile(kind)
+    if (!profile) {
+        return ""
+    }
+
+    return profile.source.type === "file" ? profile.source.path : ""
+}
+
+async function chooseSound(kind: QuickActionSoundKind) {
+    try {
+        const result = await commands.chooseSoundFile()
+        if (result.status === "ok") {
+            const profile = getSoundProfile(kind)
+            if (!profile) {
+                return
+            }
+            profile.source = { type: "file", path: result.data }
+            debouncedSaveConfig()
+        } else {
+            showError({ message: $t("error.choose_sound_failed") })
+        }
+    } catch (e) {
+        error(`choose sound error: ${e}`)
+        showError({ message: $t("error.choose_sound_failed") })
+    }
+}
+
+async function togglePreviewSound(kind: QuickActionSoundKind) {
+    const profile = getSoundProfile(kind)
+    if (!profile) {
+        return
+    }
+
+    try {
+        const result = await commands.toggleQuickActionSoundPreview(kind, profile)
+        if (result.status === "error") {
+            throw new Error(result.error)
+        }
+    } catch (e) {
+        error(`toggle preview sound error: ${e}`)
+        showError({ message: $t("error.preview_sound_failed") })
     }
 }
 
@@ -353,6 +445,14 @@ watch(
     { deep: true } // 深度监听对象变化
 )
 
+watch(
+    () => config.value.quick_action?.sound,
+    () => {
+        debouncedSaveConfig()
+    },
+    { deep: true }
+)
+
 const router_list = computed(() => {
     // TODO:抽离到新文件中，同时`MainSideBar.vue`也要抽离
     var link_list = [
@@ -547,6 +647,73 @@ const router_list = computed(() => {
                                 {{ config.quick_action!.quick_action_game?.name }}
                             </strong>
                         </div>
+                        <div class="sound-settings">
+                            <h4 class="sound-section-title">
+                                {{ $t("settings.quick_action_notification_title") }}
+                            </h4>
+                            <div class="sound-row">
+                                <ElSwitch v-model="config.quick_action!.sound.notifications.on_success" />
+                                <span class="setting-label">{{ $t("settings.quick_action_notify_success") }}</span>
+                            </div>
+                            <div class="sound-row">
+                                <ElSwitch v-model="config.quick_action!.sound.notifications.on_error" />
+                                <span class="setting-label">{{ $t("settings.quick_action_notify_error") }}</span>
+                            </div>
+                        </div>
+                        <div class="sound-settings">
+                            <h4 class="sound-section-title">
+                                {{ $t("settings.quick_action_success_sound_title") }}
+                            </h4>
+                            <div class="sound-row">
+                                <ElSwitch v-model="config.quick_action!.sound.success.enabled" />
+                                <span class="setting-label">{{ $t("settings.quick_action_sound_toggle") }}</span>
+                            </div>
+                            <div class="sound-control-row">
+                                <ElSelect v-model="successSourceType" class="sound-source-select">
+                                    <ElOption :label="$t('settings.quick_action_sound_source_success_tone')" value="success_tone" />
+                                    <ElOption :label="$t('settings.quick_action_sound_source_error_tone')" value="error_tone" />
+                                    <ElOption :label="$t('settings.quick_action_sound_source_file')" value="file" />
+                                </ElSelect>
+                                <el-button size="small" @click="chooseSound(QUICK_ACTION_SUCCESS)" :disabled="successSourceType !== 'file'">
+                                    {{ $t('settings.quick_action_sound_choose') }}
+                                </el-button>
+                            </div>
+                            <div class="sound-path" v-if="successSourceType === 'file'">
+                                {{ successSoundPath || $t('settings.quick_action_sound_no_file') }}
+                            </div>
+                            <div class="sound-actions">
+                                <el-button size="small" type="primary" @click="togglePreviewSound(QUICK_ACTION_SUCCESS)">
+                                    {{ $t('settings.quick_action_sound_preview') }}
+                                </el-button>
+                            </div>
+                        </div>
+                        <div class="sound-settings">
+                            <h4 class="sound-section-title">
+                                {{ $t("settings.quick_action_error_sound_title") }}
+                            </h4>
+                            <div class="sound-row">
+                                <ElSwitch v-model="config.quick_action!.sound.error.enabled" />
+                                <span class="setting-label">{{ $t("settings.quick_action_sound_toggle") }}</span>
+                            </div>
+                            <div class="sound-control-row">
+                                <ElSelect v-model="errorSourceType" class="sound-source-select">
+                                    <ElOption :label="$t('settings.quick_action_sound_source_success_tone')" value="success_tone" />
+                                    <ElOption :label="$t('settings.quick_action_sound_source_error_tone')" value="error_tone" />
+                                    <ElOption :label="$t('settings.quick_action_sound_source_file')" value="file" />
+                                </ElSelect>
+                                <el-button size="small" @click="chooseSound(QUICK_ACTION_ERROR)" :disabled="errorSourceType !== 'file'">
+                                    {{ $t('settings.quick_action_sound_choose') }}
+                                </el-button>
+                            </div>
+                            <div class="sound-path" v-if="errorSourceType === 'file'">
+                                {{ errorSoundPath || $t('settings.quick_action_sound_no_file') }}
+                            </div>
+                            <div class="sound-actions">
+                                <el-button size="small" type="primary" @click="togglePreviewSound(QUICK_ACTION_ERROR)">
+                                    {{ $t('settings.quick_action_sound_preview') }}
+                                </el-button>
+                            </div>
+                        </div>
                         <HotkeySelector v-model="config.quick_action!.hotkeys" />
                         <div class="setting-action">
                             <el-button type="primary" @click="saveHotkeys" :disabled="!hotkeysChanged">
@@ -625,6 +792,46 @@ const router_list = computed(() => {
     display: flex;
     align-items: center;
     gap: 10px;
+}
+
+.sound-settings {
+    margin-top: 12px;
+    padding: 12px;
+    border: 1px solid var(--el-border-color);
+    border-radius: 4px;
+}
+
+.sound-section-title {
+    margin-bottom: 8px;
+    font-weight: 600;
+}
+
+.sound-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 6px;
+}
+
+.sound-control-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.sound-source-select {
+    width: 200px;
+}
+
+.sound-path {
+    margin-top: 6px;
+    color: var(--el-text-color-secondary);
+    word-break: break-all;
+}
+
+.sound-actions {
+    margin-top: 10px;
 }
 
 .tab-title {


### PR DESCRIPTION
## Summary
* add a rodio-based audio manager that synthesizes default tones, resolves custom files, and serializes playback commands for quick action sounds. 【F:src-tauri/src/audio/mod.rs†L1-L239】
* extend quick action configuration with sound and notification settings and trigger audio feedback from manager results. 【F:src-tauri/src/config/quick_actions_settings.rs†L6-L111】【F:src-tauri/src/quick_actions/utils.rs†L1-L200】【F:src-tauri/src/quick_actions/manager.rs†L201-L362】
* expose sound controls via new IPC/bindings and enhance the settings UI with selectors, preview buttons, and localized labels. 【F:src-tauri/src/ipc_handler.rs†L89-L107】【F:src/bindings.ts†L7-L47】【F:src/bindings.ts†L197-L304】【F:src/pages/Settings.vue†L643-L715】【F:locales/en_US.json†L46-L58】

## Testing
* ⚠️ `cargo clippy --manifest-path src-tauri/Cargo.toml` *(fails: missing system library `glib-2.0` in container)* 【08f9e4†L1-L27】

------
https://chatgpt.com/codex/tasks/task_e_68d5794232388330bba65f52c26a0b83