### PR TITLE
fix(ci): retry transient release asset uploads

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -54,6 +54,9 @@ jobs:
           node-version: lts/*
           cache: "pnpm"
 
+      - name: Run portable script tests
+        run: node --test scripts/portable.test.mjs
+
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 

--- a/scripts/portable.mjs
+++ b/scripts/portable.mjs
@@ -122,6 +122,67 @@ export function isReleaseAssetNameConflict(error) {
   );
 }
 
+function hasCauseCode(error, codes) {
+  let current = error;
+  while (current && typeof current === "object") {
+    if (codes.has(current.code)) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}
+
+export function isRetriableReleaseAssetUploadError(error) {
+  const status = Number(error?.status ?? 0);
+  if (status === 408 || status === 429 || (status >= 500 && status < 600)) {
+    return true;
+  }
+
+  return hasCauseCode(
+    error,
+    new Set(["ECONNRESET", "ETIMEDOUT", "EAI_AGAIN", "UND_ERR_SOCKET"]),
+  );
+}
+
+function describeReleaseAssetUploadError(error) {
+  const status = error?.status ? `HTTP ${error.status}` : "network error";
+  const message = error?.message ? `: ${error.message}` : "";
+  return `${status}${message}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function uploadReleaseAssetWithRetry(
+  upload,
+  { log, retryDelaysMs = [2_000, 5_000, 10_000] },
+) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await upload();
+    } catch (error) {
+      const retryDelayMs = retryDelaysMs[attempt];
+      if (
+        retryDelayMs === undefined ||
+        !isRetriableReleaseAssetUploadError(error)
+      ) {
+        throw error;
+      }
+
+      log(
+        `[INFO]: release asset upload failed (${describeReleaseAssetUploadError(
+          error,
+        )}), retrying in ${retryDelayMs}ms`,
+      );
+      if (retryDelayMs > 0) {
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+}
+
 export async function deleteReleaseAssetByName(
   github,
   options,
@@ -154,6 +215,7 @@ export async function uploadReleaseAssetWithClobber({
   name,
   data,
   log = console.log,
+  retryDelaysMs,
 }) {
   const upload = () =>
     github.rest.repos.uploadReleaseAsset({
@@ -164,7 +226,7 @@ export async function uploadReleaseAssetWithClobber({
     });
 
   try {
-    return await upload();
+    return await uploadReleaseAssetWithRetry(upload, { log, retryDelaysMs });
   } catch (error) {
     if (!isReleaseAssetNameConflict(error)) {
       throw error;
@@ -182,7 +244,7 @@ export async function uploadReleaseAssetWithClobber({
       log(`[INFO]: release asset ${name} was already removed, retry upload`);
     }
 
-    return await upload();
+    return await uploadReleaseAssetWithRetry(upload, { log, retryDelaysMs });
   }
 }
 

--- a/scripts/portable.test.mjs
+++ b/scripts/portable.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   isReleaseAssetNameConflict,
+  isRetriableReleaseAssetUploadError,
   uploadReleaseAssetWithClobber,
 } from "./portable.mjs";
 
@@ -39,15 +40,23 @@ test("detects GitHub release asset name conflicts", () => {
   assert.equal(isReleaseAssetNameConflict(new Error("network failed")), false);
 });
 
-test("uploads a release asset once when there is no conflict", async () => {
-  const calls = [];
-  const github = {
+function transientUploadError() {
+  return {
+    status: 500,
+    message: "other side closed",
+    cause: { code: "UND_ERR_SOCKET" },
+  };
+}
+
+function validationError() {
+  return { status: 400, message: "bad request" };
+}
+
+function createGithubUploadStub({ upload }) {
+  return {
     rest: {
       repos: {
-        uploadReleaseAsset: async (payload) => {
-          calls.push(["upload", payload.name]);
-          return { ok: true };
-        },
+        uploadReleaseAsset: upload,
         listReleaseAssets: async () => {
           throw new Error("should not list release assets");
         },
@@ -57,14 +66,43 @@ test("uploads a release asset once when there is no conflict", async () => {
       },
     },
   };
+}
+
+const defaultUploadArgs = {
+  options: { owner: "mcthesw", repo: "game-save-manager" },
+  releaseId: "123",
+  name: "RGSM_1.9.0_x64-portable-slim.zip",
+  data: Buffer.from("zip"),
+  log: () => {},
+};
+
+test("detects retriable release asset upload errors", () => {
+  assert.equal(
+    isRetriableReleaseAssetUploadError(transientUploadError()),
+    true,
+  );
+  assert.equal(
+    isRetriableReleaseAssetUploadError({
+      message: "socket closed",
+      cause: { code: "UND_ERR_SOCKET" },
+    }),
+    true,
+  );
+  assert.equal(isRetriableReleaseAssetUploadError(validationError()), false);
+});
+
+test("uploads a release asset once when there is no conflict", async () => {
+  const calls = [];
+  const github = createGithubUploadStub({
+    upload: async (payload) => {
+      calls.push(["upload", payload.name]);
+      return { ok: true };
+    },
+  });
 
   const result = await uploadReleaseAssetWithClobber({
     github,
-    options: { owner: "mcthesw", repo: "game-save-manager" },
-    releaseId: "123",
-    name: "RGSM_1.9.0_x64-portable-slim.zip",
-    data: Buffer.from("zip"),
-    log: () => {},
+    ...defaultUploadArgs,
   });
 
   assert.deepEqual(result, { ok: true });
@@ -103,11 +141,7 @@ test("deletes the existing release asset and retries after a name conflict", asy
 
   const result = await uploadReleaseAssetWithClobber({
     github,
-    options: { owner: "mcthesw", repo: "game-save-manager" },
-    releaseId: "123",
-    name: "RGSM_1.9.0_x64-portable-slim.zip",
-    data: Buffer.from("zip"),
-    log: () => {},
+    ...defaultUploadArgs,
   });
 
   assert.deepEqual(result, { ok: true });
@@ -117,4 +151,56 @@ test("deletes the existing release asset and retries after a name conflict", asy
     ["delete", 42],
     ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
   ]);
+});
+
+test("retries transient upload failures after deleting an existing asset", async () => {
+  const calls = [];
+  const logs = [];
+  let uploadCount = 0;
+  const github = {
+    rest: {
+      repos: {
+        uploadReleaseAsset: async (payload) => {
+          uploadCount += 1;
+          calls.push(["upload", payload.name]);
+          if (uploadCount === 1) {
+            throw releaseAssetConflictError();
+          }
+          if (uploadCount === 2) {
+            throw transientUploadError();
+          }
+          return { ok: true };
+        },
+        listReleaseAssets: async (payload) => {
+          calls.push(["list", payload.release_id]);
+          return {
+            data: [
+              { id: 7, name: "LICENSE" },
+              { id: 42, name: "RGSM_1.9.0_x64-portable-slim.zip" },
+            ],
+          };
+        },
+        deleteReleaseAsset: async (payload) => {
+          calls.push(["delete", payload.asset_id]);
+        },
+      },
+    },
+  };
+
+  const result = await uploadReleaseAssetWithClobber({
+    github,
+    ...defaultUploadArgs,
+    log: (message) => logs.push(message),
+    retryDelaysMs: [0],
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.deepEqual(calls, [
+    ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
+    ["list", "123"],
+    ["delete", 42],
+    ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
+    ["upload", "RGSM_1.9.0_x64-portable-slim.zip"],
+  ]);
+  assert.match(logs.at(-1), /retrying in 0ms/);
 });


### PR DESCRIPTION
## Summary

- Retry transient GitHub release asset upload failures (HTTP 408/429/5xx and common socket/DNS timeout errors).
- Keep existing clobber behavior for duplicate asset names, then retry the post-delete upload as well.
- Add Node regression tests for conflict handling and transient upload retries, and run them in CI.

## Testing

- `node --test scripts/portable.test.mjs`
- `python scripts/nightly_changelog_test.py`
- `python -m py_compile scripts/should_publish_nightly.py scripts/nightly_changelog.py scripts/nightly_changelog_test.py`
- `pnpm --filter rgsm-gui exec prettier --check ../../scripts/portable.mjs ../../scripts/portable.test.mjs`
- `git diff --check`
- pre-commit hook: `cargo check -p rgsm --all-targets --all-features`
- pre-push hook: `pnpm --filter rgsm-gui web:typecheck`
