### PR TITLE
Fix release asset clobbering

### DIFF
--- a/.github/workflows/build-gui.yml
+++ b/.github/workflows/build-gui.yml
@@ -170,6 +170,13 @@ jobs:
           while IFS=$'\t' read -r ASSET_ID OLD_NAME; do
             if [[ "$OLD_NAME" != *"${VERSION}"* ]]; then
               NEW_NAME="${OLD_NAME/RGSM_/RGSM_${VERSION}_}"
+              EXISTING_ID="$(gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}/assets" \
+                --jq ".[] | select(.name == \"${NEW_NAME}\" and .id != ${ASSET_ID}) | .id" |
+                head -n 1)"
+              if [[ -n "$EXISTING_ID" ]]; then
+                gh api -X DELETE "repos/${{ github.repository }}/releases/assets/${EXISTING_ID}" >/dev/null
+                echo "Deleted existing target asset: ${NEW_NAME}"
+              fi
               gh api -X PATCH "repos/${{ github.repository }}/releases/assets/${ASSET_ID}" \
                 -f name="${NEW_NAME}"
               echo "Renamed: ${OLD_NAME} -> ${NEW_NAME}"

--- a/scripts/portable.mjs
+++ b/scripts/portable.mjs
@@ -89,6 +89,88 @@ export function getReleaseUploadConfig(env = process.env) {
   return { releaseId, githubToken };
 }
 
+export function isReleaseAssetNameConflict(error) {
+  if (error?.status !== 422) {
+    return false;
+  }
+
+  const errors = error.response?.data?.errors;
+  if (!Array.isArray(errors)) {
+    return false;
+  }
+
+  return errors.some(
+    (entry) =>
+      entry?.resource === "ReleaseAsset" &&
+      entry?.code === "already_exists" &&
+      entry?.field === "name",
+  );
+}
+
+export async function deleteReleaseAssetByName(
+  github,
+  options,
+  releaseId,
+  name,
+) {
+  const assets = await github.rest.repos.listReleaseAssets({
+    ...options,
+    release_id: releaseId,
+    per_page: 100,
+  });
+
+  const existingAsset = assets.data.find((asset) => asset.name === name);
+  if (!existingAsset) {
+    return false;
+  }
+
+  await github.rest.repos.deleteReleaseAsset({
+    ...options,
+    asset_id: existingAsset.id,
+  });
+
+  return true;
+}
+
+export async function uploadReleaseAssetWithClobber({
+  github,
+  options,
+  releaseId,
+  name,
+  data,
+  log = console.log,
+}) {
+  const upload = () =>
+    github.rest.repos.uploadReleaseAsset({
+      ...options,
+      release_id: releaseId,
+      name,
+      data,
+    });
+
+  try {
+    return await upload();
+  } catch (error) {
+    if (!isReleaseAssetNameConflict(error)) {
+      throw error;
+    }
+
+    const deleted = await deleteReleaseAssetByName(
+      github,
+      options,
+      releaseId,
+      name,
+    );
+    if (deleted) {
+      log(`[INFO]: deleted existing release asset ${name}`);
+    } else {
+      log(`[INFO]: release asset ${name} was already removed, retry upload`);
+    }
+
+    return await upload();
+  }
+}
+
 async function pathExists(targetPath) {
   try {
     await access(targetPath);
@@ -146,9 +228,10 @@ export async function resolvePortable() {
   console.log("[INFO]: upload to ", releaseUploadConfig.releaseId);
 
   // https://octokit.github.io/rest.js
-  await github.rest.repos.uploadReleaseAsset({
-    ...options,
-    release_id: releaseUploadConfig.releaseId,
+  await uploadReleaseAssetWithClobber({
+    github,
+    options,
+    releaseId: releaseUploadConfig.releaseId,
     name: path.basename(zipFile),
     data: zip.toBuffer(),
   });

--- a/scripts/portable.test.mjs
+++ b/scripts/portable.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  isReleaseAssetNameConflict,
+  uploadReleaseAssetWithClobber,
+} from "./portable.mjs";
+
+function releaseAssetConflictError() {
+  return {
+    status: 422,
+    response: {
+      data: {
+        errors: [
+          {
+            resource: "ReleaseAsset",
+            code: "already_exists",
+            field: "name",
+          },
+        ],
+      },
+    },
+  };
+}
+
+test("detects GitHub release asset name conflicts", () => {
+  assert.equal(isReleaseAssetNameConflict(releaseAssetConflictError()), true);
+  assert.equal(
+    isReleaseAssetNameConflict({
+      status: 422,
+      response: {
+        data: {
+          errors: [{ resource: "ReleaseAsset", code: "missing_field" }],
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(isReleaseAssetNameConflict(new Error("network failed")), false);
+});
+
+test("uploads a release asset once when there is no conflict", async () => {
+  const calls = [];
+  const github = {
+    rest: {
+      repos: {
+        uploadReleaseAsset: async (payload) => {
+          calls.push(["upload", payload.name]);
+          return { ok: true };
+        },
+        listReleaseAssets: async () => {
+          throw new Error("should not list release assets");
+        },
+        deleteReleaseAsset: async () => {
+          throw new Error("should not delete release assets");
+        },
+      },
+    },
+  };
+
+  const result = await uploadReleaseAssetWithClobber({
+    github,
+    options: { owner: "mcthesw", repo: "game-save-manager" },
+    releaseId: "123",
+    name: "RGSM_1.9.0_x64-portable-slim.zip",
+    data: Buffer.from("zip"),
+    log: () => {},
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(calls, [["upload", "RGSM_1.9.0_x64-portable-slim.zip"]]);
+});
+
+test("deletes the existing release asset and retries after a name conflict", async () => {
+  const calls = [];
+  let uploadCount = 0;
+  const github = {
+    rest: {
+      repos: {
+        uploadReleaseAsset: async (payload) => {
+          uploadCount += 1;
+          calls.push(["upload", payload.name]);
+          if (uploadCount === 1) {
+            throw releaseAssetConflictError();
+          }
+          return { ok: true };
+        },
+        listReleaseAssets: async (payload) => {
+          calls.push(["list", payload.release_id]);
+          return {
+            data: [
+              { id: 7, name: "LICENSE" },
+              { id: 42, name: "RGSM_1.9.0_x64-portable-slim.zip" },
+            ],
+          };
+        },
+        deleteReleaseAsset: async (payload) => {
+          calls.push(["delete", payload.asset_id]);
+        },
+      },
+    },
+  };
+
+  const result = await uploadReleaseAssetWithClobber({
+    github,
+    options: { owner: "mcthesw", repo: "game-save-manager" },
+    releaseId: "123",
+    name: "RGSM_1.9.0_x64-portable-slim.zip",
+    data: Buffer.from("zip"),
+    log: () => {},
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(calls, [
+    ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
+    ["list", "123"],
+    ["delete", 42],
+    ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
+  ]);
+});


### PR DESCRIPTION
## Summary

- make Windows portable release uploads idempotent by deleting an existing same-name asset and retrying the upload
- make the macOS updater artifact rename step delete an existing target asset before renaming
- add Node tests for release asset name-conflict detection and upload retry behavior

## Root Cause

The build-release workflow can reuse the same GitHub Release, especially for the `latest` nightly release or when failed jobs are rerun. GitHub rejects uploads or rename operations when the target release already contains an asset with the same name, which caused both the Windows portable upload and macOS `.app.tar.gz` rename steps to fail with `ReleaseAsset already_exists`.

## Testing

- `node --test scripts\portable.test.mjs`
- `pnpm --dir apps\rgsm-gui exec prettier --check ..\..\.github\workflows\build-gui.yml ..\..\scripts\portable.mjs ..\..\scripts\portable.test.mjs`
- `git diff --check`
- `pnpm web:lint`
- `pnpm web:typecheck`
- `pnpm web:format`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check --workspace`
- `cargo test -p rgsm-core --lib`