### PR TITLE
feat: refresh UI after quick actions

### DIFF
--- a/src-tauri/src/ipc_handler.rs
+++ b/src-tauri/src/ipc_handler.rs
@@ -315,10 +315,13 @@ pub async fn toggle_quick_action_sound_preview(
     effect: sound::QuickActionSoundEffect,
 ) -> Result<(), String> {
     let manager = app.state::<sound::SoundManager>();
-    manager.toggle_preview(preferences, effect).await.map_err(|err| {
-        error!(target: "rgsm::sound", "Failed to preview sound: {err:?}");
-        err.to_string()
-    })
+    manager
+        .toggle_preview(preferences, effect)
+        .await
+        .map_err(|err| {
+            error!(target: "rgsm::sound", "Failed to preview sound: {err:?}");
+            err.to_string()
+        })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,7 +83,10 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::stop_sound_playback,
             ipc_handler::choose_quick_action_sound_file,
         ])
-        .events(tauri_specta::collect_events![ipc_handler::IpcNotification])
+        .events(tauri_specta::collect_events![
+            ipc_handler::IpcNotification,
+            quick_actions::QuickActionCompleted
+        ])
         .constant("DEFAULT_CONFIG", config::Config::default());
 
     command_builder.export(
@@ -129,7 +132,8 @@ pub fn run() -> anyhow::Result<()> {
     let config = get_config()?;
     info!(target: "rgsm::main", "App has started.");
 
-    let exit_code = app.build(tauri::generate_context!())
+    let exit_code = app
+        .build(tauri::generate_context!())
         .expect("Cannot build tauri app")
         .run_return(move |handle, event| {
             if let tauri::RunEvent::ExitRequested { api, code, .. } = event {
@@ -148,6 +152,9 @@ pub fn run() -> anyhow::Result<()> {
         Ok(())
     } else {
         error!(target: "rgsm::main", "App has exited with error code {}.", exit_code);
-        Err(anyhow::anyhow!("App has exited with error code {}.", exit_code))
+        Err(anyhow::anyhow!(
+            "App has exited with error code {}.",
+            exit_code
+        ))
     }
 }

--- a/src-tauri/src/quick_actions/manager.rs
+++ b/src-tauri/src/quick_actions/manager.rs
@@ -100,19 +100,28 @@ impl QuickActionManager {
     }
 
     pub fn update_interval(&self, minutes: u32) {
-        if let Err(err) = self.command_tx.send(QuickActionCommand::UpdateInterval { minutes }) {
+        if let Err(err) = self
+            .command_tx
+            .send(QuickActionCommand::UpdateInterval { minutes })
+        {
             warn!(target: "rgsm::quick_action::manager", "Failed to send UpdateInterval command: {err}");
         }
     }
 
     pub fn trigger_backup(&self, trigger: QuickActionType) {
-        if let Err(err) = self.command_tx.send(QuickActionCommand::TriggerBackup(trigger)) {
+        if let Err(err) = self
+            .command_tx
+            .send(QuickActionCommand::TriggerBackup(trigger))
+        {
             warn!(target: "rgsm::quick_action::manager", "Failed to send TriggerBackup command: {err}");
         }
     }
 
     pub fn trigger_apply(&self, trigger: QuickActionType) {
-        if let Err(err) = self.command_tx.send(QuickActionCommand::TriggerApply(trigger)) {
+        if let Err(err) = self
+            .command_tx
+            .send(QuickActionCommand::TriggerApply(trigger))
+        {
             warn!(target: "rgsm::quick_action::manager", "Failed to send TriggerApply command: {err}");
         }
     }
@@ -206,7 +215,9 @@ impl QuickActionWorker {
                 }
             }
         }
-        info!("QuickActionWorker received cancel signal or channel closed, shutting down gracefully");
+        info!(
+            "QuickActionWorker received cancel signal or channel closed, shutting down gracefully"
+        );
     }
 
     async fn handle_command(&mut self, command: QuickActionCommand) {

--- a/src-tauri/src/quick_actions/mod.rs
+++ b/src-tauri/src/quick_actions/mod.rs
@@ -4,7 +4,7 @@ mod tray;
 mod utils;
 
 pub use manager::QuickActionManager;
-pub use utils::{QuickActionType, quick_apply, quick_backup};
+pub use utils::{QuickActionCompleted, QuickActionType, quick_apply, quick_backup};
 
 use hotkeys::setup_hotkeys;
 use tauri::Manager;

--- a/src-tauri/src/quick_actions/utils.rs
+++ b/src-tauri/src/quick_actions/utils.rs
@@ -5,9 +5,12 @@ use crate::{
 };
 use log::{error, info, warn};
 use rust_i18n::t;
+use serde::{Deserialize, Serialize};
+use specta::Type;
 use tauri::AppHandle;
+use tauri_specta::Event;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Type)]
 pub enum QuickActionType {
     Timer,
     Tray,
@@ -15,12 +18,54 @@ pub enum QuickActionType {
 }
 
 impl QuickActionType {
-    fn generate_describe(&self) -> String {
-        match &self {
+    fn generate_describe(self) -> String {
+        match self {
             QuickActionType::Timer => String::from("Auto Backup (Timer)"),
             QuickActionType::Tray => String::from("Quick Backup (Tray)"),
             QuickActionType::Hotkey => String::from("Quick Backup (Hotkey)"),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type)]
+pub enum QuickActionOperation {
+    Backup,
+    Apply,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type)]
+pub enum QuickActionStatus {
+    Success,
+    Failure,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct QuickActionCompleted {
+    pub operation: QuickActionOperation,
+    pub status: QuickActionStatus,
+    pub trigger: QuickActionType,
+    pub game_name: Option<String>,
+}
+
+fn emit_quick_action_event(
+    app: &AppHandle,
+    trigger: QuickActionType,
+    operation: QuickActionOperation,
+    status: QuickActionStatus,
+    game_name: Option<String>,
+) {
+    if let Err(err) = (QuickActionCompleted {
+        operation,
+        status,
+        trigger,
+        game_name,
+    })
+    .emit(app)
+    {
+        warn!(
+            target: "rgsm::quick_action",
+            "Failed to emit quick action event: {err:?}"
+        );
     }
 }
 
@@ -42,6 +87,13 @@ pub async fn quick_apply(app: &AppHandle, t: QuickActionType) {
     let game = match quick_settings.quick_action_game.clone() {
         Some(game) => game,
         None => {
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Apply,
+                QuickActionStatus::Failure,
+                None,
+            );
             show_no_game_selected_error(app, &quick_settings, &sound_preferences);
             return;
         }
@@ -72,6 +124,13 @@ pub async fn quick_apply(app: &AppHandle, t: QuickActionType) {
                 format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
             );
             play_quick_action_sound(app, sound_preferences, QuickActionSoundEffect::Failure);
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Apply,
+                QuickActionStatus::Failure,
+                Some(game.name.clone()),
+            );
         }
         Ok(_) => {
             maybe_show_success_notification(
@@ -86,6 +145,13 @@ pub async fn quick_apply(app: &AppHandle, t: QuickActionType) {
                 ),
             );
             play_quick_action_sound(app, sound_preferences, QuickActionSoundEffect::Success);
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Apply,
+                QuickActionStatus::Success,
+                Some(game.name.clone()),
+            );
         }
     }
 }
@@ -109,6 +175,13 @@ pub async fn quick_backup(app: &AppHandle, t: QuickActionType) {
     let game = match quick_settings.quick_action_game.clone() {
         Some(game) => game,
         None => {
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Backup,
+                QuickActionStatus::Failure,
+                None,
+            );
             show_no_game_selected_error(app, &quick_settings, &sound_preferences);
             return;
         }
@@ -127,6 +200,13 @@ pub async fn quick_backup(app: &AppHandle, t: QuickActionType) {
                 format!("{:#?}\n{:#?}", t!("backend.tray.find_error_detail"), e),
             );
             play_quick_action_sound(app, sound_preferences, QuickActionSoundEffect::Failure);
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Backup,
+                QuickActionStatus::Failure,
+                Some(game.name.clone()),
+            );
         }
         Ok(_) => {
             maybe_show_success_notification(
@@ -141,6 +221,13 @@ pub async fn quick_backup(app: &AppHandle, t: QuickActionType) {
                 ),
             );
             play_quick_action_sound(app, sound_preferences, QuickActionSoundEffect::Success);
+            emit_quick_action_event(
+                app,
+                t,
+                QuickActionOperation::Backup,
+                QuickActionStatus::Success,
+                Some(game.name.clone()),
+            );
         }
     }
 }

--- a/src-tauri/src/sound/mod.rs
+++ b/src-tauri/src/sound/mod.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use log::warn;
 use rodio::{
     Decoder, OutputStream, OutputStreamHandle, Sink, buffer::SamplesBuffer, source::Source,
@@ -138,15 +138,12 @@ impl SoundManager {
             return;
         }
 
-        if let Err(err) = self
-            .command_tx
-            .send(SoundCommand::Play {
-                effect,
-                preferences,
-                mode: SoundMode::QuickAction,
-                respond_to: None,
-            })
-        {
+        if let Err(err) = self.command_tx.send(SoundCommand::Play {
+            effect,
+            preferences,
+            mode: SoundMode::QuickAction,
+            respond_to: None,
+        }) {
             warn!(target: "rgsm::sound", "Failed to send quick action sound command: {err}");
         }
     }
@@ -171,7 +168,9 @@ impl SoundManager {
     pub async fn stop(&self) -> Result<()> {
         let (tx, rx) = oneshot::channel();
         self.command_tx
-            .send(SoundCommand::Stop { respond_to: Some(tx) })
+            .send(SoundCommand::Stop {
+                respond_to: Some(tx),
+            })
             .map_err(|_| anyhow!("failed to send stop sound command"))?;
         rx.await.map_err(|_| anyhow!("stop response dropped"))?;
         Ok(())

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -227,9 +227,11 @@ async chooseQuickActionSoundFile() : Promise<Result<string, string>> {
 
 
 export const events = __makeEvents__<{
-ipcNotification: IpcNotification
+ipcNotification: IpcNotification,
+quickActionCompleted: QuickActionCompleted
 }>({
-ipcNotification: "ipc-notification"
+ipcNotification: "ipc-notification",
+quickActionCompleted: "quick-action-completed"
 })
 
 /** user-defined constants **/
@@ -292,11 +294,15 @@ export type Game = { name: string; save_paths: SaveUnit[]; game_paths?: Partial<
 export type GameSnapshots = { name: string; backups: Snapshot[] }
 export type IpcNotification = { level: NotificationLevel; title: string; msg: string }
 export type NotificationLevel = "info" | "warning" | "error"
+export type QuickActionCompleted = { operation: QuickActionOperation; status: QuickActionStatus; trigger: QuickActionType; game_name: string | null }
 export type QuickActionHotkeys = { apply: string[]; backup: string[] }
+export type QuickActionOperation = "Backup" | "Apply"
 export type QuickActionSoundEffect = "Success" | "Failure"
 export type QuickActionSoundPreferences = { enable_sound?: boolean; sounds?: QuickActionSoundSlots }
 export type QuickActionSoundSlots = { success?: QuickActionSoundSource; failure?: QuickActionSoundSource }
 export type QuickActionSoundSource = { kind: "default" } | { kind: "file"; path: string }
+export type QuickActionStatus = "Success" | "Failure"
+export type QuickActionType = "Timer" | "Tray" | "Hotkey"
 export type QuickActionsSettings = { quick_action_game?: Game | null; hotkeys?: QuickActionHotkeys; enable_sound?: boolean; enable_notification?: boolean; sounds?: QuickActionSoundSlots }
 /**
  * Settings that can be configured by user

--- a/src/composables/useConfig.ts
+++ b/src/composables/useConfig.ts
@@ -1,5 +1,10 @@
 import { error } from '@tauri-apps/plugin-log';
-import { commands, DEFAULT_CONFIG, type Config } from '../bindings'
+import {
+    commands,
+    DEFAULT_CONFIG,
+    events,
+    type Config,
+} from '../bindings'
 import { $t } from '../i18n'
 
 // 定义默认配置
@@ -40,6 +45,22 @@ async function saveConfig() {
             message: $t('error.set_config_failed')
         })
     }
+}
+
+if (import.meta.client) {
+    events.quickActionCompleted
+        .listen((event) => {
+            const payload = event.payload
+            if (
+                payload.status === 'Success' &&
+                payload.operation === 'Backup'
+            ) {
+                void refreshConfig()
+            }
+        })
+        .catch((err) => {
+            error(`Failed to listen quick action events: ${err}`)
+        })
 }
 // 初始加载
 refreshConfig()

--- a/src/pages/Management/[name].vue
+++ b/src/pages/Management/[name].vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
-import { computed, ref, watch } from "vue";
+import { computed, ref, watch, onBeforeUnmount, onMounted } from "vue";
 import { ElInput, ElMessageBox } from "element-plus";
 import { useRoute, useRouter } from "vue-router";
-import { commands } from "../../bindings";
+import { commands, events } from "../../bindings";
 import SaveLocationDrawer from "../../components/SaveLocationDrawer.vue";
 import type { Game, Snapshot, Device, SaveUnit } from "../../bindings";
 import { $t } from "../../i18n";
@@ -67,6 +67,35 @@ let apply_button_apply_limit = true; // 上次未恢复好禁止读取或备份
 
 // 批量操作记录列表
 const selected_game_snapshots: Ref<Snapshot[]> = ref([]);
+
+let stopQuickActionListener: (() => void) | null = null;
+
+onMounted(async () => {
+    try {
+        stopQuickActionListener = await events.quickActionCompleted.listen(
+            async (event) => {
+                const payload = event.payload;
+                if (
+                    payload.status === 'Success' &&
+                    payload.operation === 'Backup' &&
+                    payload.game_name &&
+                    payload.game_name === game.value.name
+                ) {
+                    await refresh_backups_info();
+                }
+            },
+        );
+    } catch (e) {
+        error(`Failed to listen quick action events: ${e}`);
+    }
+});
+
+onBeforeUnmount(() => {
+    if (stopQuickActionListener) {
+        stopQuickActionListener();
+        stopQuickActionListener = null;
+    }
+});
 
 // 格式化文件大小显示
 function formatFileSize(bytes: number): string {


### PR DESCRIPTION
## Summary
- emit a typed `QuickActionCompleted` event after quick backup/apply operations so the frontend can react to their results
- expose the new event through the tauri_specta bindings
- refresh the stored config and the management view when a quick backup succeeds to keep the UI in sync with hotkey actions

## Testing
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings

------
https://chatgpt.com/codex/tasks/task_e_68e7e2514bd48330b6a37369fccdda4d