### PR TITLE
fix: read version from Cargo.toml in portable script

### DIFF
--- a/scripts/portable.mjs
+++ b/scripts/portable.mjs
@@ -3,7 +3,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 import AdmZip from 'adm-zip';
-import { createRequire } from 'module';
 import { getOctokit, context } from '@actions/github';
 
 async function resolvePortable() {
@@ -20,9 +19,12 @@ async function resolvePortable() {
   zip.addLocalFile(path.join(releaseDir, 'rgsm.exe'));
   // zip.addLocalFolder(path.join(releaseDir, "resources"), "resources");
 
-  const require = createRequire(import.meta.url);
-  const packageJson = require('../package.json');
-  const { version } = packageJson;
+  const cargoToml = await fs.readFile(path.join('./src-tauri', 'Cargo.toml'), 'utf-8');
+  const versionMatch = cargoToml.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!versionMatch) {
+    throw new Error('could not read version from src-tauri/Cargo.toml');
+  }
+  const version = versionMatch[1];
 
   const zipFile = `RGSM_${version}_x64-portable.zip`;
   zip.writeZip(zipFile);


### PR DESCRIPTION
## Bug
https://github.com/mcthesw/game-save-manager/issues/334 — The portable zip is named `RGSM_undefined_x64-portable.zip` because `package.json` has no `version` field.

## Fix
The portable build script (`scripts/portable.mjs`) was reading the version from `package.json`, which doesn't define one — resulting in `undefined` in the filename. The canonical version lives in `src-tauri/Cargo.toml`.

This PR changes the script to read the version directly from `Cargo.toml` instead, producing the correct filename (e.g. `RGSM_1.8.0_x64-portable.zip`). Also removed the now-unused `createRequire` import.

## Testing
Verified the regex correctly extracts `1.8.0` from the current `Cargo.toml`. The `fs-extra` `readFile` call is already available in the script's dependencies.

Happy to address any feedback.

Greetings, saschabuehrle