### PR TITLE
fix: correct test directory path by adding trailing slash

### DIFF
--- a/src-tauri/src/cloud_sync/backend.rs
+++ b/src-tauri/src/cloud_sync/backend.rs
@@ -72,7 +72,7 @@ impl Backend {
     pub async fn check(&self) -> Result<(), BackendError> {
         const TEST_FILENAME: &str = "test.txt";
         const TEST_CONTENT: &str = "Hello from game save manager";
-        const TEST_DIR: &str = "test_dir";
+        const TEST_DIR: &str = "test_dir/";
 
         let op = self.get_op()?;
         // Step1: 检查是否可以列出文件


### PR DESCRIPTION
The lack of a trailing slash will cause the folder creation test to fail.

According to the [create_dir ](https://docs.rs/opendal/latest/opendal/struct.Operator.html#method.create_dir) documentation, not adding a trailing slash may cause creation to fail in some cases.