### PR TITLE
fix(ci): avoid stale commits in nightly changelog

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -20,6 +20,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Run script tests
+        run: python scripts/nightly_changelog_test.py
+
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -85,6 +85,10 @@ jobs:
           fi
 
           gh release upload "${RELEASE_TAG}" LICENSE --clobber --repo "${{ github.repository }}"
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
       - name: Update release notes with changes since last stable release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -100,17 +104,9 @@ jobs:
 
           echo "Generating changelog since stable release: $LAST_STABLE"
           git fetch --tags --force --quiet
-
-          CHANGELOG="$(git log "${LAST_STABLE}..HEAD" \
-            --pretty=format:"- %s (%h)" \
-            --no-merges)"
-
-          if [ -z "$CHANGELOG" ]; then
-            CHANGELOG="No changes since last stable release."
-          fi
-
-          printf "## Changes since last stable release (%s)\n\n%s\n" \
-            "$LAST_STABLE" "$CHANGELOG" > /tmp/release-notes.md
+          python scripts/nightly_changelog.py \
+            --stable-tag "$LAST_STABLE" \
+            --output /tmp/release-notes.md
 
           gh release edit "latest" \
             --notes-file /tmp/release-notes.md \

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ target/
 
 # Misc
 .DS_Store
+__pycache__/
+*.pyc
 .fleet
 .idea
 GameSaveManager.config.json.backup.*

--- a/scripts/nightly_changelog.py
+++ b/scripts/nightly_changelog.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Generate nightly release notes relative to the latest stable release."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def git(*args: str, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=False,
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed with exit code {result.returncode}:\n"
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def resolve_commit(ref: str, cwd: Path | None = None) -> str:
+    return git("rev-parse", "--verify", f"refs/tags/{ref}^{{commit}}", cwd=cwd)
+
+
+def changelog_since_stable(stable_ref: str, cwd: Path | None = None) -> str:
+    stable_commit = resolve_commit(stable_ref, cwd=cwd)
+
+    # Use a symmetric-difference range with patch-equivalence filtering. This
+    # keeps nightly notes correct even when the default branch was rebased or
+    # rebuilt and the stable tag is no longer an ancestor of HEAD.
+    return git(
+        "log",
+        "--cherry-pick",
+        "--right-only",
+        f"{stable_commit}...HEAD",
+        "--pretty=format:- %s (%h)",
+        "--no-merges",
+        cwd=cwd,
+    )
+
+
+def release_notes(stable_ref: str, cwd: Path | None = None) -> str:
+    changelog = changelog_since_stable(stable_ref, cwd=cwd)
+    if not changelog:
+        changelog = "No changes since last stable release."
+
+    return f"## Changes since last stable release ({stable_ref})\n\n{changelog}\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stable-tag", required=True)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    notes = release_notes(args.stable_tag)
+    if args.output:
+        args.output.write_text(notes, encoding="utf-8")
+    else:
+        print(notes, end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/nightly_changelog_test.py
+++ b/scripts/nightly_changelog_test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Regression tests for nightly changelog generation."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from nightly_changelog import changelog_since_stable, git
+
+
+def run_git(repo: Path, *args: str) -> str:
+    return git(*args, cwd=repo)
+
+
+def write_file(repo: Path, relative_path: str, content: str) -> None:
+    path = repo / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def commit_file(repo: Path, relative_path: str, content: str, message: str) -> None:
+    write_file(repo, relative_path, content)
+    run_git(repo, "add", relative_path)
+    run_git(repo, "commit", "-m", message)
+
+
+class NightlyChangelogTests(unittest.TestCase):
+    def test_excludes_stable_changes_after_history_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            run_git(repo, "init")
+            run_git(repo, "config", "user.email", "ci@example.com")
+            run_git(repo, "config", "user.name", "CI")
+
+            commit_file(repo, "README.md", "root\n", "chore: initial")
+            root = run_git(repo, "rev-parse", "HEAD")
+
+            run_git(repo, "switch", "-c", "stable")
+            commit_file(repo, "release.txt", "stable branch\n", "chore: release branch marker")
+            commit_file(repo, "app.txt", "stable feature\n", "feat: stable baseline")
+            run_git(repo, "tag", "v1.0.0")
+
+            run_git(repo, "switch", "-c", "dev", root)
+            commit_file(repo, "app.txt", "stable feature\n", "feat: stable baseline")
+            commit_file(repo, "nightly.txt", "fix\n", "fix: nightly change")
+
+            legacy_changelog = run_git(repo, "log", "v1.0.0..HEAD", "--pretty=format:%s")
+            self.assertIn("feat: stable baseline", legacy_changelog)
+
+            changelog = changelog_since_stable("v1.0.0", cwd=repo)
+            self.assertIn("fix: nightly change", changelog)
+            self.assertNotIn("feat: stable baseline", changelog)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Generate nightly changelogs with `git log --cherry-pick --right-only <stable>...HEAD` so rewritten/rebased histories do not pull stable-era commits back into the notes.
- Move release-note generation into a small Python helper and cover the divergent-history regression.
- Run the changelog regression test in CI and ignore Python bytecode caches.

## Testing

- `python scripts/nightly_changelog_test.py`
- `python -m py_compile scripts/should_publish_nightly.py scripts/nightly_changelog.py scripts/nightly_changelog_test.py`
- `python scripts/nightly_changelog.py --stable-tag v1.8.0 | grep -c '^- '` → `65` (legacy `git log v1.8.0..HEAD --no-merges` produced `445`)
- `git diff --check`
- pre-commit hook: `cargo check -p rgsm --all-targets --all-features`
- pre-push hook: `pnpm --filter rgsm-gui web:typecheck`
