### PR TITLE
Fix deleted game quick-action references

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
@@ -1,9 +1,11 @@
 //! Hook pipeline composition and built-in side-effect registration.
 //!
 //! Core hooks (pipeline, checksum, cloud_sync, pre_restore) live in rgsm_core.
-//! GUI-specific hooks (notification, scheduler_sync) live here.
+//! GUI-specific hooks (notification, quick_action_sync, scheduler_sync) live here.
 
 pub mod notification_hook;
+mod quick_action_sync_hook;
+mod runtime_config_sync;
 mod scheduler_sync_hook;
 
 // Re-export everything from core hooks so the rest of the GUI can `use crate::hooks::*`
@@ -59,10 +61,16 @@ pub fn build_builtin_pipeline(
     if config.settings.verify_archive_before_apply {
         hooks.push(Box::new(rgsm_core::hooks::checksum_hook::ArchiveVerifyHook));
     }
-    let scheduler_sync: Arc<dyn SchedulerSync> =
+    let scheduler_sync: Arc<dyn runtime_config_sync::ConfigRuntimeSync> =
         Arc::new(scheduler_sync_hook::TauriSchedulerSync::new(app.clone()));
     hooks.push(Box::new(scheduler_sync_hook::SchedulerSyncHook::new(
         scheduler_sync,
+    )));
+    let quick_action_sync: Arc<dyn runtime_config_sync::ConfigRuntimeSync> = Arc::new(
+        quick_action_sync_hook::TauriQuickActionRuntimeSync::new(app.clone()),
+    );
+    hooks.push(Box::new(quick_action_sync_hook::QuickActionSyncHook::new(
+        quick_action_sync,
     )));
     if !matches!(config.settings.cloud_settings.backend, Backend::Disabled) {
         let sync_queue: Arc<dyn SyncJobQueue> = task_manager;

--- a/apps/rgsm-gui/src-tauri/src/hooks/quick_action_sync_hook.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/quick_action_sync_hook.rs
@@ -1,0 +1,105 @@
+//! Built-in hook that keeps quick action runtime state aligned with config.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+use tauri::{AppHandle, Manager};
+
+use super::runtime_config_sync::ConfigRuntimeSync;
+use crate::quick_actions::QuickActionManager;
+use rgsm_core::hooks::{ConfigSavedCtx, GameDeletedCtx, GameUpdatedCtx, LifecycleHook};
+
+pub struct TauriQuickActionRuntimeSync {
+    app: AppHandle,
+}
+
+impl TauriQuickActionRuntimeSync {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+#[async_trait]
+impl ConfigRuntimeSync for TauriQuickActionRuntimeSync {
+    async fn sync_from_config(&self) -> Result<()> {
+        if let Some(manager) = self.app.try_state::<Arc<QuickActionManager>>() {
+            manager.reload_current_game_from_config().await?;
+        }
+        Ok(())
+    }
+}
+
+/// Refreshes the live quick action manager after persisted config changes.
+pub struct QuickActionSyncHook {
+    runtime: Arc<dyn ConfigRuntimeSync>,
+}
+
+impl QuickActionSyncHook {
+    pub fn new(runtime: Arc<dyn ConfigRuntimeSync>) -> Self {
+        Self { runtime }
+    }
+
+    async fn sync_from_config(&self) -> Result<()> {
+        self.runtime.sync_from_config().await
+    }
+}
+
+#[async_trait]
+impl LifecycleHook for QuickActionSyncHook {
+    fn name(&self) -> &str {
+        "QuickActionSyncHook"
+    }
+
+    fn priority(&self) -> u32 {
+        45
+    }
+
+    async fn on_game_updated(&self, _ctx: &GameUpdatedCtx) -> Result<()> {
+        self.sync_from_config().await
+    }
+
+    async fn on_game_deleted(&self, _ctx: &GameDeletedCtx) -> Result<()> {
+        self.sync_from_config().await
+    }
+
+    async fn on_config_saved(&self, _ctx: &ConfigSavedCtx) -> Result<()> {
+        self.sync_from_config().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rgsm_core::config::Config;
+    use rgsm_core::hooks::{ConfigSavedCtx, HookSource};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct CountingRuntimeSync {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ConfigRuntimeSync for CountingRuntimeSync {
+        async fn sync_from_config(&self) -> Result<()> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn config_saved_refreshes_quick_action_runtime() {
+        let sync = Arc::new(CountingRuntimeSync {
+            calls: AtomicUsize::new(0),
+        });
+        let hook = QuickActionSyncHook::new(sync.clone());
+
+        hook.on_config_saved(&ConfigSavedCtx {
+            config: Config::default(),
+            source: HookSource::UserManual,
+        })
+        .await
+        .expect("quick action sync should succeed");
+
+        assert_eq!(sync.calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/apps/rgsm-gui/src-tauri/src/hooks/runtime_config_sync.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/runtime_config_sync.rs
@@ -1,0 +1,7 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait ConfigRuntimeSync: Send + Sync {
+    async fn sync_from_config(&self) -> Result<()>;
+}

--- a/apps/rgsm-gui/src-tauri/src/hooks/scheduler_sync_hook.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/scheduler_sync_hook.rs
@@ -1,16 +1,12 @@
-//! Built-in hook that keeps the live scheduler aligned with persisted config.
-//!
-//! It listens to existing game/config lifecycle events instead of inventing a
-//! new hook event taxonomy just for scheduler maintenance.
-
 use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 
+use super::runtime_config_sync::ConfigRuntimeSync;
 use crate::quick_actions::AutoBackupScheduler;
 use rgsm_core::hooks::{
-    ConfigSavedCtx, GameAddedCtx, GameDeletedCtx, GameUpdatedCtx, LifecycleHook, SchedulerSync,
+    ConfigSavedCtx, GameAddedCtx, GameDeletedCtx, GameUpdatedCtx, LifecycleHook,
 };
 
 pub struct TauriSchedulerSync {
@@ -23,22 +19,28 @@ impl TauriSchedulerSync {
     }
 }
 
-impl SchedulerSync for TauriSchedulerSync {
-    fn sync_from_config(&self) {
+#[async_trait]
+impl ConfigRuntimeSync for TauriSchedulerSync {
+    async fn sync_from_config(&self) -> Result<()> {
         if let Some(scheduler) = self.app.try_state::<AutoBackupScheduler>() {
             scheduler.sync_from_config();
         }
+        Ok(())
     }
 }
 
 /// Keeps the live auto-backup scheduler synchronized with persisted config changes.
 pub struct SchedulerSyncHook {
-    scheduler: Arc<dyn SchedulerSync>,
+    scheduler: Arc<dyn ConfigRuntimeSync>,
 }
 
 impl SchedulerSyncHook {
-    pub fn new(scheduler: Arc<dyn SchedulerSync>) -> Self {
+    pub fn new(scheduler: Arc<dyn ConfigRuntimeSync>) -> Self {
         Self { scheduler }
+    }
+
+    async fn sync_from_config(&self) -> Result<()> {
+        self.scheduler.sync_from_config().await
     }
 }
 
@@ -53,22 +55,18 @@ impl LifecycleHook for SchedulerSyncHook {
     }
 
     async fn on_game_added(&self, _ctx: &GameAddedCtx) -> Result<()> {
-        self.scheduler.sync_from_config();
-        Ok(())
+        self.sync_from_config().await
     }
 
     async fn on_game_updated(&self, _ctx: &GameUpdatedCtx) -> Result<()> {
-        self.scheduler.sync_from_config();
-        Ok(())
+        self.sync_from_config().await
     }
 
     async fn on_game_deleted(&self, _ctx: &GameDeletedCtx) -> Result<()> {
-        self.scheduler.sync_from_config();
-        Ok(())
+        self.sync_from_config().await
     }
 
     async fn on_config_saved(&self, _ctx: &ConfigSavedCtx) -> Result<()> {
-        self.scheduler.sync_from_config();
-        Ok(())
+        self.sync_from_config().await
     }
 }

--- a/apps/rgsm-gui/src-tauri/src/quick_actions/manager.rs
+++ b/apps/rgsm-gui/src-tauri/src/quick_actions/manager.rs
@@ -25,6 +25,9 @@ pub enum QuickActionCommand {
         game: Box<Game>,
         respond_to: oneshot::Sender<anyhow::Result<()>>,
     },
+    ReloadCurrentGame {
+        respond_to: oneshot::Sender<anyhow::Result<()>>,
+    },
     TriggerBackup(QuickActionType),
     TriggerApply(QuickActionType),
 }
@@ -81,6 +84,16 @@ impl QuickActionManager {
             .context("failed to send SetCurrentGame command")?;
         rx.await
             .context("manager dropped SetCurrentGame response")??;
+        Ok(())
+    }
+
+    pub async fn reload_current_game_from_config(&self) -> anyhow::Result<()> {
+        let (tx, rx) = oneshot::channel();
+        self.command_tx
+            .send(QuickActionCommand::ReloadCurrentGame { respond_to: tx })
+            .context("failed to send ReloadCurrentGame command")?;
+        rx.await
+            .context("manager dropped ReloadCurrentGame response")??;
         Ok(())
     }
 
@@ -176,6 +189,10 @@ impl QuickActionWorker {
                 let result = self.handle_set_current_game(*game).await;
                 let _ = respond_to.send(result);
             }
+            QuickActionCommand::ReloadCurrentGame { respond_to } => {
+                let result = self.handle_reload_current_game().await;
+                let _ = respond_to.send(result);
+            }
             QuickActionCommand::TriggerBackup(trigger) => {
                 let app = self.manager.app_handle();
                 quick_backup(&app, trigger).await;
@@ -206,24 +223,47 @@ impl QuickActionWorker {
             state.current_game = Some(game.clone());
         }
 
+        self.set_tray_title(&current_game_label(Some(&game)))?;
+
+        self.refresh_tray_game_label();
+        Ok(())
+    }
+
+    async fn handle_reload_current_game(&mut self) -> anyhow::Result<()> {
+        let current_game = get_config()
+            .context("failed to load config")?
+            .quick_action
+            .quick_action_game;
+        let label = current_game_label(current_game.as_ref());
+
+        {
+            let mut state = self.manager.lock_state();
+            state.current_game = current_game;
+        }
+
+        if let Err(err) = self.set_tray_title(&label) {
+            warn!(
+                target: "rgsm::quick_action::manager",
+                "Failed to refresh quick action tray title: {err:?}"
+            );
+        }
+        self.refresh_tray_game_label();
+        Ok(())
+    }
+
+    fn set_tray_title(&self, label: &str) -> anyhow::Result<()> {
         self.manager
             .app_handle()
             .tray_by_id("tray_icon")
             .ok_or_else(|| anyhow::anyhow!("Cannot get tray"))?
-            .set_title(Some(&game.name))?;
-
-        self.refresh_tray_game_label();
+            .set_title(Some(label))?;
         Ok(())
     }
 
     fn refresh_tray_game_label(&self) {
         let (label, item) = {
             let state = self.manager.lock_state();
-            let label = state
-                .current_game
-                .as_ref()
-                .map(|game| game.name.clone())
-                .unwrap_or_else(|| t!("backend.tray.no_game_selected").into());
+            let label = current_game_label(state.current_game.as_ref());
             let item = state.tray_game_item.clone();
             (label, item)
         };
@@ -236,5 +276,46 @@ impl QuickActionWorker {
                 );
             }
         }
+    }
+}
+
+fn current_game_label(current_game: Option<&Game>) -> String {
+    current_game
+        .map(|game| game.name.clone())
+        .unwrap_or_else(|| t!("backend.tray.no_game_selected").into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::current_game_label;
+    use rgsm_core::backup::Game;
+    use std::collections::HashMap;
+
+    fn game(name: &str) -> Game {
+        Game {
+            name: name.to_string(),
+            storage_key: "game-key".to_string(),
+            save_paths: Vec::new(),
+            game_paths: HashMap::new(),
+            next_save_unit_id: 0,
+            cloud_sync_enabled: true,
+            auto_backup: None,
+            ludusavi_meta: None,
+            store_user_ids: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn current_game_label_uses_selected_game_name() {
+        assert_eq!(
+            current_game_label(Some(&game("Selected Game"))),
+            "Selected Game"
+        );
+    }
+
+    #[test]
+    fn current_game_label_uses_no_game_selected_text_without_current_game() {
+        rust_i18n::set_locale("en_US");
+        assert_eq!(current_game_label(None), "No game selected");
     }
 }

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -764,6 +764,7 @@ async function del_cur() {
       const result = await commands.deleteGame(game.value);
       if (result.status === 'error') {
         notifyError($t('error.delete_game_failed'));
+        return;
       }
       await refreshConfig();
       router.back();

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -289,6 +289,19 @@ impl Game {
         }
     }
 
+    /// Return whether two persisted game references identify the same game.
+    ///
+    /// Current configs use `storage_key` as the stable identity. Legacy configs
+    /// can still hold empty keys in secondary references, so those fall back to
+    /// display-name matching.
+    pub fn references_same_game(&self, other: &Game) -> bool {
+        if !self.storage_key.is_empty() && !other.storage_key.is_empty() {
+            return self.storage_key == other.storage_key;
+        }
+
+        self.name == other.name
+    }
+
     /// Remote cloud path prefix for this game, e.g. `save_data/Game Name`.
     pub fn remote_path_prefix(&self) -> String {
         format!("save_data/{}", self.backup_dir_name())
@@ -738,6 +751,9 @@ impl Game {
         config
             .games
             .retain(|x| x.backup_dir_name() != self.backup_dir_name());
+        // TODO(config-hooks): move this cleanup into a gated config-change hook
+        // once config commits can mutate/abort the pending write transaction.
+        config.remove_deleted_game_references(self);
         set_config_local(&config)?;
 
         info!(target:"rgsm::backup::game",

--- a/crates/rgsm-core/src/backup/tests/game.rs
+++ b/crates/rgsm-core/src/backup/tests/game.rs
@@ -5,7 +5,7 @@ use crate::backup::{
     CreatedBy, Game, GameDraft, GameSnapshots, SaveUnit, SaveUnitDraft, SaveUnitType, Snapshot,
     TIMER_AUTO_BACKUP_DESCRIPTION, TimerSnapshotDecision,
 };
-use crate::config::Config;
+use crate::config::{Config, get_config};
 use crate::device::get_current_device_id;
 use filetime::{FileTime, set_file_mtime};
 use std::collections::HashMap;
@@ -419,6 +419,25 @@ fn make_test_game(game_name: &str, backup_root: &Path) -> Result<Game, Box<dyn s
     })
 }
 
+fn make_test_game_with_storage_key(
+    game_name: &str,
+    storage_key: &str,
+    backup_root: &Path,
+) -> Result<Game, Box<dyn std::error::Error>> {
+    init_backups_json(storage_key, backup_root)?;
+    Ok(Game {
+        name: game_name.to_string(),
+        storage_key: storage_key.to_string(),
+        save_paths: Vec::new(),
+        game_paths: HashMap::new(),
+        next_save_unit_id: 0,
+        cloud_sync_enabled: true,
+        auto_backup: None,
+        ludusavi_meta: None,
+        store_user_ids: std::collections::HashMap::new(),
+    })
+}
+
 #[test]
 fn batch_delete_removes_snapshots_and_returns_remote_paths() -> TestResult {
     let _config_lock = lock_config_file();
@@ -609,6 +628,67 @@ fn batch_delete_empty_dates_is_noop() -> TestResult {
         assert_eq!(result.snapshots.backups.len(), 1);
         assert!(result.deleted_remote_paths.is_empty());
 
+        Ok(())
+    })
+}
+
+#[test]
+fn delete_game_clears_quick_action_reference_by_storage_key() -> TestResult {
+    let _config_lock = lock_config_file();
+    run_async_test(async {
+        let temp_dir = temp_dir::TempDir::new()?;
+        let backup_root = temp_dir.path().join("backup");
+        fs::create_dir_all(&backup_root)?;
+
+        let deleted_game =
+            make_test_game_with_storage_key("Deleted Game", "deleted-game-key", &backup_root)?;
+        let remaining_game =
+            make_test_game_with_storage_key("Remaining Game", "remaining-game-key", &backup_root)?;
+        let mut quick_action_reference = deleted_game.clone();
+        quick_action_reference.name = "Renamed Deleted Game".to_string();
+
+        let mut config = Config {
+            backup_path: backup_root.to_string_lossy().to_string(),
+            games: vec![deleted_game.clone(), remaining_game.clone()],
+            ..Config::default()
+        };
+        config.quick_action.quick_action_game = Some(quick_action_reference);
+        let _config_guard = restore_config_guard(&config)?;
+
+        deleted_game.delete_game().await?;
+
+        let persisted = get_config()?;
+        assert_eq!(persisted.games.len(), 1);
+        assert_eq!(persisted.games[0].storage_key, remaining_game.storage_key);
+        assert!(persisted.quick_action.quick_action_game.is_none());
+        Ok(())
+    })
+}
+
+#[test]
+fn delete_game_clears_legacy_quick_action_reference_by_name() -> TestResult {
+    let _config_lock = lock_config_file();
+    run_async_test(async {
+        let temp_dir = temp_dir::TempDir::new()?;
+        let backup_root = temp_dir.path().join("backup");
+        fs::create_dir_all(&backup_root)?;
+
+        let deleted_game = make_test_game("Legacy Deleted Game", &backup_root)?;
+        let remaining_game = make_test_game("Legacy Remaining Game", &backup_root)?;
+        let mut config = Config {
+            backup_path: backup_root.to_string_lossy().to_string(),
+            games: vec![deleted_game.clone(), remaining_game.clone()],
+            ..Config::default()
+        };
+        config.quick_action.quick_action_game = Some(deleted_game.clone());
+        let _config_guard = restore_config_guard(&config)?;
+
+        deleted_game.delete_game().await?;
+
+        let persisted = get_config()?;
+        assert_eq!(persisted.games.len(), 1);
+        assert_eq!(persisted.games[0].name, remaining_game.name);
+        assert!(persisted.quick_action.quick_action_game.is_none());
         Ok(())
     })
 }

--- a/crates/rgsm-core/src/config/app_config.rs
+++ b/crates/rgsm-core/src/config/app_config.rs
@@ -73,10 +73,118 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    pub fn remove_deleted_game_references(&mut self, deleted_game: &Game) -> bool {
+        let quick_action_changed = self
+            .quick_action
+            .remove_deleted_game_reference(deleted_game);
+        let favorites_changed =
+            FavoriteTreeNode::remove_deleted_game_leaves(&mut self.favorites, deleted_game);
+
+        quick_action_changed || favorites_changed
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct FavoriteTreeNode {
     node_id: String,
     label: String,
     is_leaf: bool,
     children: Option<Vec<Self>>,
+}
+
+impl FavoriteTreeNode {
+    fn remove_deleted_game_leaves(nodes: &mut Vec<Self>, deleted_game: &Game) -> bool {
+        let mut changed = false;
+
+        nodes.retain_mut(|node| {
+            if node.is_leaf && node.label == deleted_game.name {
+                changed = true;
+                return false;
+            }
+
+            if let Some(children) = &mut node.children
+                && Self::remove_deleted_game_leaves(children, deleted_game)
+            {
+                changed = true;
+            }
+
+            true
+        });
+
+        changed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_game(name: &str, storage_key: &str) -> Game {
+        Game {
+            name: name.to_string(),
+            storage_key: storage_key.to_string(),
+            save_paths: Vec::new(),
+            game_paths: HashMap::new(),
+            next_save_unit_id: 0,
+            cloud_sync_enabled: true,
+            auto_backup: None,
+            ludusavi_meta: None,
+            store_user_ids: HashMap::new(),
+        }
+    }
+
+    fn favorite_leaf(label: &str) -> FavoriteTreeNode {
+        FavoriteTreeNode {
+            node_id: format!("leaf-{label}"),
+            label: label.to_string(),
+            is_leaf: true,
+            children: None,
+        }
+    }
+
+    fn favorite_folder(label: &str, children: Vec<FavoriteTreeNode>) -> FavoriteTreeNode {
+        FavoriteTreeNode {
+            node_id: format!("folder-{label}"),
+            label: label.to_string(),
+            is_leaf: false,
+            children: Some(children),
+        }
+    }
+
+    #[test]
+    fn cleanup_deleted_game_references_removes_matching_favorite_leaves() {
+        let deleted_game = test_game("Deleted Game", "deleted-game-key");
+        let mut config = Config {
+            favorites: vec![
+                favorite_leaf("Deleted Game"),
+                favorite_folder(
+                    "Folder",
+                    vec![
+                        favorite_leaf("Deleted Game"),
+                        favorite_leaf("Remaining Game"),
+                    ],
+                ),
+                favorite_folder("Deleted Game", vec![]),
+            ],
+            ..Config::default()
+        };
+
+        assert!(config.remove_deleted_game_references(&deleted_game));
+
+        assert_eq!(config.favorites.len(), 2);
+        assert_eq!(config.favorites[0].label, "Folder");
+        assert_eq!(
+            config.favorites[0]
+                .children
+                .as_ref()
+                .expect("folder children should remain")
+                .iter()
+                .map(|node| node.label.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Remaining Game"]
+        );
+        assert_eq!(config.favorites[1].label, "Deleted Game");
+        assert!(!config.favorites[1].is_leaf);
+    }
 }

--- a/crates/rgsm-core/src/config/quick_actions_settings.rs
+++ b/crates/rgsm-core/src/config/quick_actions_settings.rs
@@ -79,6 +79,21 @@ impl Default for QuickActionsSettings {
     }
 }
 
+impl QuickActionsSettings {
+    pub fn remove_deleted_game_reference(&mut self, deleted_game: &Game) -> bool {
+        let should_clear = self
+            .quick_action_game
+            .as_ref()
+            .is_some_and(|game| game.references_same_game(deleted_game));
+
+        if should_clear {
+            self.quick_action_game = None;
+        }
+
+        should_clear
+    }
+}
+
 impl From<&QuickActionsSettings> for QuickActionSoundPreferences {
     fn from(value: &QuickActionsSettings) -> Self {
         Self {

--- a/crates/rgsm-core/src/hooks/mod.rs
+++ b/crates/rgsm-core/src/hooks/mod.rs
@@ -20,4 +20,4 @@ pub use cloud_sync_hook::CloudSyncEnqueueHook;
 pub use contexts::*;
 pub use pipeline::*;
 pub use pre_restore_backup_hook::PreRestoreBackupHook;
-pub use traits::{HookResult, LifecycleHook, SchedulerSync, SnapshotHook, SyncJobQueue};
+pub use traits::{HookResult, LifecycleHook, SnapshotHook, SyncJobQueue};

--- a/crates/rgsm-core/src/hooks/traits.rs
+++ b/crates/rgsm-core/src/hooks/traits.rs
@@ -59,7 +59,3 @@ pub use LifecycleHook as SnapshotHook;
 pub trait SyncJobQueue: Send + Sync {
     async fn enqueue(&self, job: CloudSyncJob);
 }
-
-pub trait SchedulerSync: Send + Sync {
-    fn sync_from_config(&self);
-}


### PR DESCRIPTION
## Summary

- Clear persisted quick-action game references when the selected game is deleted, matching by `storage_key` first and legacy name fallback second.
- Remove deleted game favorite leaves from config-owned favorites during the delete transaction.
- Refresh quick-action runtime state through a GUI hook instead of directly from the IPC delete command.
- Share a GUI-side `ConfigRuntimeSync` trait between scheduler and quick-action runtime refresh hooks.

## Root Cause

Deleting a game removed it from `config.games` and deleted its backup directory, but config-owned references such as `quick_action.quick_action_game` could still point at the deleted game. The running quick-action manager also kept its in-memory current game until restart or manual refresh.

## Validation

- `cargo fmt --check`
- `cargo test -p rgsm-core --lib` (186 passed)
- `cargo test -p rgsm --lib quick_action` (5 passed)
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `pnpm web:typecheck`
- `pnpm web:lint`
- `pnpm web:format`
- `git diff --check`

Fixes #350