### PR TITLE
add stable save-unit IDs for archive prefix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4789,7 +4789,7 @@ dependencies = [
 
 [[package]]
 name = "rgsm"
-version = "1.7.4"
+version = "1.7.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgsm"
-version = "1.7.4"
+version = "1.7.5"
 description = "A user friendly game save manager"
 authors = ["Sworld"]
 license = ""

--- a/src-tauri/src/app_dirs.rs
+++ b/src-tauri/src/app_dirs.rs
@@ -4,6 +4,8 @@ use std::sync::OnceLock;
 
 /// Stores the application's data directory path
 static APP_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+#[cfg(test)]
+static TEST_APP_DATA_DIR: OnceLock<temp_dir::TempDir> = OnceLock::new();
 
 /// Get the directory where application data should be stored
 ///
@@ -14,39 +16,64 @@ static APP_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 /// The result is cached after the first call.
 /// The data directory is determined at startup and remains fixed for the application lifetime.
 pub fn get_app_data_dir() -> &'static PathBuf {
-    APP_DATA_DIR.get_or_init(|| {
-        // In debug mode, check pwd first to avoid test configs in target/debug
-        // being cleared during cargo clean or rebuilds
-        #[cfg(debug_assertions)]
-        {
-            if let Ok(cwd) = std::env::current_dir() {
-                let pwd_config_path = cwd.join("GameSaveManager.config.json");
-                if pwd_config_path.exists() {
-                    info!("Debug mode: Using pwd as data directory: {}", cwd.display());
-                    return cwd;
-                }
+    APP_DATA_DIR.get_or_init(init_app_data_dir)
+}
+
+#[cfg(test)]
+fn init_app_data_dir() -> PathBuf {
+    init_test_app_data_dir()
+}
+
+#[cfg(not(test))]
+fn init_app_data_dir() -> PathBuf {
+    init_runtime_app_data_dir()
+}
+
+#[cfg(test)]
+fn init_test_app_data_dir() -> PathBuf {
+    let test_data_dir = TEST_APP_DATA_DIR.get_or_init(|| {
+        temp_dir::TempDir::new().expect("failed to create temporary test data directory")
+    });
+    info!(
+        "Test mode: Using temp directory as data directory: {}",
+        test_data_dir.path().display()
+    );
+    test_data_dir.path().to_path_buf()
+}
+
+#[cfg_attr(test, allow(dead_code))]
+fn init_runtime_app_data_dir() -> PathBuf {
+    // In debug mode, check pwd first to avoid test configs in target/debug
+    // being cleared during cargo clean or rebuilds
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(cwd) = std::env::current_dir() {
+            let pwd_config_path = cwd.join("GameSaveManager.config.json");
+            if pwd_config_path.exists() {
+                info!("Debug mode: Using pwd as data directory: {}", cwd.display());
+                return cwd;
             }
         }
+    }
 
-        // Standard behavior: use executable directory for both portable and installed versions
-        if let Ok(exe_path) = std::env::current_exe() {
-            if let Some(exe_dir) = exe_path.parent() {
-                info!(
-                    "Using executable directory as data directory: {}",
-                    exe_dir.display()
-                );
-                return exe_dir.to_path_buf();
-            }
+    // Standard behavior: use executable directory for both portable and installed versions
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            info!(
+                "Using executable directory as data directory: {}",
+                exe_dir.display()
+            );
+            return exe_dir.to_path_buf();
         }
+    }
 
-        // Fallback only if we cannot determine executable directory
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        log::warn!(
-            "Failed to determine executable directory, falling back to current directory: {}",
-            cwd.display()
-        );
-        cwd
-    })
+    // Fallback only if we cannot determine executable directory
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    log::warn!(
+        "Failed to determine executable directory, falling back to current directory: {}",
+        cwd.display()
+    );
+    cwd
 }
 
 /// Resolve a path relative to the app data directory

--- a/src-tauri/src/backup/archive/compress.rs
+++ b/src-tauri/src/backup/archive/compress.rs
@@ -80,17 +80,14 @@ where
     Ok(())
 }
 
-/// Write a single save unit into the ZIP under its index prefix (`{index}/...`).
+/// Write a single save unit into the ZIP under its ID prefix (`{id}/...`).
 ///
-/// **Index stability rule**: The `index` is the positional index of the save unit
-/// within `save_paths`. This index is persisted in the archive and used during
-/// restore to map entries back to save units. Like protobuf field numbers,
-/// save-unit indices must remain stable — when removing a save unit, its index
-/// slot must not be reused by a different unit.
+/// The `id` is `save_unit.id` — a stable, monotonically-assigned identifier
+/// that does not change when save units are added or removed. This replaces
+/// the former positional index, which could shift and break old archives.
 fn append_save_unit<T>(
     writer: &mut ZipWriter<T>,
     save_unit: &SaveUnit,
-    index: usize,
     preset: CompressionPreset,
 ) -> Result<(), BackupFileError>
 where
@@ -101,19 +98,19 @@ where
         return Err(BackupFileError::NotExists(unit_path));
     }
 
-    let index_prefix = PathBuf::from(index.to_string());
+    let id_prefix = PathBuf::from(save_unit.id.to_string());
     match save_unit.unit_type {
         SaveUnitType::File => {
             let file_name = unit_path
                 .file_name()
                 .ok_or(BackupFileError::NonePathError)?;
-            write_file_entry(writer, &unit_path, &index_prefix.join(file_name), preset)
+            write_file_entry(writer, &unit_path, &id_prefix.join(file_name), preset)
         }
         SaveUnitType::Folder => {
             let folder_name = unit_path
                 .file_name()
                 .ok_or(BackupFileError::NonePathError)?;
-            add_directory(writer, &unit_path, &index_prefix.join(folder_name), preset)
+            add_directory(writer, &unit_path, &id_prefix.join(folder_name), preset)
         }
     }
 }
@@ -159,8 +156,8 @@ pub fn compress_to_file(
     zip.set_comment(ArchiveMeta::new(preset).to_comment());
 
     let mut compress_errors = Vec::new();
-    for (index, save_unit) in save_paths.iter().enumerate() {
-        if let Err(err) = append_save_unit(&mut zip, save_unit, index, preset) {
+    for save_unit in save_paths {
+        if let Err(err) = append_save_unit(&mut zip, save_unit, preset) {
             compress_errors.push(err);
         }
     }

--- a/src-tauri/src/backup/archive/compress.rs
+++ b/src-tauri/src/backup/archive/compress.rs
@@ -1,9 +1,10 @@
 //! ZIP archive creation from save units.
 //!
-//! Writes V2 archives with index-prefixed entries and structured metadata.
-//! Each save unit is stored under `{index}/` to prevent same-name collisions.
+//! Writes V2 archives with ID-prefixed entries and structured metadata.
+//! Each save unit is stored under `{id}/` to prevent same-name collisions.
 
 use std::{
+    collections::HashSet,
     fs::{self, File},
     io::{Read, Seek, Write},
     path::{Path, PathBuf},
@@ -115,6 +116,18 @@ where
     }
 }
 
+fn ensure_unique_save_unit_ids(save_paths: &[SaveUnit]) -> Result<(), CompressError> {
+    let mut seen = HashSet::with_capacity(save_paths.len());
+    for save_unit in save_paths {
+        if !seen.insert(save_unit.id) {
+            return Err(CompressError::Single(BackupFileError::DuplicateSaveUnitId(
+                save_unit.id,
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Write an origin directory to zip writer.
 ///
 /// `prefix_path` should usually be the origin directory name.
@@ -151,6 +164,8 @@ pub fn compress_to_file(
     zip_path: &Path,
     preset: CompressionPreset,
 ) -> Result<u64, CompressError> {
+    ensure_unique_save_unit_ids(save_paths)?;
+
     let file = File::create(zip_path).map_err(|e| CompressError::Single(e.into()))?;
     let mut zip = ZipWriter::new(file);
     zip.set_comment(ArchiveMeta::new(preset).to_comment());

--- a/src-tauri/src/backup/archive/decompress.rs
+++ b/src-tauri/src/backup/archive/decompress.rs
@@ -153,7 +153,6 @@ fn restore_folder_unit(
 
 fn restore_save_unit_from_temp(
     unit: &SaveUnit,
-    index: usize,
     version: ArchiveVersion,
     temp_root: &Path,
     app_handle: Option<&AppHandle>,
@@ -163,14 +162,11 @@ fn restore_save_unit_from_temp(
         .file_name()
         .ok_or(BackupFileError::NonePathError)?;
 
-    // V2+ archives store entries under {index}/{name}, older versions use flat layout.
-    //
-    // **Index stability rule**: The index is the positional index of the save unit
-    // within `save_paths` at the time the archive was created. Restore relies on
-    // the same ordering. Like protobuf field numbers, save-unit indices must remain
-    // stable — removing a save unit must not cause remaining units to shift indices.
+    // V2+ archives store entries under `{save_unit_id}/{name}`, older versions use flat layout.
+    // The ID is a stable, monotonically-assigned identifier that does not change when
+    // save units are added or removed.
     let original_path = if version.uses_index_prefix() {
-        temp_root.join(index.to_string()).join(file_name)
+        temp_root.join(unit.id.to_string()).join(file_name)
     } else {
         temp_root.join(file_name)
     };
@@ -212,9 +208,8 @@ pub(super) fn decompress_from_archive(
     }
 
     let mut restore_errors = Vec::new();
-    for (index, unit) in save_paths.iter().enumerate() {
-        if let Err(err) = restore_save_unit_from_temp(unit, index, version, &temp_root, app_handle)
-        {
+    for unit in save_paths {
+        if let Err(err) = restore_save_unit_from_temp(unit, version, &temp_root, app_handle) {
             restore_errors.push(err);
         }
     }

--- a/src-tauri/src/backup/game.rs
+++ b/src-tauri/src/backup/game.rs
@@ -25,6 +25,10 @@ pub struct Game {
     // Key: DeviceId (String), Value: Path (String)
     #[serde(default)]
     pub game_paths: HashMap<DeviceId, String>,
+    /// Monotonically increasing counter for assigning unique save-unit IDs.
+    /// Each call to `new_save_unit_id()` returns the current value and increments it.
+    #[serde(default)]
+    pub next_save_unit_id: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src-tauri/src/backup/game.rs
+++ b/src-tauri/src/backup/game.rs
@@ -2,14 +2,15 @@ use log::{info, warn};
 use rust_i18n::t;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tauri::{AppHandle, Emitter};
 
 use crate::backup::state_fingerprint::{fingerprint_source_state, fingerprint_zip_state};
 use crate::backup::{
-    ArchiveBackend, GameSnapshots, SaveUnit, Snapshot, TIMER_AUTO_BACKUP_DESCRIPTION, ZipBackend,
+    ArchiveBackend, GameSnapshots, SaveUnit, SaveUnitDraft, Snapshot,
+    TIMER_AUTO_BACKUP_DESCRIPTION, ZipBackend,
 };
 use crate::config::{get_backup_path, get_config, set_config_local};
 use crate::device::DeviceId;
@@ -26,9 +27,34 @@ pub struct Game {
     #[serde(default)]
     pub game_paths: HashMap<DeviceId, String>,
     /// Monotonically increasing counter for assigning unique save-unit IDs.
-    /// Each call to `new_save_unit_id()` returns the current value and increments it.
+    /// IDs can be provided by callers (frontend/CLI/FFI), and backend normalization
+    /// keeps this counter aligned with the highest in-use ID.
     #[serde(default)]
     pub next_save_unit_id: u32,
+}
+
+/// Frontend/IPC input shape for creating/updating a game.
+/// Save-unit IDs are assigned and normalized in backend domain logic.
+#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+pub struct GameDraft {
+    pub name: String,
+    pub save_paths: Vec<SaveUnitDraft>,
+    #[serde(default)]
+    pub game_paths: HashMap<DeviceId, String>,
+}
+
+fn save_unit_identity(
+    unit_type: &crate::backup::SaveUnitType,
+    paths: &HashMap<DeviceId, String>,
+) -> String {
+    let mut entries: Vec<_> = paths.iter().collect();
+    entries.sort_by(|(left_id, _), (right_id, _)| left_id.cmp(right_id));
+    let paths_key = entries
+        .into_iter()
+        .map(|(device_id, path)| format!("{device_id}={path}"))
+        .collect::<Vec<_>>()
+        .join("|");
+    format!("{unit_type:?}|{paths_key}")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,7 +93,98 @@ pub struct GameDeleted {
     pub remote_game_dir_path: String,
 }
 
+impl GameDraft {
+    /// Convert frontend/IPC draft to persisted game model with stable save-unit IDs.
+    pub fn into_game(self, existing: Option<&Game>) -> Game {
+        let mut existing_ids_by_identity: HashMap<String, VecDeque<u32>> = HashMap::new();
+        let mut next_save_unit_id = existing.map(|game| game.next_save_unit_id).unwrap_or(0);
+
+        if let Some(existing_game) = existing {
+            for save_unit in &existing_game.save_paths {
+                let identity = save_unit_identity(&save_unit.unit_type, &save_unit.paths);
+                existing_ids_by_identity
+                    .entry(identity)
+                    .or_default()
+                    .push_back(save_unit.id);
+                if save_unit.id >= next_save_unit_id {
+                    next_save_unit_id = save_unit.id.saturating_add(1);
+                }
+            }
+        }
+
+        let mut used_ids = HashSet::new();
+        let mut save_paths = Vec::with_capacity(self.save_paths.len());
+        for draft in self.save_paths {
+            let identity = save_unit_identity(&draft.unit_type, &draft.paths);
+            let reused_id = existing_ids_by_identity
+                .get_mut(&identity)
+                .and_then(|ids| ids.pop_front());
+
+            let id = if let Some(id) = reused_id {
+                used_ids.insert(id);
+                id
+            } else {
+                while used_ids.contains(&next_save_unit_id) {
+                    next_save_unit_id = next_save_unit_id.saturating_add(1);
+                }
+                let id = next_save_unit_id;
+                used_ids.insert(id);
+                next_save_unit_id = next_save_unit_id.saturating_add(1);
+                id
+            };
+
+            save_paths.push(SaveUnit {
+                id,
+                unit_type: draft.unit_type,
+                paths: draft.paths,
+                delete_before_apply: draft.delete_before_apply,
+            });
+        }
+
+        let mut game = Game {
+            name: self.name,
+            save_paths,
+            game_paths: self.game_paths,
+            next_save_unit_id,
+        };
+        game.normalize_save_unit_ids();
+        game
+    }
+}
+
 impl Game {
+    /// Normalize save-unit IDs to keep them unique and stable inside this game.
+    ///
+    /// This is the backend safety net for all callers (frontend/CLI/FFI):
+    /// - keep the first occurrence of each existing ID;
+    /// - reassign only duplicated IDs using the monotonic counter;
+    /// - move `next_save_unit_id` forward to one past the highest assigned ID.
+    pub fn normalize_save_unit_ids(&mut self) {
+        let mut used_ids = HashSet::with_capacity(self.save_paths.len());
+        let mut next_id = self.next_save_unit_id;
+
+        for save_unit in &self.save_paths {
+            if used_ids.insert(save_unit.id) && save_unit.id >= next_id {
+                next_id = save_unit.id.saturating_add(1);
+            }
+        }
+
+        used_ids.clear();
+        for save_unit in &mut self.save_paths {
+            if used_ids.insert(save_unit.id) {
+                continue;
+            }
+            while used_ids.contains(&next_id) {
+                next_id = next_id.saturating_add(1);
+            }
+            save_unit.id = next_id;
+            used_ids.insert(next_id);
+            next_id = next_id.saturating_add(1);
+        }
+
+        self.next_save_unit_id = next_id;
+    }
+
     pub fn get_game_snapshots_info(&self) -> Result<GameSnapshots, BackupError> {
         let backup_path = get_backup_path()?.join(&self.name).join("Backups.json");
         let backup_info = serde_json::from_slice(&fs::read(backup_path)?)?;

--- a/src-tauri/src/backup/mod.rs
+++ b/src-tauri/src/backup/mod.rs
@@ -15,10 +15,10 @@ pub use extra_backups::ExtraBackupItem;
 pub use extra_backups::{
     delete_extra_backup, extra_backup_folder_path, list_extra_backups, restore_extra_backup,
 };
-pub use game::Game;
 pub(crate) use game::TimerSnapshotDecision;
+pub use game::{Game, GameDraft};
 pub use game_snapshots::GameSnapshots;
-pub use save_unit::{SaveUnit, SaveUnitType};
+pub use save_unit::{SaveUnit, SaveUnitDraft, SaveUnitType};
 pub use snapshot::Snapshot;
 pub use utils::*;
 

--- a/src-tauri/src/backup/save_unit.rs
+++ b/src-tauri/src/backup/save_unit.rs
@@ -15,9 +15,17 @@ pub enum SaveUnitType {
 }
 
 /// A save unit declares one of the files/folders
-/// that should be backup for a game
+/// that should be backup for a game.
+///
+/// The `id` field is a stable identifier used as the index prefix in V2 archives.
+/// Unlike positional indices, it does not change when save units are added or removed,
+/// ensuring old archives can always be restored correctly.
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct SaveUnit {
+    /// Stable identifier for this save unit, used as archive entry prefix in V2 format.
+    /// Assigned by `Game::new_save_unit_id()` and never reused within a game.
+    #[serde(default)]
+    pub id: u32,
     pub unit_type: SaveUnitType,
     #[serde(default)] // 如果反序列化时字段不存在，则使用默认值 (空 HashMap)
     pub paths: HashMap<DeviceId, String>, // 存储不同设备的路径

--- a/src-tauri/src/backup/save_unit.rs
+++ b/src-tauri/src/backup/save_unit.rs
@@ -19,16 +19,28 @@ pub enum SaveUnitType {
 ///
 /// The `id` field is a stable identifier used as the index prefix in V2 archives.
 /// Unlike positional indices, it does not change when save units are added or removed,
-/// ensuring old archives can always be restored correctly.
+/// ensuring old archives can always be restored correctly. The backend will
+/// normalize duplicated IDs when persisting config.
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct SaveUnit {
     /// Stable identifier for this save unit, used as archive entry prefix in V2 format.
-    /// Assigned by `Game::new_save_unit_id()` and never reused within a game.
+    /// Provided by the caller (frontend/CLI/FFI) and kept unique by backend normalization.
     #[serde(default)]
     pub id: u32,
     pub unit_type: SaveUnitType,
     #[serde(default)] // 如果反序列化时字段不存在，则使用默认值 (空 HashMap)
     pub paths: HashMap<DeviceId, String>, // 存储不同设备的路径
+    #[serde(default = "default_value::default_false")]
+    pub delete_before_apply: bool,
+}
+
+/// Frontend/IPC input shape for save-unit editing.
+/// ID allocation is handled by backend domain logic.
+#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+pub struct SaveUnitDraft {
+    pub unit_type: SaveUnitType,
+    #[serde(default)]
+    pub paths: HashMap<DeviceId, String>,
     #[serde(default = "default_value::default_false")]
     pub delete_before_apply: bool,
 }

--- a/src-tauri/src/backup/tests/archive.rs
+++ b/src-tauri/src/backup/tests/archive.rs
@@ -7,6 +7,7 @@ use crate::backup::archive::{
 use crate::backup::state_fingerprint::{fingerprint_source_state, fingerprint_zip_state};
 use crate::backup::{SaveUnit, SaveUnitType};
 use crate::device::get_current_device_id;
+use crate::preclude::{BackupFileError, CompressError};
 use filetime::{FileTime, set_file_mtime};
 use std::{
     collections::HashMap,
@@ -480,6 +481,49 @@ mod tests {
 
         assert_eq!(fs::read(&file_a)?, b"content-from-unit-a");
         assert_eq!(fs::read(&file_b)?, b"content-from-unit-b");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_compress_rejects_duplicate_save_unit_ids() -> Result<(), Box<dyn std::error::Error>> {
+        let _config_lock = lock_config_file();
+        let _config_guard = ConfigFileGuard::write_default_config()?;
+
+        let temp_dir = temp_dir::TempDir::new()?;
+        let temp_path = temp_dir.path();
+        let backup_dir = temp_path.join("backup");
+        fs::create_dir_all(&backup_dir)?;
+        let zip_path = backup_dir.join("duplicate_id.zip");
+
+        let dir_a = temp_path.join("unit_a");
+        let dir_b = temp_path.join("unit_b");
+        fs::create_dir_all(&dir_a)?;
+        fs::create_dir_all(&dir_b)?;
+
+        let file_a = dir_a.join("save.dat");
+        let file_b = dir_b.join("save.dat");
+        fs::write(&file_a, b"a")?;
+        fs::write(&file_b, b"b")?;
+
+        let save_units = [
+            build_file_save_unit_with_id(&file_a, 0),
+            build_file_save_unit_with_id(&file_b, 0),
+        ];
+
+        let err = compress_to_file(&save_units, &zip_path, CompressionPreset::Standard)
+            .expect_err("duplicate save-unit IDs should be rejected");
+        assert!(
+            matches!(
+                err,
+                CompressError::Single(BackupFileError::DuplicateSaveUnitId(0))
+            ),
+            "unexpected error: {err:?}"
+        );
+        assert!(
+            !zip_path.exists(),
+            "zip file should not be created when duplicate IDs are rejected"
+        );
 
         Ok(())
     }

--- a/src-tauri/src/backup/tests/archive.rs
+++ b/src-tauri/src/backup/tests/archive.rs
@@ -23,12 +23,17 @@ mod tests {
     use chrono::{Datelike, LocalResult, Timelike};
 
     fn build_file_save_unit(path: &Path) -> SaveUnit {
+        build_file_save_unit_with_id(path, 0)
+    }
+
+    fn build_file_save_unit_with_id(path: &Path, id: u32) -> SaveUnit {
         let mut paths = HashMap::new();
         paths.insert(
             get_current_device_id().clone(),
             path.to_string_lossy().to_string(),
         );
         SaveUnit {
+            id,
             unit_type: SaveUnitType::File,
             paths,
             delete_before_apply: false,
@@ -441,8 +446,8 @@ mod tests {
         fs::write(&file_a, b"content-from-unit-a")?;
         fs::write(&file_b, b"content-from-unit-b")?;
 
-        let unit_a = build_file_save_unit(&file_a);
-        let unit_b = build_file_save_unit(&file_b);
+        let unit_a = build_file_save_unit_with_id(&file_a, 0);
+        let unit_b = build_file_save_unit_with_id(&file_b, 1);
         let save_units = [unit_a, unit_b];
 
         let backup_dir = temp_path.join("backup");
@@ -542,7 +547,10 @@ mod tests {
         fs::write(&file_a, b"data-a")?;
         fs::write(&file_b, b"data-b")?;
 
-        let save_units = [build_file_save_unit(&file_a), build_file_save_unit(&file_b)];
+        let save_units = [
+            build_file_save_unit_with_id(&file_a, 0),
+            build_file_save_unit_with_id(&file_b, 1),
+        ];
 
         let backup_dir = temp_path.join("backup");
         fs::create_dir_all(&backup_dir)?;

--- a/src-tauri/src/backup/tests/game.rs
+++ b/src-tauri/src/backup/tests/game.rs
@@ -2,8 +2,8 @@ use super::utils::{ConfigFileGuard, lock_config_file};
 use crate::backup::archive::system_time_to_zip_datetime;
 use crate::backup::state_fingerprint::{fingerprint_source_state, fingerprint_zip_state};
 use crate::backup::{
-    Game, GameSnapshots, SaveUnit, SaveUnitType, Snapshot, TIMER_AUTO_BACKUP_DESCRIPTION,
-    TimerSnapshotDecision,
+    Game, GameDraft, GameSnapshots, SaveUnit, SaveUnitDraft, SaveUnitType, Snapshot,
+    TIMER_AUTO_BACKUP_DESCRIPTION, TimerSnapshotDecision,
 };
 use crate::config::Config;
 use crate::device::get_current_device_id;
@@ -578,4 +578,135 @@ fn batch_delete_empty_dates_is_noop() -> TestResult {
 
         Ok(())
     })
+}
+
+#[test]
+fn normalize_save_unit_ids_reassigns_duplicates() {
+    let mut game = Game {
+        name: "normalize-dup".to_string(),
+        save_paths: vec![
+            SaveUnit {
+                id: 0,
+                unit_type: SaveUnitType::File,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 0,
+                unit_type: SaveUnitType::Folder,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 2,
+                unit_type: SaveUnitType::File,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 2,
+                unit_type: SaveUnitType::Folder,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+        ],
+        game_paths: HashMap::new(),
+        next_save_unit_id: 1,
+    };
+
+    game.normalize_save_unit_ids();
+
+    let ids: Vec<u32> = game.save_paths.iter().map(|u| u.id).collect();
+    assert_eq!(ids, vec![0, 3, 2, 4]);
+    assert_eq!(game.next_save_unit_id, 5);
+}
+
+#[test]
+fn normalize_save_unit_ids_assigns_sequential_from_legacy_defaults() {
+    let mut game = Game {
+        name: "normalize-legacy".to_string(),
+        save_paths: vec![
+            SaveUnit {
+                id: 0,
+                unit_type: SaveUnitType::File,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 0,
+                unit_type: SaveUnitType::Folder,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 0,
+                unit_type: SaveUnitType::File,
+                paths: HashMap::new(),
+                delete_before_apply: false,
+            },
+        ],
+        game_paths: HashMap::new(),
+        next_save_unit_id: 0,
+    };
+
+    game.normalize_save_unit_ids();
+
+    let ids: Vec<u32> = game.save_paths.iter().map(|u| u.id).collect();
+    assert_eq!(ids, vec![0, 1, 2]);
+    assert_eq!(game.next_save_unit_id, 3);
+}
+
+#[test]
+fn game_draft_into_game_reuses_existing_ids_and_allocates_new_ones() {
+    let device_id = "device-a".to_string();
+
+    let mut existing_path_a = HashMap::new();
+    existing_path_a.insert(device_id.clone(), "C:\\A\\save.dat".to_string());
+    let mut existing_path_b = HashMap::new();
+    existing_path_b.insert(device_id.clone(), "C:\\B\\save.dat".to_string());
+
+    let existing = Game {
+        name: "DraftReuse".to_string(),
+        save_paths: vec![
+            SaveUnit {
+                id: 5,
+                unit_type: SaveUnitType::File,
+                paths: existing_path_a.clone(),
+                delete_before_apply: false,
+            },
+            SaveUnit {
+                id: 7,
+                unit_type: SaveUnitType::File,
+                paths: existing_path_b,
+                delete_before_apply: false,
+            },
+        ],
+        game_paths: HashMap::new(),
+        next_save_unit_id: 8,
+    };
+
+    let mut new_path = HashMap::new();
+    new_path.insert(device_id, "C:\\C\\save.dat".to_string());
+    let draft = GameDraft {
+        name: "DraftReuse".to_string(),
+        save_paths: vec![
+            SaveUnitDraft {
+                unit_type: SaveUnitType::File,
+                paths: existing_path_a,
+                delete_before_apply: false,
+            },
+            SaveUnitDraft {
+                unit_type: SaveUnitType::File,
+                paths: new_path,
+                delete_before_apply: false,
+            },
+        ],
+        game_paths: HashMap::new(),
+    };
+
+    let game = draft.into_game(Some(&existing));
+    let ids: Vec<u32> = game.save_paths.iter().map(|u| u.id).collect();
+
+    assert_eq!(ids, vec![5, 8]);
+    assert_eq!(game.next_save_unit_id, 9);
 }

--- a/src-tauri/src/backup/tests/game.rs
+++ b/src-tauri/src/backup/tests/game.rs
@@ -35,6 +35,7 @@ fn build_file_save_unit(path: &Path) -> SaveUnit {
         path.to_string_lossy().to_string(),
     );
     SaveUnit {
+        id: 0,
         unit_type: SaveUnitType::File,
         paths,
         delete_before_apply: false,
@@ -142,6 +143,7 @@ fn timer_backup_skips_when_unchanged() -> TestResult {
             name: game_name.to_string(),
             save_paths: vec![build_file_save_unit(&save_file)],
             game_paths: HashMap::new(),
+            next_save_unit_id: 1,
         };
 
         let first = game
@@ -183,6 +185,7 @@ fn timer_backup_creates_when_changed() -> TestResult {
             name: game_name.to_string(),
             save_paths: vec![build_file_save_unit(&save_file)],
             game_paths: HashMap::new(),
+            next_save_unit_id: 1,
         };
 
         let first = game
@@ -232,6 +235,7 @@ fn timer_backup_compares_only_latest_auto_backup() -> TestResult {
             name: game_name.to_string(),
             save_paths: vec![build_file_save_unit(&save_file)],
             game_paths: HashMap::new(),
+            next_save_unit_id: 1,
         };
 
         let first = game
@@ -280,6 +284,7 @@ fn legacy_auto_snapshot_creates_once_before_dedup() -> TestResult {
             name: game_name.to_string(),
             save_paths: vec![build_file_save_unit(&save_file)],
             game_paths: HashMap::new(),
+            next_save_unit_id: 1,
         };
 
         create_legacy_auto_snapshot(&game, &save_file, "2000-01-01_00-00-00")?;
@@ -322,6 +327,7 @@ fn fingerprint_source_and_zip_match_for_fresh_snapshot() -> TestResult {
             name: game_name.to_string(),
             save_paths: vec![build_file_save_unit(&save_file)],
             game_paths: HashMap::new(),
+            next_save_unit_id: 1,
         };
 
         game.create_snapshot("Manual Snapshot").await?;
@@ -376,6 +382,7 @@ fn make_test_game(game_name: &str, backup_root: &Path) -> Result<Game, Box<dyn s
         name: game_name.to_string(),
         save_paths: Vec::new(),
         game_paths: HashMap::new(),
+        next_save_unit_id: 0,
     })
 }
 

--- a/src-tauri/src/backup/utils.rs
+++ b/src-tauri/src/backup/utils.rs
@@ -8,7 +8,7 @@ use tauri::AppHandle;
 use tokio::sync::Semaphore;
 
 use super::game::SnapshotCreated;
-use super::{Game, GameSnapshots};
+use super::{GameDraft, GameSnapshots};
 
 async fn create_backup_folder(name: &str) -> Result<(), BackupError> {
     let backup_path = get_backup_path()?.join(name);
@@ -32,7 +32,7 @@ async fn create_backup_folder(name: &str) -> Result<(), BackupError> {
     Ok(())
 }
 
-pub async fn create_game_backup(game: &Game) -> Result<(), BackupError> {
+pub async fn create_game_backup(game: &GameDraft) -> Result<(), BackupError> {
     let mut config = get_config()?;
     create_backup_folder(&game.name).await?;
 
@@ -41,11 +41,12 @@ pub async fn create_game_backup(game: &Game) -> Result<(), BackupError> {
     match pos {
         Some(index) => {
             // 如果找到了，就用新的游戏覆盖它
-            config.games[index] = game.clone();
+            let existing = &config.games[index];
+            config.games[index] = game.clone().into_game(Some(existing));
         }
         None => {
             // 如果没有找到，就将新的游戏添加到 `games` 数组中
-            config.games.push(game.clone());
+            config.games.push(game.clone().into_game(None));
         }
     }
     set_config_local(&config)?;

--- a/src-tauri/src/config/utils.rs
+++ b/src-tauri/src/config/utils.rs
@@ -37,7 +37,11 @@ pub fn get_config() -> Result<Config, ConfigError> {
 /// Replace the config file with a new config struct without triggering cloud sync.
 pub fn set_config_local(config: &Config) -> Result<(), ConfigError> {
     let config_path = resolve_app_path("GameSaveManager.config.json");
-    fs::write(config_path, serde_json::to_string_pretty(&config)?)?;
+    let mut normalized = config.clone();
+    for game in &mut normalized.games {
+        game.normalize_save_unit_ids();
+    }
+    fs::write(config_path, serde_json::to_string_pretty(&normalized)?)?;
     Ok(())
 }
 

--- a/src-tauri/src/ipc_handler.rs
+++ b/src-tauri/src/ipc_handler.rs
@@ -1,4 +1,4 @@
-use crate::backup::{ExtraBackupItem, Game, GameSnapshots};
+use crate::backup::{ExtraBackupItem, Game, GameDraft, GameSnapshots};
 use crate::cloud_sync::{self, Backend, CloudSyncJob, CloudSyncTaskManager};
 use crate::config::{Config, QuickActionSoundPreferences, get_backup_path, get_config};
 use crate::device::{Device, get_current_device_id};
@@ -94,8 +94,8 @@ pub async fn get_local_config() -> Result<Config, String> {
 
 #[tauri::command]
 #[specta::specta]
-pub async fn add_game(game: Game, app_handle: AppHandle) -> Result<(), String> {
-    info!(target:"rgsm::ipc", "Adding game: {:?}", game);
+pub async fn add_game(game: GameDraft, app_handle: AppHandle) -> Result<(), String> {
+    info!(target:"rgsm::ipc", "Adding game draft: {:?}", game);
     backup::create_game_backup(&game).await.map_err(|e| {
         error!(target:"rgsm::ipc", "Failed to add game: {:?}", e);
         e.to_string()
@@ -103,36 +103,44 @@ pub async fn add_game(game: Game, app_handle: AppHandle) -> Result<(), String> {
 
     if let Ok(config) = get_config() {
         if config.settings.cloud_settings.always_sync {
-            match game.get_game_snapshots_info() {
-                Ok(snapshots) => {
-                    enqueue_cloud_sync_job(
-                        &app_handle,
-                        CloudSyncJob::UploadMetadata {
-                            backend: config.settings.cloud_settings.backend.clone(),
-                            game_name: snapshots.name.clone(),
-                            snapshots,
-                        },
-                    )
-                    .await;
+            if let Some(saved_game) = config.games.iter().find(|g| g.name == game.name) {
+                match saved_game.get_game_snapshots_info() {
+                    Ok(snapshots) => {
+                        enqueue_cloud_sync_job(
+                            &app_handle,
+                            CloudSyncJob::UploadMetadata {
+                                backend: config.settings.cloud_settings.backend.clone(),
+                                game_name: snapshots.name.clone(),
+                                snapshots,
+                            },
+                        )
+                        .await;
 
-                    enqueue_cloud_sync_job(
-                        &app_handle,
-                        CloudSyncJob::UploadConfig {
-                            backend: config.settings.cloud_settings.backend,
-                            context: "add_game".to_string(),
-                        },
-                    )
-                    .await;
+                        enqueue_cloud_sync_job(
+                            &app_handle,
+                            CloudSyncJob::UploadConfig {
+                                backend: config.settings.cloud_settings.backend,
+                                context: "add_game".to_string(),
+                            },
+                        )
+                        .await;
+                    }
+                    Err(err) => warn!(
+                        target: "rgsm::ipc",
+                        "Failed to collect new game snapshots for cloud enqueue: {err:?}"
+                    ),
                 }
-                Err(err) => warn!(
+            } else {
+                warn!(
                     target: "rgsm::ipc",
-                    "Failed to collect new game snapshots for cloud enqueue: {err:?}"
-                ),
+                    "Saved game '{}' not found in config after add_game",
+                    game.name
+                );
             }
         }
     }
 
-    info!(target:"rgsm::ipc", "Successfully added game: {:?}", game);
+    info!(target:"rgsm::ipc", "Successfully added game draft: {:?}", game.name);
     Ok(())
 }
 

--- a/src-tauri/src/preclude/errors.rs
+++ b/src-tauri/src/preclude/errors.rs
@@ -15,6 +15,8 @@ pub enum BackupFileError {
     Fs(#[from] fs_extra::error::Error),
     #[error("Cannot convert path to string")]
     NonePathError,
+    #[error("Duplicate save-unit id detected in game config: {0}")]
+    DuplicateSaveUnitId(u32),
     #[error("Path resolution error: {0:#?}")]
     PathResolution(#[from] ResolveError),
     #[error(transparent)]

--- a/src-tauri/src/updater/migration.rs
+++ b/src-tauri/src/updater/migration.rs
@@ -10,7 +10,10 @@ use crate::config::{Config, get_backup_path};
 use crate::preclude::*;
 use crate::updater::{
     probe::probe_config_version,
-    versions::{CURRENT_VERSION, Config1_4_0, MIN_SUPPORTED_VERSION, VERSION_1_4_0, VERSION_1_6_0},
+    versions::{
+        CURRENT_VERSION, Config1_4_0, MIN_SUPPORTED_VERSION, VERSION_1_4_0, VERSION_1_6_0,
+        VERSION_1_7_5,
+    },
 };
 
 /// Update configuration file to the latest version
@@ -34,6 +37,7 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<(), UpdaterError> {
     let current = Version::parse(CURRENT_VERSION)?;
     let min_supported = Version::parse(MIN_SUPPORTED_VERSION)?;
     let version_1_6_0 = Version::parse(VERSION_1_6_0)?;
+    let version_1_7_5 = Version::parse(VERSION_1_7_5)?;
 
     // Version compatibility check
     if version > current {
@@ -56,11 +60,16 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<(), UpdaterError> {
     let content = fs::read_to_string(path)?;
 
     // Migrate based on version
-    let new_cfg = migrate_config(&content, &version)?;
+    let mut new_cfg = migrate_config(&content, &version)?;
 
     // Migrate game snapshots if upgrading from before 1.6.0
     if version < version_1_6_0 {
         migrate_game_snapshots_to_chain()?;
+    }
+
+    // Assign stable IDs to save units if upgrading from before 1.7.5
+    if version < version_1_7_5 {
+        new_cfg = migrate_save_unit_ids(new_cfg);
     }
 
     // Write new config
@@ -197,4 +206,110 @@ fn migrate_game_snapshots_to_chain() -> Result<(), UpdaterError> {
 
     info!(target: "rgsm::updater", "Game snapshots migration completed");
     Ok(())
+}
+
+/// Assign stable IDs to save units that were created before v1.7.5.
+///
+/// Old save units have `id: 0` (the serde default). This migration assigns
+/// sequential IDs starting from 0 and sets `next_save_unit_id` to one past
+/// the last assigned ID. This preserves the positional-index mapping that
+/// old V2 archives were created with.
+fn migrate_save_unit_ids(mut config: Config) -> Config {
+    for game in &mut config.games {
+        // Skip games that already have non-zero IDs (already migrated or created post-1.7.5)
+        let needs_migration = game.next_save_unit_id == 0
+            && game.save_paths.iter().all(|u| u.id == 0)
+            && !game.save_paths.is_empty();
+
+        if !needs_migration {
+            continue;
+        }
+
+        // Assign IDs matching the positional index so existing V2 archives
+        // (which used `enumerate()` index as prefix) remain compatible.
+        for (i, unit) in game.save_paths.iter_mut().enumerate() {
+            unit.id = i as u32;
+        }
+        game.next_save_unit_id = game.save_paths.len() as u32;
+
+        info!(
+            target: "rgsm::updater",
+            "Assigned stable IDs to {} save units for game '{}'",
+            game.save_paths.len(),
+            game.name
+        );
+    }
+
+    config
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::{SaveUnit, SaveUnitType};
+
+    #[test]
+    fn migrate_save_unit_ids_assigns_sequential_ids() {
+        let mut config = Config::default();
+        config.games.push(crate::backup::Game {
+            name: "TestGame".to_string(),
+            save_paths: vec![
+                SaveUnit {
+                    id: 0,
+                    unit_type: SaveUnitType::Folder,
+                    paths: Default::default(),
+                    delete_before_apply: false,
+                },
+                SaveUnit {
+                    id: 0,
+                    unit_type: SaveUnitType::File,
+                    paths: Default::default(),
+                    delete_before_apply: false,
+                },
+            ],
+            game_paths: Default::default(),
+            next_save_unit_id: 0,
+        });
+
+        let migrated = migrate_save_unit_ids(config);
+        let game = &migrated.games[0];
+        assert_eq!(game.save_paths[0].id, 0);
+        assert_eq!(game.save_paths[1].id, 1);
+        assert_eq!(game.next_save_unit_id, 2);
+    }
+
+    #[test]
+    fn migrate_save_unit_ids_skips_already_migrated() {
+        let mut config = Config::default();
+        config.games.push(crate::backup::Game {
+            name: "AlreadyMigrated".to_string(),
+            save_paths: vec![SaveUnit {
+                id: 5,
+                unit_type: SaveUnitType::File,
+                paths: Default::default(),
+                delete_before_apply: false,
+            }],
+            game_paths: Default::default(),
+            next_save_unit_id: 6,
+        });
+
+        let migrated = migrate_save_unit_ids(config);
+        let game = &migrated.games[0];
+        assert_eq!(game.save_paths[0].id, 5);
+        assert_eq!(game.next_save_unit_id, 6);
+    }
+
+    #[test]
+    fn migrate_save_unit_ids_skips_empty_games() {
+        let mut config = Config::default();
+        config.games.push(crate::backup::Game {
+            name: "EmptyGame".to_string(),
+            save_paths: vec![],
+            game_paths: Default::default(),
+            next_save_unit_id: 0,
+        });
+
+        let migrated = migrate_save_unit_ids(config);
+        assert_eq!(migrated.games[0].next_save_unit_id, 0);
+    }
 }

--- a/src-tauri/src/updater/versions/mod.rs
+++ b/src-tauri/src/updater/versions/mod.rs
@@ -6,6 +6,8 @@ pub const MIN_SUPPORTED_VERSION: &str = "1.0.0";
 pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Version 1.6.0 - introduced branch/tree view for snapshots
 pub const VERSION_1_6_0: &str = "1.6.0";
+/// Version 1.7.5 - introduced stable save-unit IDs
+pub const VERSION_1_7_5: &str = "1.7.5";
 
 // 1.4.X
 mod v1_4_0;

--- a/src-tauri/src/updater/versions/v1_4_0.rs
+++ b/src-tauri/src/updater/versions/v1_4_0.rs
@@ -61,6 +61,7 @@ impl From<Config> for CurrentConfig {
                         let mut paths = HashMap::new();
                         paths.insert(current_device_id.clone(), su.path);
                         SaveUnit {
+                            id: 0,
                             unit_type: su.unit_type,
                             paths,
                             delete_before_apply: su.delete_before_apply,
@@ -71,6 +72,7 @@ impl From<Config> for CurrentConfig {
                     name: g.name,
                     save_paths,
                     game_paths,
+                    next_save_unit_id: 0,
                 }
             })
             .collect();

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -382,7 +382,7 @@ quickActionCompleted: "quick-action-completed"
 
 /** user-defined constants **/
 
-export const DEFAULT_CONFIG = {"backup_path":"save_data","devices":{},"favorites":[],"games":[],"quick_action":{"enable_notification":true,"enable_sound":true,"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null,"sounds":{"failure":{"kind":"default"},"success":{"kind":"default"}}},"settings":{"add_new_to_favorites":false,"appearance":{"custom_font_enabled":false,"ui_font_family":""},"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"max_concurrency":1,"root_path":"/game-save-manager"},"compression_preset":"Standard","default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"max_auto_backup_count":0,"max_extra_backup_count":5,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"save_list_expand_behavior":"always_closed","save_list_last_expanded":false,"show_edit_button":false},"version":"1.7.4"} as const;
+export const DEFAULT_CONFIG = {"backup_path":"save_data","devices":{},"favorites":[],"games":[],"quick_action":{"enable_notification":true,"enable_sound":true,"hotkeys":{"apply":["","",""],"backup":["","",""]},"quick_action_game":null,"sounds":{"failure":{"kind":"default"},"success":{"kind":"default"}}},"settings":{"add_new_to_favorites":false,"appearance":{"custom_font_enabled":false,"ui_font_family":""},"cloud_settings":{"always_sync":false,"auto_sync_interval":0,"backend":{"type":"Disabled"},"max_concurrency":1,"root_path":"/game-save-manager"},"compression_preset":"Standard","default_delete_before_apply":false,"default_expend_favorites_tree":false,"exit_to_tray":true,"extra_backup_when_apply":true,"home_page":"/","locale":"zh_SIMPLIFIED","log_to_file":true,"max_auto_backup_count":0,"max_extra_backup_count":5,"prompt_when_auto_backup":true,"prompt_when_not_described":false,"save_list_expand_behavior":"always_closed","save_list_last_expanded":false,"show_edit_button":false},"version":"1.7.5"} as const;
 
 /** user-defined types **/
 
@@ -472,7 +472,12 @@ export type FavoriteTreeNode = { node_id: string; label: string; is_leaf: boolea
 /**
  * A game struct contains the save units and the game's launcher
  */
-export type Game = { name: string; save_paths: SaveUnit[]; game_paths?: Partial<{ [key in string]: string }> }
+export type Game = { name: string; save_paths: SaveUnit[]; game_paths?: Partial<{ [key in string]: string }>; 
+/**
+ * Monotonically increasing counter for assigning unique save-unit IDs.
+ * Each call to `new_save_unit_id()` returns the current value and increments it.
+ */
+next_save_unit_id?: number }
 /**
  * A backup list info is a json file in a backup folder for a game.
  * It contains the name of the game,
@@ -583,9 +588,18 @@ path: string;
 tags: string[] }
 /**
  * A save unit declares one of the files/folders
- * that should be backup for a game
+ * that should be backup for a game.
+ * 
+ * The `id` field is a stable identifier used as the index prefix in V2 archives.
+ * Unlike positional indices, it does not change when save units are added or removed,
+ * ensuring old archives can always be restored correctly.
  */
-export type SaveUnit = { unit_type: SaveUnitType; paths?: Partial<{ [key in string]: string }>; delete_before_apply?: boolean }
+export type SaveUnit = { 
+/**
+ * Stable identifier for this save unit, used as archive entry prefix in V2 format.
+ * Assigned by `Game::new_save_unit_id()` and never reused within a game.
+ */
+id?: number; unit_type: SaveUnitType; paths?: Partial<{ [key in string]: string }>; delete_before_apply?: boolean }
 /**
  * A save unit should be a file or a folder
  */

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -45,7 +45,7 @@ async getLocalConfig() : Promise<Result<Config, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async addGame(game: Game) : Promise<Result<null, string>> {
+async addGame(game: GameDraft) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_game", { game }) };
 } catch (e) {
@@ -475,9 +475,15 @@ export type FavoriteTreeNode = { node_id: string; label: string; is_leaf: boolea
 export type Game = { name: string; save_paths: SaveUnit[]; game_paths?: Partial<{ [key in string]: string }>; 
 /**
  * Monotonically increasing counter for assigning unique save-unit IDs.
- * Each call to `new_save_unit_id()` returns the current value and increments it.
+ * IDs can be provided by callers (frontend/CLI/FFI), and backend normalization
+ * keeps this counter aligned with the highest in-use ID.
  */
 next_save_unit_id?: number }
+/**
+ * Frontend/IPC input shape for creating/updating a game.
+ * Save-unit IDs are assigned and normalized in backend domain logic.
+ */
+export type GameDraft = { name: string; save_paths: SaveUnitDraft[]; game_paths?: Partial<{ [key in string]: string }> }
 /**
  * A backup list info is a json file in a backup folder for a game.
  * It contains the name of the game,
@@ -592,14 +598,20 @@ tags: string[] }
  * 
  * The `id` field is a stable identifier used as the index prefix in V2 archives.
  * Unlike positional indices, it does not change when save units are added or removed,
- * ensuring old archives can always be restored correctly.
+ * ensuring old archives can always be restored correctly. The backend will
+ * normalize duplicated IDs when persisting config.
  */
 export type SaveUnit = { 
 /**
  * Stable identifier for this save unit, used as archive entry prefix in V2 format.
- * Assigned by `Game::new_save_unit_id()` and never reused within a game.
+ * Provided by the caller (frontend/CLI/FFI) and kept unique by backend normalization.
  */
 id?: number; unit_type: SaveUnitType; paths?: Partial<{ [key in string]: string }>; delete_before_apply?: boolean }
+/**
+ * Frontend/IPC input shape for save-unit editing.
+ * ID allocation is handled by backend domain logic.
+ */
+export type SaveUnitDraft = { unit_type: SaveUnitType; paths?: Partial<{ [key in string]: string }>; delete_before_apply?: boolean }
 /**
  * A save unit should be a file or a folder
  */

--- a/src/pages/AddGame.vue
+++ b/src/pages/AddGame.vue
@@ -3,8 +3,8 @@ import { DocumentAdd, Check, RefreshRight, Download, InfoFilled } from '@element
 import { reactive, ref, watchEffect } from 'vue';
 import {
   commands,
-  type Game,
-  type SaveUnit,
+  type GameDraft,
+  type SaveUnitDraft,
   type Device,
   type ImportableGame,
   type SavePath,
@@ -44,12 +44,11 @@ const buttons = [
 ] as const;
 
 const game_name = ref(''); // 写入游戏名
-const save_paths = reactive<SaveUnit[]>([]); // 选择游戏存档目录
+const save_paths = reactive<SaveUnitDraft[]>([]); // 选择游戏存档目录
 const game_path = ref(''); // 选择游戏启动程序
 const game_icon_src = ref('/orange.png');
 const is_editing = ref(false); // 是否正在编辑已有的游戏
 const currentDevice = ref<Device | null>(null); // 当前设备信息
-const nextSaveUnitId = ref(0); // monotonically increasing save-unit ID counter
 
 // Import dialog state
 const showImportDialog = ref(false);
@@ -94,7 +93,6 @@ watchEffect(() => {
       is_editing.value = true;
       game_name.value = gameConfig.name;
       save_paths.splice(0, save_paths.length, ...(gameConfig.save_paths ?? []));
-      nextSaveUnitId.value = gameConfig.next_save_unit_id ?? 0;
 
       // 获取当前设备的游戏路径
       if (gameConfig.game_paths && currentDevice.value) {
@@ -127,13 +125,11 @@ function check_name_valid(name: string) {
   const invalid_reg = /[<>:"/\\|?*]/;
   return !invalid_reg.test(name);
 }
-function generate_save_unit(unit_type: 'Folder' | 'File', path: string): SaveUnit {
+function generate_save_unit(unit_type: 'Folder' | 'File', path: string): SaveUnitDraft {
   const delete_before_apply = config.value?.settings.default_delete_before_apply;
-  const id = nextSaveUnitId.value++;
 
   // 创建一个基本的 SaveUnit，使用当前设备ID作为路径映射的键
-  const saveUnit: SaveUnit = {
-    id,
+  const saveUnit: SaveUnitDraft = {
     unit_type,
     paths: {},
     delete_before_apply,
@@ -347,13 +343,12 @@ async function handleCustomizeConfirm(data: { gameName: string; savePaths: SaveP
     }
 
     // Build save units with accurate type info
-    const validSavePaths: SaveUnit[] = [];
+    const validSavePaths: SaveUnitDraft[] = [];
     for (const path of pathsToCheck) {
       const pathInfo = pathInfoMap.get(path);
       // Extract isFile only when status is 'ok'
       const isFile = pathInfo?.status === 'ok' ? pathInfo.isFile : undefined;
-      const saveUnit: SaveUnit = {
-        id: nextSaveUnitId.value++,
+      const saveUnit: SaveUnitDraft = {
         unit_type: determineSaveUnitType(path, isFile),
         paths: {},
         delete_before_apply: config.value?.settings.default_delete_before_apply,
@@ -437,8 +432,7 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
       }
 
       // Convert to SaveUnits
-      const savePaths: SaveUnit[] = [];
-      let batchNextId = 0;
+      const savePaths: SaveUnitDraft[] = [];
 
       for (const sp of selectedPaths) {
         if (!sp.path || sp.path.trim() === '') {
@@ -452,8 +446,7 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
         const pathInfo = pathInfoMap.get(sp.path);
         // Extract isFile only when status is 'ok'
         const isFile = pathInfo?.status === 'ok' ? pathInfo.isFile : undefined;
-        const saveUnit: SaveUnit = {
-          id: batchNextId++,
+        const saveUnit: SaveUnitDraft = {
           unit_type: determineSaveUnitType(sp.path, isFile),
           paths: {},
           delete_before_apply: config.value?.settings.default_delete_before_apply,
@@ -484,10 +477,9 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
       }
 
       // Create the game
-      const newGame: Game = {
+      const newGame: GameDraft = {
         name: gameName,
         save_paths: savePaths,
-        next_save_unit_id: batchNextId,
       };
 
       const addResult = await commands.addGame(newGame);
@@ -559,10 +551,9 @@ async function save() {
     showError({ message: $t('addgame.duplicated_name_error') });
     return;
   }
-  const game: Game = {
+  const game: GameDraft = {
     name: game_name.value,
     save_paths: save_paths,
-    next_save_unit_id: nextSaveUnitId.value,
   };
 
   // 如果有游戏路径和当前设备信息，则添加游戏路径
@@ -603,7 +594,6 @@ function reset_info(show_notification: boolean = true) {
   game_name.value = '';
   save_paths.splice(0, save_paths.length);
   game_path.value = '';
-  nextSaveUnitId.value = 0;
   // TODO:This is a first occurrence of a i18n text duplication. How to handle this?
   if (show_notification) {
     showSuccess({ message: $t('settings.reset_success') });

--- a/src/pages/AddGame.vue
+++ b/src/pages/AddGame.vue
@@ -49,6 +49,7 @@ const game_path = ref(''); // 选择游戏启动程序
 const game_icon_src = ref('/orange.png');
 const is_editing = ref(false); // 是否正在编辑已有的游戏
 const currentDevice = ref<Device | null>(null); // 当前设备信息
+const nextSaveUnitId = ref(0); // monotonically increasing save-unit ID counter
 
 // Import dialog state
 const showImportDialog = ref(false);
@@ -93,6 +94,7 @@ watchEffect(() => {
       is_editing.value = true;
       game_name.value = gameConfig.name;
       save_paths.splice(0, save_paths.length, ...(gameConfig.save_paths ?? []));
+      nextSaveUnitId.value = gameConfig.next_save_unit_id ?? 0;
 
       // 获取当前设备的游戏路径
       if (gameConfig.game_paths && currentDevice.value) {
@@ -127,9 +129,11 @@ function check_name_valid(name: string) {
 }
 function generate_save_unit(unit_type: 'Folder' | 'File', path: string): SaveUnit {
   const delete_before_apply = config.value?.settings.default_delete_before_apply;
+  const id = nextSaveUnitId.value++;
 
   // 创建一个基本的 SaveUnit，使用当前设备ID作为路径映射的键
   const saveUnit: SaveUnit = {
+    id,
     unit_type,
     paths: {},
     delete_before_apply,
@@ -349,6 +353,7 @@ async function handleCustomizeConfirm(data: { gameName: string; savePaths: SaveP
       // Extract isFile only when status is 'ok'
       const isFile = pathInfo?.status === 'ok' ? pathInfo.isFile : undefined;
       const saveUnit: SaveUnit = {
+        id: nextSaveUnitId.value++,
         unit_type: determineSaveUnitType(path, isFile),
         paths: {},
         delete_before_apply: config.value?.settings.default_delete_before_apply,
@@ -433,6 +438,7 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
 
       // Convert to SaveUnits
       const savePaths: SaveUnit[] = [];
+      let batchNextId = 0;
 
       for (const sp of selectedPaths) {
         if (!sp.path || sp.path.trim() === '') {
@@ -447,6 +453,7 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
         // Extract isFile only when status is 'ok'
         const isFile = pathInfo?.status === 'ok' ? pathInfo.isFile : undefined;
         const saveUnit: SaveUnit = {
+          id: batchNextId++,
           unit_type: determineSaveUnitType(sp.path, isFile),
           paths: {},
           delete_before_apply: config.value?.settings.default_delete_before_apply,
@@ -480,6 +487,7 @@ async function handleBatchImportConfirm(configs: GameConfig[]) {
       const newGame: Game = {
         name: gameName,
         save_paths: savePaths,
+        next_save_unit_id: batchNextId,
       };
 
       const addResult = await commands.addGame(newGame);
@@ -554,6 +562,7 @@ async function save() {
   const game: Game = {
     name: game_name.value,
     save_paths: save_paths,
+    next_save_unit_id: nextSaveUnitId.value,
   };
 
   // 如果有游戏路径和当前设备信息，则添加游戏路径
@@ -594,6 +603,7 @@ function reset_info(show_notification: boolean = true) {
   game_name.value = '';
   save_paths.splice(0, save_paths.length);
   game_path.value = '';
+  nextSaveUnitId.value = 0;
   // TODO:This is a first occurrence of a i18n text duplication. How to handle this?
   if (show_notification) {
     showSuccess({ message: $t('settings.reset_success') });


### PR DESCRIPTION
Replace positional enumerate() index with a stable, monotonically-assigned id field on SaveUnit. This ensures old archives can always be restored correctly even when save units are added, removed, or reordered.

- Add id: u32 to SaveUnit with #[serde(default)] for backward compat
- Add next_save_unit_id: u32 to Game as an ID counter
- Update compress/decompress to use save_unit.id instead of positional index
- Add config migration (v1.7.5) assigning sequential IDs to existing units
- Frontend: assign IDs in AddGame.vue (manual, import, and batch flows)
- Bump version to 1.7.5
- 55 tests passing (3 new migration tests)
