### PR TITLE
fix(ci): allow pnpm dependency build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,8 @@
 packages:
   - 'apps/rgsm-gui'
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  unrs-resolver: true
+  vue-demi: true


### PR DESCRIPTION
## Summary
- Allow pnpm v11 to run required dependency build scripts during CI installs.

## Testing
- `CI=true pnpm install --frozen-lockfile`
- `git diff --check`