### PR TITLE
fix(ci): harden nightly publish baseline

### DIFF
--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.x"
 
       - id: changes
-        name: Check changes since latest nightly
+        name: Check changes since latest successful nightly
         run: python scripts/should_publish_nightly.py --event-name "${{ github.event_name }}"
 
   create-release:
@@ -99,7 +99,7 @@ jobs:
           fi
 
           echo "Generating changelog since stable release: $LAST_STABLE"
-          git fetch --tags --quiet
+          git fetch --tags --force --quiet
 
           CHANGELOG="$(git log "${LAST_STABLE}..HEAD" \
             --pretty=format:"- %s (%h)" \
@@ -138,3 +138,28 @@ jobs:
       release_id: ${{ needs.create-release.outputs.release_id }}
       release_tag: ${{ needs.create-release.outputs.release_tag }}
     secrets: inherit
+
+  mark-nightly-success:
+    name: Mark successful nightly
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Update successful nightly baseline tag
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          BASELINE_TAG="latest-built"
+
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${BASELINE_TAG}" >/dev/null 2>&1; then
+            gh api "repos/${{ github.repository }}/git/refs/tags/${BASELINE_TAG}" \
+              --method PATCH \
+              -f sha="${GITHUB_SHA}" \
+              -F force=true >/dev/null
+          else
+            gh api "repos/${{ github.repository }}/git/refs" \
+              --method POST \
+              -f ref="refs/tags/${BASELINE_TAG}" \
+              -f sha="${GITHUB_SHA}" >/dev/null
+          fi

--- a/scripts/should_publish_nightly.py
+++ b/scripts/should_publish_nightly.py
@@ -72,7 +72,7 @@ def skip(reason: str) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--event-name", default=os.environ.get("GITHUB_EVENT_NAME", ""))
-    parser.add_argument("--release-tag", default="latest")
+    parser.add_argument("--release-tag", default="latest-built")
     args = parser.parse_args()
 
     if args.event_name == "workflow_dispatch":
@@ -90,8 +90,8 @@ def main() -> int:
         check=False,
     )
     if not base_sha:
-        print(f"No {args.release_tag} tag found; publishing nightly.")
-        publish(f"no {args.release_tag} tag")
+        print(f"No {args.release_tag} baseline tag found; publishing nightly.")
+        publish(f"no {args.release_tag} baseline tag")
         return 0
 
     head_sha = os.environ.get("GITHUB_SHA") or git("rev-parse", "HEAD")
@@ -106,14 +106,14 @@ def main() -> int:
     summary = [
         "### Nightly change detection",
         "",
-        f"Base `{args.release_tag}` tag: `{base_sha}`",
+        f"Base `{args.release_tag}` successful nightly tag: `{base_sha}`",
         f"Head: `{head_sha}`",
         "",
     ]
 
     if not changed_files:
-        print("No release-relevant changes since latest nightly; skipping publish.")
-        summary.append("No release-relevant changes since latest nightly.")
+        print("No release-relevant changes since latest successful nightly; skipping publish.")
+        summary.append("No release-relevant changes since latest successful nightly.")
         append_step_summary("\n".join(summary))
         skip("no release-relevant changes")
         return 0


### PR DESCRIPTION
## Summary

- Force tag refresh while updating nightly release notes, fixing failures after moving the mutable `latest` tag.
- Use a separate `latest-built` baseline tag for change detection so failed nightly publishes do not make future scheduled runs skip.
- Update the `latest-built` tag only after the full build workflow succeeds.

## Testing

- `python -m py_compile scripts/should_publish_nightly.py`
- `python scripts/should_publish_nightly.py --event-name workflow_dispatch`
- `python scripts/should_publish_nightly.py --event-name schedule`
- `git diff --check`
