### PR TITLE
feat(ui): 增加文件点击时按住Ctrl打开父文件夹的功能

### DIFF
--- a/apps/rgsm-gui/src/components/PathVariableInput.vue
+++ b/apps/rgsm-gui/src/components/PathVariableInput.vue
@@ -190,17 +190,18 @@ function getCursorOffset(): number {
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return -1;
   const range = sel.getRangeAt(0);
-  if (!editorRef.value.contains(range.startContainer)) return -1;
+  if (!editorRef.value.contains(range.startContainer as Node)) return -1;
 
   let offset = 0;
-  const children = Array.from(editorRef.value.childNodes);
+  const children = Array.from((editorRef.value as unknown as HTMLElement).childNodes) as Node[];
 
   for (let i = 0; i < children.length; i++) {
     const node = children[i];
     if (!node) continue;
-    if (range.startContainer === editorRef.value && i === range.startOffset) return offset;
+    if (range.startContainer === (editorRef.value as unknown as Node) && i === range.startOffset)
+      return offset;
     if (range.startContainer === node) return offset + range.startOffset;
-    if (node.contains(range.startContainer)) return offset;
+    if (node.contains(range.startContainer as Node)) return offset;
     offset += nodeRawLen(node);
   }
 
@@ -213,7 +214,7 @@ function setCursorAtOffset(targetOffset: number) {
   if (!sel) return;
 
   let offset = 0;
-  const children = Array.from(editorRef.value.childNodes);
+  const children = Array.from((editorRef.value as unknown as HTMLElement).childNodes) as Node[];
 
   for (const node of children) {
     const len = nodeRawLen(node);
@@ -221,9 +222,9 @@ function setCursorAtOffset(targetOffset: number) {
       const r = document.createRange();
       if (node.nodeType === Node.TEXT_NODE) {
         const pos = Math.min(targetOffset - offset, node.textContent?.length || 0);
-        r.setStart(node, pos);
+        r.setStart(node as Node, pos);
       } else {
-        r.setStartAfter(node);
+        r.setStartAfter(node as Node);
       }
       r.collapse(true);
       sel.removeAllRanges();
@@ -234,7 +235,7 @@ function setCursorAtOffset(targetOffset: number) {
   }
 
   const r = document.createRange();
-  r.selectNodeContents(editorRef.value);
+  r.selectNodeContents(editorRef.value as unknown as Node);
   r.collapse(false);
   sel.removeAllRanges();
   sel.addRange(r);
@@ -347,9 +348,10 @@ function onKeydown(e: KeyboardEvent) {
       const range = sel.getRangeAt(0);
       if (range.collapsed) {
         let nodeBefore: Node | null = null;
-        if (range.startContainer === editorRef.value) {
+        if (range.startContainer === (editorRef.value as unknown as Node)) {
           const idx = range.startOffset - 1;
-          if (idx >= 0) nodeBefore = editorRef.value.childNodes[idx] ?? null;
+          if (idx >= 0)
+            nodeBefore = (editorRef.value as unknown as HTMLElement).childNodes[idx] ?? null;
         } else if (range.startOffset === 0) {
           nodeBefore = range.startContainer.previousSibling;
         }

--- a/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
+++ b/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
@@ -395,6 +395,35 @@ function formatUnitType(unitType: SaveUnit['unit_type']) {
       return unitType;
   }
 }
+
+async function handleOpenPath(e: MouseEvent, path: string, unit?: SaveUnit) {
+  if (!path || !path.trim()) return;
+
+  const ctrl = (e && (e as MouseEvent).ctrlKey) || (e && (e as MouseEvent).metaKey);
+  if (ctrl && unit && unit.unit_type === 'File') {
+    const normalized = path.replace(/\\/g, '/');
+    const idx = normalized.lastIndexOf('/');
+    const parent = idx > -1 ? normalized.substring(0, idx) : normalized;
+    try {
+      const result = await commands.openFileOrFolder(parent);
+      if (result.status === 'error') {
+        showError({ message: $t('error.open_url_failed') });
+      }
+    } catch {
+      showError({ message: $t('error.open_url_failed') });
+    }
+    return;
+  }
+
+  try {
+    const result = await commands.openFileOrFolder(path);
+    if (result.status === 'error') {
+      showError({ message: $t('error.open_url_failed') });
+    }
+  } catch {
+    showError({ message: $t('error.open_url_failed') });
+  }
+}
 </script>
 
 <template>
@@ -539,14 +568,23 @@ function formatUnitType(unitType: SaveUnit['unit_type']) {
               }}</el-tag>
             </div>
             <div class="unit-card-actions">
-              <el-button
-                text
-                size="small"
-                :disabled="!getDevicePath(unit, selectedDeviceId)"
-                @click="openPath(getDevicePath(unit, selectedDeviceId))"
+              <el-tooltip
+                :content="
+                  unit.unit_type === 'File'
+                    ? $t('save_location_drawer.open_ctrl_hint')
+                    : $t('save_location_drawer.open')
+                "
+                placement="top"
               >
-                {{ $t('save_location_drawer.open') }}
-              </el-button>
+                <el-button
+                  text
+                  size="small"
+                  :disabled="!getDevicePath(unit, selectedDeviceId)"
+                  @click="(e) => handleOpenPath(e, getDevicePath(unit, selectedDeviceId), unit)"
+                >
+                  {{ $t('save_location_drawer.open') }}
+                </el-button>
+              </el-tooltip>
               <el-button text size="small" @click="chooseUnitPath(unit)">
                 {{ $t('save_location_drawer.pick_path') }}
               </el-button>
@@ -624,14 +662,23 @@ function formatUnitType(unitType: SaveUnit['unit_type']) {
                 <el-button text size="small" @click="chooseUnitPath(unit)">
                   {{ $t('save_location_drawer.pick_path') }}
                 </el-button>
-                <el-button
-                  text
-                  size="small"
-                  :disabled="!getDevicePath(unit, selectedDeviceId)"
-                  @click="openPath(getDevicePath(unit, selectedDeviceId))"
+                <el-tooltip
+                  :content="
+                    unit.unit_type === 'File'
+                      ? $t('save_location_drawer.open_ctrl_hint')
+                      : $t('save_location_drawer.open')
+                  "
+                  placement="top"
                 >
-                  {{ $t('save_location_drawer.open') }}
-                </el-button>
+                  <el-button
+                    text
+                    size="small"
+                    :disabled="!getDevicePath(unit, selectedDeviceId)"
+                    @click="(e) => handleOpenPath(e, getDevicePath(unit, selectedDeviceId), unit)"
+                  >
+                    {{ $t('save_location_drawer.open') }}
+                  </el-button>
+                </el-tooltip>
                 <el-button type="primary" size="small" plain @click="setUnitEnabled(unit, true)">
                   {{ $t('save_location_drawer.restore') }}
                 </el-button>

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -452,7 +452,8 @@
     "no_active_paths": "No active save locations yet. Add a folder, file, or registry key to start backing up this game.",
     "type_folder": "Folder",
     "type_file": "File",
-    "type_registry": "Registry"
+    "type_registry": "Registry",
+    "open_ctrl_hint": "Hold Ctrl and click to open the containing folder"
   },
   "sync_settings": {
     "title": "Sync settings",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -452,7 +452,8 @@
     "no_active_paths": "还没有启用中的存档路径。新增文件夹、文件或注册表项后即可开始备份。",
     "type_folder": "文件夹",
     "type_file": "文件",
-    "type_registry": "注册表"
+    "type_registry": "注册表",
+    "open_ctrl_hint": "按住 Ctrl 并点击打开父文件夹"
   },
   "sync_settings": {
     "title": "同步设置",


### PR DESCRIPTION
在SaveLocationDrawer.vue中增加了一个新的异步函数handleOpenPath，用于处理文件路径的点击事件，并根据是否按住Ctrl键来决定是打开文件本身还是打开其包含的文件夹。同时，对模板中的两个按钮添加了el-tooltip，用于显示提示信息。

在locales/en_US.json和locales/zh_SIMPLIFIED.json中添加了新的翻译项"open_ctrl_hint"，分别对应英文和简体中文的提示信息，用于告知用户如何通过按住Ctrl键来打开父文件夹。