### PR TITLE
Harden cloud sync conflict recovery

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -2,7 +2,7 @@ use crate::{quick_actions, sound};
 use rgsm_core::backup::{CreatedBy, ExtraBackupItem, Game, GameDraft, GameSnapshots};
 use rgsm_core::cloud_sync::{
     self, BatchSyncItemStatus, BatchSyncReport, CancelCloudSyncResult, CloudSyncSessionConfig,
-    CloudSyncTaskManager, SyncGameOutcome,
+    CloudSyncTaskManager, ConflictResolution, ConflictResolutionOutcome, SyncGameOutcome,
 };
 use rgsm_core::config::{Config, QuickActionSoundPreferences, get_backup_path, get_config};
 use rgsm_core::device::{Device, get_current_device_id};
@@ -1087,6 +1087,32 @@ pub async fn sync_game(
     info!(target:"rgsm::ipc", "Syncing game: {}", game_name);
     svc(&app_handle)
         .sync_game(&game_name)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Resolve a user-visible cloud sync conflict for one game.
+#[tauri::command]
+#[specta::specta]
+pub async fn resolve_game_sync_conflict(
+    game_name: String,
+    resolution: ConflictResolution,
+    app_handle: AppHandle,
+) -> Result<ConflictResolutionOutcome, String> {
+    info!(target:"rgsm::ipc", "Resolving cloud sync conflict for game: {}", game_name);
+    svc(&app_handle)
+        .resolve_game_conflict(&game_name, resolution)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Retry syncing the shared configuration to the configured cloud backend.
+#[tauri::command]
+#[specta::specta]
+pub async fn sync_config(app_handle: AppHandle) -> Result<(), String> {
+    info!(target:"rgsm::ipc", "Syncing cloud config");
+    svc(&app_handle)
+        .sync_config()
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -145,6 +145,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::list_config_backups,
             ipc_handler::restore_config_backup,
             ipc_handler::sync_game,
+            ipc_handler::resolve_game_sync_conflict,
+            ipc_handler::sync_config,
         ])
         .events(tauri_specta::collect_events![
             ipc_handler::IpcNotification,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -483,6 +483,28 @@ async syncGame(gameName: string) : Promise<Result<SyncGameOutcome, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Resolve a user-visible cloud sync conflict for one game.
+ */
+async resolveGameSyncConflict(gameName: string, resolution: ConflictResolution) : Promise<Result<ConflictResolutionOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("resolve_game_sync_conflict", { gameName, resolution }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Retry syncing the shared configuration to the configured cloud backend.
+ */
+async syncConfig() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("sync_config") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -604,6 +626,11 @@ export type Config = { version: string; backup_path: string; games: Game[]; sett
  * 设备ID到设备名称的映射
  */
 devices?: Partial<{ [key in string]: Device }> }
+/**
+ * What the user chose to do when a conflict is detected.
+ */
+export type ConflictResolution = "keep_local" | "accept_remote" | "fork" | "cancelled"
+export type ConflictResolutionOutcome = "cancelled" | "kept_local" | "accepted_remote"
 /**
  * Tracks how a snapshot was created.
  * 

--- a/apps/rgsm-gui/src/components/SyncConflictDialog.vue
+++ b/apps/rgsm-gui/src/components/SyncConflictDialog.vue
@@ -1,0 +1,174 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { $t } from '../i18n';
+import type { ConflictResolution, GameSyncState } from '../bindings';
+
+const props = defineProps<{
+  modelValue: boolean;
+  gameName: string;
+  state?: GameSyncState | null;
+  currentDeviceId?: string;
+  resolving?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: boolean): void;
+  (event: 'resolve', resolution: ConflictResolution): void;
+}>();
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+});
+
+function snapshotLabel(value?: string | null): string {
+  return value || $t('sync_settings.conflict.no_snapshot');
+}
+
+function formatTime(value?: string | null): string {
+  if (!value) return $t('sync_settings.conflict.not_synced');
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function decideLater() {
+  visible.value = false;
+}
+</script>
+
+<template>
+  <ElDialog
+    v-model="visible"
+    :title="$t('sync_settings.conflict.title')"
+    width="520px"
+    destroy-on-close
+  >
+    <p class="conflict-summary">
+      {{ $t('sync_settings.conflict.summary', { game: gameName }) }}
+    </p>
+
+    <div class="progress-grid">
+      <section class="progress-panel">
+        <h4>{{ $t('sync_settings.conflict.local_title') }}</h4>
+        <dl>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.snapshot') }}</dt>
+            <dd>{{ snapshotLabel(state?.last_known_local_head) }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.device') }}</dt>
+            <dd>{{ currentDeviceId || $t('sync_settings.conflict.current_device') }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.last_checked') }}</dt>
+            <dd>{{ formatTime(state?.last_sync_at) }}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="progress-panel">
+        <h4>{{ $t('sync_settings.conflict.cloud_title') }}</h4>
+        <dl>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.snapshot') }}</dt>
+            <dd>{{ snapshotLabel(state?.last_known_remote_head) }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.device') }}</dt>
+            <dd>{{ $t('sync_settings.conflict.cloud_device') }}</dd>
+          </div>
+          <div>
+            <dt>{{ $t('sync_settings.conflict.last_checked') }}</dt>
+            <dd>{{ formatTime(state?.last_sync_at) }}</dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+
+    <template #footer>
+      <div class="dialog-actions">
+        <ElButton :disabled="resolving" @click="decideLater">
+          {{ $t('sync_settings.conflict.decide_later') }}
+        </ElButton>
+        <ElButton
+          type="primary"
+          plain
+          :loading="resolving"
+          @click="emit('resolve', 'accept_remote')"
+        >
+          {{ $t('sync_settings.conflict.accept_remote') }}
+        </ElButton>
+        <ElButton type="warning" :loading="resolving" @click="emit('resolve', 'keep_local')">
+          {{ $t('sync_settings.conflict.keep_local') }}
+        </ElButton>
+      </div>
+    </template>
+  </ElDialog>
+</template>
+
+<style scoped>
+.conflict-summary {
+  margin: 0 0 16px;
+  color: var(--el-text-color-regular);
+  line-height: 1.5;
+}
+
+.progress-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.progress-panel {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 8px;
+  padding: 12px;
+  background: var(--el-fill-color-lighter);
+}
+
+.progress-panel h4 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+  color: var(--el-text-color-primary);
+}
+
+.progress-panel dl {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.progress-panel div {
+  display: grid;
+  gap: 2px;
+}
+
+.progress-panel dt {
+  color: var(--el-text-color-secondary);
+  font-size: 0.78rem;
+}
+
+.progress-panel dd {
+  margin: 0;
+  color: var(--el-text-color-primary);
+  font-size: 0.85rem;
+  word-break: break-word;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+@media (max-width: 560px) {
+  .progress-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .dialog-actions {
+    flex-wrap: wrap;
+  }
+}
+</style>

--- a/apps/rgsm-gui/src/pages/SyncSettings.vue
+++ b/apps/rgsm-gui/src/pages/SyncSettings.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch, type Ref } from 'vue';
 import { $t } from '../i18n';
-import { commands, type Backend, type GameSyncState, type SyncState } from '../bindings';
+import {
+  commands,
+  type Backend,
+  type ConflictResolution,
+  type GameSyncState,
+  type SyncState,
+} from '../bindings';
 import { error } from '@tauri-apps/plugin-log';
-import { Lock, Refresh, Upload, Download } from '@element-plus/icons-vue';
+import { Download, Lock, Refresh, Upload, Warning } from '@element-plus/icons-vue';
 
 interface WebDAV {
   type: 'WebDAV';
@@ -54,6 +60,10 @@ const feedback = useFeedback();
 const activeTab = ref('overview');
 const syncState = ref<SyncState | null>(null);
 const syncingGames = ref<Set<string>>(new Set());
+const syncingConfig = ref(false);
+const resolvingConflict = ref(false);
+const conflictDialogVisible = ref(false);
+const selectedConflictGameName = ref<string | null>(null);
 const cloud_settings = ref<EditableCloudSettings>(
   toEditableCloudSettings(config.value!.settings.cloud_settings)
 );
@@ -124,6 +134,8 @@ interface GameRow {
   cloudSyncEnabled: boolean;
   status: 'synced' | 'pending' | 'failed' | 'disabled' | 'conflict' | 'unknown';
   lastSyncAt: string | null;
+  detail: string | null;
+  syncState: GameSyncState | null;
 }
 
 /** Returns true when the error string indicates the bucket requires virtual-hosted-style addressing. */
@@ -144,6 +156,14 @@ function resolveStatus(enabled: boolean, gs?: GameSyncState): GameRow['status'] 
   return 'unknown';
 }
 
+function syncErrorDetail(gs?: GameSyncState): string | null {
+  const result = gs?.last_sync_result;
+  if (result && typeof result === 'object' && 'error' in result) {
+    return String(result.error);
+  }
+  return null;
+}
+
 const gameRows = computed<GameRow[]>(() => {
   const states = syncState.value?.games ?? {};
   const configState = syncState.value?.config_state;
@@ -153,6 +173,8 @@ const gameRows = computed<GameRow[]>(() => {
     cloudSyncEnabled: true,
     status: resolveStatus(savedBackendEnabled.value, configState),
     lastSyncAt: configState?.last_sync_at ?? null,
+    detail: syncErrorDetail(configState),
+    syncState: configState ?? null,
   };
 
   const rows: GameRow[] = (config.value?.games ?? []).map((game) => {
@@ -164,6 +186,8 @@ const gameRows = computed<GameRow[]>(() => {
       cloudSyncEnabled: game.cloud_sync_enabled !== false,
       status: resolveStatus(enabled, gs),
       lastSyncAt: gs?.last_sync_at ?? null,
+      detail: syncErrorDetail(gs),
+      syncState: gs ?? null,
     };
   });
 
@@ -187,6 +211,79 @@ function statusLabel(status: StatusKey) {
 
 function statusType(status: StatusKey): TagType {
   return STATUS_META[status]?.type ?? 'info';
+}
+
+const selectedConflictRow = computed(
+  () =>
+    gameRows.value.find((row) => !row.isConfig && row.name === selectedConflictGameName.value) ??
+    null
+);
+const selectedConflictState = computed(() => selectedConflictRow.value?.syncState ?? null);
+
+function openConflictDialog(row: GameRow) {
+  if (row.isConfig || row.status !== 'conflict') return;
+  selectedConflictGameName.value = row.name;
+  conflictDialogVisible.value = true;
+}
+
+async function retryConfigSync() {
+  if (!savedBackendEnabled.value || syncingConfig.value) return;
+  syncingConfig.value = true;
+  try {
+    const result = await commands.syncConfig();
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.config_sync_failed')}: ${result.error}`);
+      error(`Sync config error: ${result.error}`);
+      return;
+    }
+    notifySuccess($t('sync_settings.config_sync_success'));
+  } catch (e) {
+    error(`Sync config exception: ${e}`);
+    notifyError(String(e));
+  } finally {
+    syncingConfig.value = false;
+    await loadSyncState();
+  }
+}
+
+async function resolveConflict(resolution: ConflictResolution) {
+  const row = selectedConflictRow.value;
+  if (!row || row.isConfig) return;
+
+  const confirmKey =
+    resolution === 'keep_local'
+      ? 'sync_settings.conflict.keep_local_confirm'
+      : 'sync_settings.conflict.accept_remote_confirm';
+
+  try {
+    await feedback.confirm($t(confirmKey, { game: row.name }), $t('sync_settings.conflict.title'), {
+      confirmButtonText: $t('sync_settings.confirm'),
+      cancelButtonText: $t('sync_settings.cancel'),
+      type: 'warning',
+    });
+  } catch {
+    notifyInfo($t('sync_settings.canceled'));
+    return;
+  }
+
+  try {
+    resolvingConflict.value = true;
+    const result = await commands.resolveGameSyncConflict(row.name, resolution);
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.conflict.resolve_failed')}: ${result.error}`);
+      error(`Resolve conflict error for ${row.name}: ${result.error}`);
+      return;
+    }
+
+    notifySuccess($t('sync_settings.conflict.resolve_success'));
+    conflictDialogVisible.value = false;
+  } catch (e) {
+    error(`Resolve conflict exception for ${row.name}: ${e}`);
+    notifyError(`${$t('sync_settings.conflict.resolve_failed')}: ${String(e)}`);
+  } finally {
+    resolvingConflict.value = false;
+    await loadSyncState();
+  }
 }
 
 async function toggleGameSync(row: GameRow) {
@@ -531,11 +628,16 @@ onMounted(async () => {
           >
             <template #default="{ row }">
               <div class="game-name-cell">
-                <span class="game-name">{{ row.name }}</span>
-                <ElTag v-if="row.isConfig" size="small" type="info" round effect="plain">
-                  <ElIcon :size="12" style="margin-right: 2px"><Lock /></ElIcon>
-                  {{ $t('sync_settings.overview.always_synced') }}
-                </ElTag>
+                <div class="game-name-stack">
+                  <div class="game-title-line">
+                    <span class="game-name">{{ row.name }}</span>
+                    <ElTag v-if="row.isConfig" size="small" type="info" round effect="plain">
+                      <ElIcon :size="12" style="margin-right: 2px"><Lock /></ElIcon>
+                      {{ $t('sync_settings.overview.always_synced') }}
+                    </ElTag>
+                  </div>
+                  <span v-if="row.detail" class="row-detail">{{ row.detail }}</span>
+                </div>
               </div>
             </template>
           </ElTableColumn>
@@ -574,10 +676,30 @@ onMounted(async () => {
               <span class="time-text">{{ formatTime(row.lastSyncAt) }}</span>
             </template>
           </ElTableColumn>
-          <ElTableColumn :label="$t('sync_settings.overview.actions')" width="100" align="center">
+          <ElTableColumn :label="$t('sync_settings.overview.actions')" width="150" align="center">
             <template #default="{ row }">
               <ElButton
-                v-if="!row.isConfig && row.cloudSyncEnabled && savedBackendEnabled"
+                v-if="row.isConfig && row.status === 'failed' && savedBackendEnabled"
+                :icon="Refresh"
+                size="small"
+                text
+                :loading="syncingConfig"
+                @click="retryConfigSync"
+              >
+                {{ $t('sync_settings.config_retry') }}
+              </ElButton>
+              <ElButton
+                v-else-if="!row.isConfig && row.status === 'conflict'"
+                :icon="Warning"
+                type="warning"
+                size="small"
+                text
+                @click="openConflictDialog(row)"
+              >
+                {{ $t('sync_settings.conflict.resolve') }}
+              </ElButton>
+              <ElButton
+                v-else-if="!row.isConfig && row.cloudSyncEnabled && savedBackendEnabled"
                 :icon="Refresh"
                 size="small"
                 text
@@ -730,6 +852,15 @@ onMounted(async () => {
         </div>
       </ElTabPane>
     </ElTabs>
+
+    <SyncConflictDialog
+      v-model="conflictDialogVisible"
+      :game-name="selectedConflictRow?.name ?? ''"
+      :state="selectedConflictState"
+      :current-device-id="syncState?.current_device_id"
+      :resolving="resolvingConflict"
+      @resolve="resolveConflict"
+    />
   </div>
 </template>
 
@@ -815,8 +946,28 @@ onMounted(async () => {
   gap: 8px;
 }
 
+.game-name-stack {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.game-title-line {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
 .game-name {
   font-weight: 500;
+}
+
+.row-detail {
+  color: var(--el-text-color-secondary);
+  font-size: 0.78em;
+  line-height: 1.35;
+  word-break: break-word;
 }
 
 .config-lock-icon {

--- a/crates/rgsm-core/src/cloud_sync/conflict.rs
+++ b/crates/rgsm-core/src/cloud_sync/conflict.rs
@@ -33,6 +33,9 @@ pub enum SyncRelation {
 pub enum ConflictResolution {
     KeepLocal,
     AcceptRemote,
+    /// Preserve both local and remote branches without merging.
+    ///
+    /// TODO: implement branch selection and upload semantics for this git-like fork workflow.
     Fork,
     Cancelled,
 }

--- a/crates/rgsm-core/src/cloud_sync/facade.rs
+++ b/crates/rgsm-core/src/cloud_sync/facade.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 
-use log::warn;
 use serde::{Deserialize, Serialize};
 use specta::Type;
 use tokio::fs;
 use tokio_util::sync::CancellationToken;
 
 use super::conflict::{SyncRelation, determine_sync_relation};
-use super::sync_state::{
-    PendingAction, SyncResult, build_game_sync_state, update_config_sync_state,
-    update_game_sync_state, with_sync_state,
+use super::state_recording::{
+    current_device_head, log_config_sync_failure, log_game_sync_failure, record_config_state,
+    record_game_state,
 };
+use super::sync_state::{PendingAction, SyncResult};
 use super::utils::{
     SyncOperationError, commit_staged_backup_root, load_remote_config, load_remote_game_snapshots,
-    new_stage_root, replace_local_game_from_stage, stage_remote_game_download,
-    target_backup_root_from_config, upload_config, upload_game_data,
+    new_stage_root, replace_local_game_with_remote, stage_remote_game_download,
+    target_backup_root_from_config, upload_config_snapshot, upload_game_data,
 };
 use super::{Backend, CloudSyncSessionConfig};
 use crate::backup::GameSnapshots;
@@ -61,48 +61,19 @@ fn empty_batch_report() -> BatchSyncReport {
     }
 }
 
-fn record_config_state(
-    session: &CloudSyncSessionConfig,
-    result: SyncResult,
-    pending: PendingAction,
-) {
-    let state = build_game_sync_state(None, None, result, pending);
-    if let Err(err) = with_sync_state(|sync_state| {
-        update_config_sync_state(sync_state, session, state);
-    }) {
-        warn!("Failed to record config sync state: {err}");
-    }
-}
-
-fn record_game_state(
-    session: &CloudSyncSessionConfig,
-    game_name: &str,
-    local_head: Option<String>,
-    remote_head: Option<String>,
-    result: SyncResult,
-    pending: PendingAction,
-) {
-    let state = build_game_sync_state(local_head, remote_head, result, pending);
-    let game_name = game_name.to_string();
-    if let Err(err) = with_sync_state(|sync_state| {
-        update_game_sync_state(sync_state, session, &game_name, state);
-    }) {
-        warn!("Failed to record sync state for {game_name}: {err}");
-    }
-}
-
 async fn upload_config_with_token(
     session: &CloudSyncSessionConfig,
+    config: &crate::config::Config,
     token: Option<&CancellationToken>,
 ) -> Result<(), SyncOperationError> {
     let op = session.get_op().map_err(SyncOperationError::Backend)?;
     if let Some(token) = token {
         tokio::select! {
             _ = token.cancelled() => Err(SyncOperationError::Cancelled),
-            result = upload_config(&op) => result.map_err(SyncOperationError::Backend),
+            result = upload_config_snapshot(&op, config) => result.map_err(SyncOperationError::Backend),
         }
     } else {
-        upload_config(&op)
+        upload_config_snapshot(&op, config)
             .await
             .map_err(SyncOperationError::Backend)
     }
@@ -110,10 +81,6 @@ async fn upload_config_with_token(
 
 fn empty_remote_snapshots(game_name: &str) -> GameSnapshots {
     GameSnapshots::new(game_name)
-}
-
-fn current_device_head(info: &GameSnapshots) -> Option<String> {
-    info.current_device_head_cloned()
 }
 
 fn is_ancestor(
@@ -291,9 +258,7 @@ async fn coexist_game_from_remote(
         )
         .await
         .map_err(|err| match err {
-            SyncOperationError::Cancelled => {
-                BackendError::Unexpected(anyhow::anyhow!("Sync unexpectedly cancelled"))
-            }
+            SyncOperationError::Cancelled => BackendError::Cancelled,
             SyncOperationError::Backend(inner) => inner,
         })?;
 
@@ -304,12 +269,10 @@ async fn coexist_game_from_remote(
         let merged = merge_snapshots_metadata(&local, &downloaded)?;
         game.set_game_snapshots_info(&merged)?;
 
-        upload_game_data(op, &game.name, session.normalized_max_concurrency(), None)
+        upload_game_data(op, game, session.normalized_max_concurrency(), None)
             .await
             .map_err(|err| match err {
-                SyncOperationError::Cancelled => {
-                    BackendError::Unexpected(anyhow::anyhow!("Sync unexpectedly cancelled"))
-                }
+                SyncOperationError::Cancelled => BackendError::Cancelled,
                 SyncOperationError::Backend(inner) => inner,
             })
     }
@@ -330,7 +293,7 @@ pub async fn upload_all_from_session(
     let op = session.get_op()?;
     let mut report = empty_batch_report();
 
-    match upload_config_with_token(session, token.as_ref()).await {
+    match upload_config_with_token(session, &config, token.as_ref()).await {
         Ok(()) => {
             record_config_state(session, SyncResult::Success, PendingAction::None);
         }
@@ -342,6 +305,7 @@ pub async fn upload_all_from_session(
         Err(SyncOperationError::Backend(err)) => {
             let message = err.to_string();
             report.config.status = BatchSyncItemStatus::Failed(message.clone());
+            log_config_sync_failure(session, "overwrite_upload_config", &message);
             record_config_state(
                 session,
                 SyncResult::Error(message),
@@ -358,7 +322,7 @@ pub async fn upload_all_from_session(
             .and_then(|info| current_device_head(&info));
         match upload_game_data(
             &op,
-            &game.name,
+            &game,
             session.normalized_max_concurrency(),
             token.clone(),
         )
@@ -399,6 +363,13 @@ pub async fn upload_all_from_session(
                     name: game.name.clone(),
                     status: BatchSyncItemStatus::Failed(message.clone()),
                 });
+                log_game_sync_failure(
+                    session,
+                    &game.name,
+                    "overwrite_upload_game",
+                    PendingAction::RetryRequired,
+                    &message,
+                );
                 record_game_state(
                     session,
                     &game.name,
@@ -432,6 +403,7 @@ pub async fn download_all_from_session(
         Err(SyncOperationError::Backend(err)) => {
             let message = err.to_string();
             report.config.status = BatchSyncItemStatus::Failed(message.clone());
+            log_config_sync_failure(session, "overwrite_download_config", &message);
             record_config_state(
                 session,
                 SyncResult::Error(message),
@@ -474,6 +446,13 @@ pub async fn download_all_from_session(
                     status: BatchSyncItemStatus::Failed(message.clone()),
                 });
                 let _ = fs::remove_dir_all(&stage_root).await;
+                log_game_sync_failure(
+                    session,
+                    &game.name,
+                    "overwrite_download_game",
+                    PendingAction::RetryRequired,
+                    &message,
+                );
                 record_config_state(
                     session,
                     SyncResult::Error(message.clone()),
@@ -497,6 +476,7 @@ pub async fn download_all_from_session(
     {
         let message = err.to_string();
         report.config.status = BatchSyncItemStatus::Failed(message.clone());
+        log_config_sync_failure(session, "overwrite_download_commit", &message);
         record_config_state(
             session,
             SyncResult::Error(message),
@@ -524,26 +504,18 @@ pub async fn download_all_from_session(
     Ok(report)
 }
 
-pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, BackendError> {
-    let config = get_config()?;
-    let session = CloudSyncSessionConfig::from(&config.settings.cloud_settings);
-    let op = session.get_op()?;
-    let game = config
-        .games
-        .iter()
-        .find(|game| game.name == game_name)
-        .ok_or_else(|| {
-            BackendError::Unexpected(anyhow::anyhow!("Game '{}' not found", game_name))
-        })?;
-
+pub async fn sync_game(
+    session: &CloudSyncSessionConfig,
+    op: &opendal::Operator,
+    game: &crate::backup::Game,
+) -> Result<SyncGameOutcome, BackendError> {
+    let game_name = game.name.as_str();
     let dir_name = game.backup_dir_name().into_owned();
     let local = game.get_game_snapshots_info()?;
-    let remote = load_remote_game_snapshots(&op, &dir_name, None)
+    let remote = load_remote_game_snapshots(op, &dir_name, None)
         .await
         .map_err(|err| match err {
-            SyncOperationError::Cancelled => {
-                BackendError::Unexpected(anyhow::anyhow!("Sync unexpectedly cancelled"))
-            }
+            SyncOperationError::Cancelled => BackendError::Cancelled,
             SyncOperationError::Backend(inner) => inner,
         })?
         .unwrap_or_else(|| empty_remote_snapshots(game_name));
@@ -551,7 +523,7 @@ pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, B
     match determine_sync_relation(&local, &remote) {
         SyncRelation::InSync => {
             record_game_state(
-                &session,
+                session,
                 game_name,
                 current_device_head(&local),
                 current_device_head(&remote),
@@ -561,17 +533,41 @@ pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, B
             Ok(SyncGameOutcome::AlreadyInSync)
         }
         SyncRelation::CurrentDeviceAhead => {
-            let uploaded =
-                upload_game_data(&op, game_name, session.normalized_max_concurrency(), None)
-                    .await
-                    .map_err(|err| match err {
-                        SyncOperationError::Cancelled => {
-                            BackendError::Unexpected(anyhow::anyhow!("Sync unexpectedly cancelled"))
-                        }
+            let uploaded = match upload_game_data(
+                op,
+                game,
+                session.normalized_max_concurrency(),
+                None,
+            )
+            .await
+            {
+                Ok(uploaded) => uploaded,
+                Err(err) => {
+                    let backend_err = match err {
+                        SyncOperationError::Cancelled => BackendError::Cancelled,
                         SyncOperationError::Backend(inner) => inner,
-                    })?;
+                    };
+                    let message = backend_err.to_string();
+                    log_game_sync_failure(
+                        session,
+                        game_name,
+                        "sync_game_upload",
+                        PendingAction::RetryRequired,
+                        &message,
+                    );
+                    record_game_state(
+                        session,
+                        game_name,
+                        current_device_head(&local),
+                        current_device_head(&remote),
+                        SyncResult::Error(message),
+                        PendingAction::RetryRequired,
+                    );
+                    return Err(backend_err);
+                }
+            };
             record_game_state(
-                &session,
+                session,
                 game_name,
                 current_device_head(&uploaded),
                 current_device_head(&uploaded),
@@ -581,32 +577,42 @@ pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, B
             Ok(SyncGameOutcome::Uploaded)
         }
         SyncRelation::CurrentDeviceBehind => {
-            let backup_root = get_backup_path()?;
-            let stage_root = new_stage_root(&backup_root, "game-download-stage");
-            if stage_root.exists() {
-                let _ = fs::remove_dir_all(&stage_root).await;
-            }
-            fs::create_dir_all(&stage_root).await?;
-            let downloaded = stage_remote_game_download(
-                &op,
-                &dir_name,
-                &stage_root,
-                session.normalized_max_concurrency(),
+            let downloaded = match replace_local_game_with_remote(
+                session,
+                game,
+                op,
+                "game-download-stage",
                 None,
             )
             .await
-            .map_err(|err| match err {
-                SyncOperationError::Cancelled => {
-                    BackendError::Unexpected(anyhow::anyhow!("Sync unexpectedly cancelled"))
+            {
+                Ok(downloaded) => downloaded,
+                Err(err) => {
+                    let backend_err = match err {
+                        SyncOperationError::Cancelled => BackendError::Cancelled,
+                        SyncOperationError::Backend(inner) => inner,
+                    };
+                    let message = backend_err.to_string();
+                    log_game_sync_failure(
+                        session,
+                        game_name,
+                        "sync_game_download",
+                        PendingAction::RetryRequired,
+                        &message,
+                    );
+                    record_game_state(
+                        session,
+                        game_name,
+                        current_device_head(&local),
+                        current_device_head(&remote),
+                        SyncResult::Error(message),
+                        PendingAction::RetryRequired,
+                    );
+                    return Err(backend_err);
                 }
-                SyncOperationError::Backend(inner) => inner,
-            })?;
-            replace_local_game_from_stage(&stage_root, &backup_root, &dir_name).await?;
-            if stage_root.exists() {
-                let _ = fs::remove_dir_all(&stage_root).await;
-            }
+            };
             record_game_state(
-                &session,
+                session,
                 game_name,
                 current_device_head(&downloaded),
                 current_device_head(&downloaded),
@@ -616,9 +622,9 @@ pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, B
             Ok(SyncGameOutcome::Downloaded)
         }
         SyncRelation::SharedTreeDiverged | SyncRelation::ParallelBranches => {
-            let merged = coexist_game_from_remote(&session, game, &op).await?;
+            let merged = coexist_game_from_remote(session, game, op).await?;
             record_game_state(
-                &session,
+                session,
                 game_name,
                 current_device_head(&merged),
                 current_device_head(&merged),
@@ -629,7 +635,7 @@ pub async fn sync_game_from_config(game_name: &str) -> Result<SyncGameOutcome, B
         }
         SyncRelation::IncompatibleState => {
             record_game_state(
-                &session,
+                session,
                 game_name,
                 current_device_head(&local),
                 current_device_head(&remote),

--- a/crates/rgsm-core/src/cloud_sync/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/mod.rs
@@ -3,6 +3,8 @@ mod cloud_settings;
 #[allow(dead_code)]
 pub mod conflict;
 mod facade;
+mod recovery;
+mod state_recording;
 pub mod sync_state;
 mod task_manager;
 pub mod transfer;
@@ -14,8 +16,9 @@ pub use cloud_settings::CloudSettings;
 pub use conflict::{ConflictResolution, SyncRelation};
 pub use facade::{
     BatchSyncItemStatus, BatchSyncReport, SyncGameOutcome, download_all_from_session,
-    session_from_backend, sync_game_from_config, upload_all_from_session,
+    session_from_backend, sync_game, upload_all_from_session,
 };
+pub use recovery::{ConflictResolutionOutcome, resolve_game_conflict, sync_config};
 #[allow(unused_imports)]
 pub use sync_state::{GameSyncState, PendingAction, SyncResult, SyncState};
 pub use task_manager::{

--- a/crates/rgsm-core/src/cloud_sync/recovery.rs
+++ b/crates/rgsm-core/src/cloud_sync/recovery.rs
@@ -1,0 +1,632 @@
+use log::info;
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::CloudSyncSessionConfig;
+use super::conflict::{ConflictResolution, SyncRelation, determine_sync_relation};
+use super::state_recording::{
+    current_device_head, log_config_sync_failure, log_game_sync_failure, merged_error_state,
+    record_config_state, record_game_state,
+};
+use super::sync_state::{GameSyncState, PendingAction, SyncResult, load_sync_state};
+use super::utils::{
+    SyncOperationError, load_remote_game_snapshots, replace_local_game_with_remote,
+    upload_config_snapshot, upload_game_data,
+};
+use crate::backup::{Game, GameSnapshots};
+use crate::config::Config;
+use crate::preclude::BackendError;
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ConflictResolutionOutcome {
+    Cancelled,
+    KeptLocal,
+    AcceptedRemote,
+}
+
+struct ConflictContext {
+    previous_state: GameSyncState,
+    local: GameSnapshots,
+    remote: GameSnapshots,
+}
+
+fn sync_error_to_backend(err: SyncOperationError) -> BackendError {
+    match err {
+        SyncOperationError::Cancelled => BackendError::Cancelled,
+        SyncOperationError::Backend(inner) => inner,
+    }
+}
+
+fn require_unresolved_conflict_state(game_name: &str) -> Result<GameSyncState, BackendError> {
+    let state = load_sync_state()?;
+    let Some(game_state) = state.games.get(game_name) else {
+        return Err(BackendError::InvalidConflictState(game_name.to_string()));
+    };
+    if game_state.pending_action != PendingAction::UserDecisionRequired {
+        return Err(BackendError::InvalidConflictState(game_name.to_string()));
+    }
+    Ok(game_state.clone())
+}
+
+async fn load_remote_snapshots(
+    op: &Operator,
+    game: &Game,
+) -> Result<Option<GameSnapshots>, BackendError> {
+    load_remote_game_snapshots(op, &game.backup_dir_name(), None)
+        .await
+        .map_err(sync_error_to_backend)
+}
+
+async fn load_conflict_context(
+    op: &Operator,
+    game: &Game,
+) -> Result<ConflictContext, BackendError> {
+    let previous_state = require_unresolved_conflict_state(&game.name)?;
+    let local = game.get_game_snapshots_info()?;
+    let Some(remote) = load_remote_snapshots(op, game).await? else {
+        return Err(BackendError::InvalidConflictState(game.name.clone()));
+    };
+
+    if determine_sync_relation(&local, &remote) != SyncRelation::IncompatibleState {
+        return Err(BackendError::InvalidConflictState(game.name.clone()));
+    }
+
+    Ok(ConflictContext {
+        previous_state,
+        local,
+        remote,
+    })
+}
+
+fn record_resolution_failure(
+    session: &CloudSyncSessionConfig,
+    game: &Game,
+    context: &ConflictContext,
+    operation: &str,
+    backend_err: &BackendError,
+) {
+    let message = backend_err.to_string();
+    let (local_head, remote_head, result, pending) = merged_error_state(
+        Some(&context.previous_state),
+        current_device_head(&context.local),
+        current_device_head(&context.remote),
+        message.clone(),
+        PendingAction::UserDecisionRequired,
+    );
+    record_game_state(
+        session,
+        &game.name,
+        local_head,
+        remote_head,
+        result,
+        pending,
+    );
+    log_game_sync_failure(
+        session,
+        &game.name,
+        operation,
+        PendingAction::UserDecisionRequired,
+        &message,
+    );
+}
+
+pub async fn resolve_game_conflict(
+    session: &CloudSyncSessionConfig,
+    op: &Operator,
+    game: &Game,
+    resolution: ConflictResolution,
+) -> Result<ConflictResolutionOutcome, BackendError> {
+    match resolution {
+        ConflictResolution::Cancelled => {
+            info!(
+                target: "rgsm::cloud::recovery",
+                "Conflict resolution cancelled for game {}",
+                game.name
+            );
+            Ok(ConflictResolutionOutcome::Cancelled)
+        }
+        ConflictResolution::Fork => {
+            // TODO: fork should preserve both branch heads without merging, like a git branch.
+            Err(BackendError::UnsupportedConflictResolution("fork".into()))
+        }
+        ConflictResolution::KeepLocal | ConflictResolution::AcceptRemote => {
+            let context = load_conflict_context(op, game).await?;
+            match resolution {
+                ConflictResolution::KeepLocal => {
+                    keep_local_progress(session, op, game, &context).await
+                }
+                ConflictResolution::AcceptRemote => {
+                    accept_remote_progress(session, op, game, &context).await
+                }
+                ConflictResolution::Cancelled | ConflictResolution::Fork => unreachable!(),
+            }
+        }
+    }
+}
+
+async fn keep_local_progress(
+    session: &CloudSyncSessionConfig,
+    op: &Operator,
+    game: &Game,
+    context: &ConflictContext,
+) -> Result<ConflictResolutionOutcome, BackendError> {
+    let result = upload_game_data(op, game, session.normalized_max_concurrency(), None).await;
+
+    match result {
+        Ok(uploaded) => {
+            let head = current_device_head(&uploaded);
+            record_game_state(
+                session,
+                &game.name,
+                head.clone(),
+                head,
+                SyncResult::Success,
+                PendingAction::None,
+            );
+            Ok(ConflictResolutionOutcome::KeptLocal)
+        }
+        Err(err) => {
+            let backend_err = sync_error_to_backend(err);
+            record_resolution_failure(session, game, context, "resolve_keep_local", &backend_err);
+            Err(backend_err)
+        }
+    }
+}
+
+async fn accept_remote_progress(
+    session: &CloudSyncSessionConfig,
+    op: &Operator,
+    game: &Game,
+    context: &ConflictContext,
+) -> Result<ConflictResolutionOutcome, BackendError> {
+    let result = replace_local_game_with_remote(
+        session,
+        game,
+        op,
+        "game-conflict-accept-remote-stage",
+        None,
+    )
+    .await;
+
+    match result {
+        Ok(downloaded) => {
+            let remote_head = current_device_head(&downloaded);
+            record_game_state(
+                session,
+                &game.name,
+                remote_head.clone(),
+                remote_head,
+                SyncResult::Success,
+                PendingAction::None,
+            );
+            Ok(ConflictResolutionOutcome::AcceptedRemote)
+        }
+        Err(err) => {
+            let backend_err = sync_error_to_backend(err);
+            record_resolution_failure(
+                session,
+                game,
+                context,
+                "resolve_accept_remote",
+                &backend_err,
+            );
+            Err(backend_err)
+        }
+    }
+}
+
+pub async fn sync_config(
+    session: &CloudSyncSessionConfig,
+    op: &Operator,
+    config: &Config,
+) -> Result<(), BackendError> {
+    match upload_config_snapshot(op, config).await {
+        Ok(()) => {
+            record_config_state(session, SyncResult::Success, PendingAction::None);
+            Ok(())
+        }
+        Err(err) => {
+            let message = err.to_string();
+            record_config_state(
+                session,
+                SyncResult::Error(message.clone()),
+                PendingAction::RetryRequired,
+            );
+            log_config_sync_failure(session, "manual_config_upload", &message);
+            Err(err)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use opendal::Operator;
+    use opendal::services;
+    use temp_dir::TempDir;
+
+    use super::*;
+    use crate::backup::Snapshot;
+    use crate::cloud_sync::{Backend, CloudSyncSessionConfig};
+    use crate::config::{Config, Settings};
+    use crate::device::get_current_device_id;
+
+    struct ConfigFileGuard {
+        path: PathBuf,
+        original: Option<Vec<u8>>,
+    }
+
+    impl ConfigFileGuard {
+        fn write(config: &Config) -> Self {
+            let path = crate::app_dirs::resolve_app_path("GameSaveManager.config.json");
+            let original = fs::read(&path).ok();
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("config parent should be created");
+            }
+            fs::write(&path, serde_json::to_vec_pretty(config).unwrap())
+                .expect("config should be written");
+            Self { path, original }
+        }
+    }
+
+    impl Drop for ConfigFileGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                let _ = fs::write(&self.path, original);
+            } else {
+                let _ = fs::remove_file(&self.path);
+            }
+        }
+    }
+
+    fn memory_operator() -> Operator {
+        Operator::new(services::Memory::default()).unwrap().finish()
+    }
+
+    fn test_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn session() -> CloudSyncSessionConfig {
+        CloudSyncSessionConfig {
+            root_path: "/test-root".into(),
+            max_concurrency: 1,
+            backend: Backend::Disabled,
+        }
+    }
+
+    fn game() -> Game {
+        Game {
+            name: "Test Game".to_string(),
+            storage_key: "test-game".to_string(),
+            save_paths: Vec::new(),
+            game_paths: Default::default(),
+            next_save_unit_id: 0,
+            cloud_sync_enabled: true,
+            auto_backup: None,
+            ludusavi_meta: None,
+            store_user_ids: Default::default(),
+        }
+    }
+
+    fn snapshot(date: &str, parent: Option<&str>, path: String) -> Snapshot {
+        Snapshot {
+            date: date.to_string(),
+            describe: String::new(),
+            path,
+            size: 0,
+            parent: parent.map(str::to_string),
+            archive_hash: None,
+            device_id: Some(get_current_device_id().clone()),
+            created_by: Default::default(),
+        }
+    }
+
+    fn snapshots(name: &str, items: Vec<Snapshot>, head: &str) -> GameSnapshots {
+        let mut snapshots = GameSnapshots::new(name);
+        snapshots.backups = items;
+        snapshots.set_current_device_head(Some(head.to_string()));
+        snapshots
+    }
+
+    fn write_local_snapshots(backup_root: &Path, game: &Game, dates: &[&str]) -> GameSnapshots {
+        let game_dir = backup_root.join(game.backup_dir_name().as_ref());
+        fs::create_dir_all(&game_dir).expect("game directory should be created");
+        let items = dates
+            .iter()
+            .enumerate()
+            .map(|(index, date)| {
+                let zip_path = game_dir.join(format!("{date}.zip"));
+                fs::write(&zip_path, format!("local {date}")).expect("zip should be written");
+                let parent = index.checked_sub(1).map(|previous| dates[previous]);
+                snapshot(date, parent, zip_path.to_string_lossy().to_string())
+            })
+            .collect::<Vec<_>>();
+        let info = snapshots(&game.name, items, dates.last().unwrap());
+        fs::write(
+            game_dir.join("Backups.json"),
+            serde_json::to_vec_pretty(&info).unwrap(),
+        )
+        .expect("metadata should be written");
+        info
+    }
+
+    async fn write_remote_snapshots(op: &Operator, storage_key: &str, info: &GameSnapshots) {
+        write_remote_metadata(op, storage_key, info).await;
+        for snapshot in &info.backups {
+            let zip_path = super::super::utils::game_cloud_zip_path(storage_key, &snapshot.date)
+                .expect("remote zip path should build");
+            op.write(&zip_path, format!("remote {}", snapshot.date))
+                .await
+                .expect("remote zip should be written");
+        }
+    }
+
+    async fn write_remote_metadata(op: &Operator, storage_key: &str, info: &GameSnapshots) {
+        let metadata_path = super::super::utils::game_cloud_metadata_path(storage_key).unwrap();
+        op.write(&metadata_path, serde_json::to_vec_pretty(info).unwrap())
+            .await
+            .expect("remote metadata should be written");
+    }
+
+    fn write_conflict_state(session: &CloudSyncSessionConfig, game: &Game) {
+        record_game_state(
+            session,
+            &game.name,
+            Some("local".into()),
+            Some("remote".into()),
+            SyncResult::Conflict,
+            PendingAction::UserDecisionRequired,
+        );
+    }
+
+    fn read_game_state(game: &Game) -> super::super::sync_state::GameSyncState {
+        super::super::sync_state::load_sync_state()
+            .expect("sync state should load")
+            .games
+            .get(&game.name)
+            .cloned()
+            .expect("game state should exist")
+    }
+
+    fn config_for(backup_root: &Path, game: &Game) -> Config {
+        Config {
+            backup_path: backup_root.to_string_lossy().to_string(),
+            games: vec![game.clone()],
+            settings: Settings {
+                cloud_settings: super::super::CloudSettings {
+                    backend: Backend::Disabled,
+                    root_path: "/test-root".into(),
+                    max_concurrency: 1,
+                    auto_sync_interval: 0,
+                },
+                ..Settings::default()
+            },
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn incompatible_sync_relation_records_user_decision_required() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let backup_root = temp.path().join("backup");
+        write_local_snapshots(&backup_root, &game, &["base", "local"]);
+        let config = config_for(&backup_root, &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        let op = memory_operator();
+        let remote = snapshots(
+            &game.name,
+            vec![
+                snapshot("base", None, String::new()),
+                snapshot("cloud", Some("base"), String::new()),
+            ],
+            "cloud",
+        );
+        test_runtime().block_on(write_remote_snapshots(&op, "test-game", &remote));
+
+        let result = test_runtime()
+            .block_on(super::super::facade::sync_game(&session, &op, &game))
+            .unwrap();
+
+        assert_eq!(result, super::super::SyncGameOutcome::Conflict);
+        let state = read_game_state(&game);
+        assert_eq!(state.last_sync_result, Some(SyncResult::Conflict));
+        assert_eq!(state.pending_action, PendingAction::UserDecisionRequired);
+    }
+
+    #[test]
+    fn cancelled_resolution_preserves_conflict_state() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let config = config_for(&temp.path().join("backup"), &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        write_conflict_state(&session, &game);
+        let before = read_game_state(&game);
+
+        let result = test_runtime()
+            .block_on(resolve_game_conflict(
+                &session,
+                &memory_operator(),
+                &game,
+                ConflictResolution::Cancelled,
+            ))
+            .unwrap();
+
+        assert_eq!(result, ConflictResolutionOutcome::Cancelled);
+        let after = read_game_state(&game);
+        assert_eq!(before.last_sync_result, after.last_sync_result);
+        assert_eq!(before.pending_action, after.pending_action);
+    }
+
+    #[test]
+    fn resolution_requires_unresolved_conflict_state() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let backup_root = temp.path().join("backup");
+        write_local_snapshots(&backup_root, &game, &["base", "local"]);
+        let config = config_for(&backup_root, &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        let op = memory_operator();
+
+        let result = test_runtime().block_on(resolve_game_conflict(
+            &session,
+            &op,
+            &game,
+            ConflictResolution::KeepLocal,
+        ));
+
+        assert!(matches!(result, Err(BackendError::InvalidConflictState(_))));
+    }
+
+    #[test]
+    fn keep_local_uploads_metadata_and_clears_conflict_state() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let backup_root = temp.path().join("backup");
+        let local = write_local_snapshots(&backup_root, &game, &["base", "local"]);
+        let config = config_for(&backup_root, &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        let op = memory_operator();
+        let remote = snapshots(
+            &game.name,
+            vec![
+                snapshot("base", None, String::new()),
+                snapshot("remote", Some("base"), String::new()),
+            ],
+            "remote",
+        );
+        test_runtime().block_on(write_remote_snapshots(&op, "test-game", &remote));
+        write_conflict_state(&session, &game);
+
+        let result = test_runtime()
+            .block_on(resolve_game_conflict(
+                &session,
+                &op,
+                &game,
+                ConflictResolution::KeepLocal,
+            ))
+            .unwrap();
+
+        assert_eq!(result, ConflictResolutionOutcome::KeptLocal);
+        let remote_path = super::super::utils::game_cloud_metadata_path("test-game").unwrap();
+        let remote: GameSnapshots = serde_json::from_slice(
+            &test_runtime()
+                .block_on(op.read(&remote_path))
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert_eq!(remote.current_device_head(), local.current_device_head());
+        let state = read_game_state(&game);
+        assert_eq!(state.last_sync_result, Some(SyncResult::Success));
+        assert_eq!(state.pending_action, PendingAction::None);
+    }
+
+    #[test]
+    fn accept_remote_stages_remote_data_and_clears_conflict_state() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let backup_root = temp.path().join("backup");
+        write_local_snapshots(&backup_root, &game, &["base", "local"]);
+        let config = config_for(&backup_root, &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        let op = memory_operator();
+        let remote = snapshots(
+            &game.name,
+            vec![
+                snapshot("base", None, String::new()),
+                snapshot("remote", Some("base"), String::new()),
+            ],
+            "remote",
+        );
+        test_runtime().block_on(write_remote_snapshots(&op, "test-game", &remote));
+        write_conflict_state(&session, &game);
+
+        let result = test_runtime()
+            .block_on(resolve_game_conflict(
+                &session,
+                &op,
+                &game,
+                ConflictResolution::AcceptRemote,
+            ))
+            .unwrap();
+
+        assert_eq!(result, ConflictResolutionOutcome::AcceptedRemote);
+        let local: GameSnapshots = serde_json::from_slice(
+            &fs::read(backup_root.join("test-game").join("Backups.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            local.current_device_head().map(String::as_str),
+            Some("remote")
+        );
+        assert!(
+            local
+                .backups
+                .iter()
+                .all(|snapshot| PathBuf::from(&snapshot.path).starts_with(&backup_root))
+        );
+        assert_eq!(
+            fs::read_to_string(backup_root.join("test-game").join("remote.zip")).unwrap(),
+            "remote remote"
+        );
+        let state = read_game_state(&game);
+        assert_eq!(state.last_sync_result, Some(SyncResult::Success));
+        assert_eq!(state.pending_action, PendingAction::None);
+    }
+
+    #[test]
+    fn failed_resolution_keeps_conflict_visible_and_records_error() {
+        let _lock = crate::config::lock_config_test_file();
+        let temp = TempDir::new().expect("temp dir should be created");
+        let game = game();
+        let backup_root = temp.path().join("backup");
+        write_local_snapshots(&backup_root, &game, &["base", "local"]);
+        let config = config_for(&backup_root, &game);
+        let _guard = ConfigFileGuard::write(&config);
+        let session = session();
+        let op = memory_operator();
+        let remote = snapshots(
+            &game.name,
+            vec![
+                snapshot("base", None, String::new()),
+                snapshot("remote", Some("base"), String::new()),
+            ],
+            "remote",
+        );
+        test_runtime().block_on(write_remote_metadata(&op, "test-game", &remote));
+        write_conflict_state(&session, &game);
+
+        let result = test_runtime().block_on(resolve_game_conflict(
+            &session,
+            &op,
+            &game,
+            ConflictResolution::AcceptRemote,
+        ));
+
+        assert!(result.is_err());
+        let state = read_game_state(&game);
+        assert!(matches!(state.last_sync_result, Some(SyncResult::Error(_))));
+        assert_eq!(state.last_known_local_head.as_deref(), Some("local"));
+        assert_eq!(state.last_known_remote_head.as_deref(), Some("remote"));
+        assert_eq!(state.pending_action, PendingAction::UserDecisionRequired);
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/state_recording.rs
+++ b/crates/rgsm-core/src/cloud_sync/state_recording.rs
@@ -1,0 +1,82 @@
+use log::warn;
+
+use super::CloudSyncSessionConfig;
+use super::sync_state::{
+    GameSyncState, PendingAction, SyncResult, build_game_sync_state, update_config_sync_state,
+    update_game_sync_state, with_sync_state,
+};
+use crate::backup::GameSnapshots;
+
+pub(super) fn current_device_head(info: &GameSnapshots) -> Option<String> {
+    info.current_device_head_cloned()
+}
+
+pub(super) fn record_config_state(
+    session: &CloudSyncSessionConfig,
+    result: SyncResult,
+    pending: PendingAction,
+) {
+    let state = build_game_sync_state(None, None, result, pending);
+    if let Err(err) = with_sync_state(|sync_state| {
+        update_config_sync_state(sync_state, session, state);
+    }) {
+        warn!("Failed to record config sync state: {err}");
+    }
+}
+
+pub(super) fn record_game_state(
+    session: &CloudSyncSessionConfig,
+    game_name: &str,
+    local_head: Option<String>,
+    remote_head: Option<String>,
+    result: SyncResult,
+    pending: PendingAction,
+) {
+    let state = build_game_sync_state(local_head, remote_head, result, pending);
+    let game_name = game_name.to_string();
+    if let Err(err) = with_sync_state(|sync_state| {
+        update_game_sync_state(sync_state, session, &game_name, state);
+    }) {
+        warn!("Failed to record sync state for {game_name}: {err}");
+    }
+}
+
+pub(super) fn merged_error_state(
+    previous: Option<&GameSyncState>,
+    local_head: Option<String>,
+    remote_head: Option<String>,
+    message: String,
+    pending: PendingAction,
+) -> (Option<String>, Option<String>, SyncResult, PendingAction) {
+    let local_head =
+        local_head.or_else(|| previous.and_then(|state| state.last_known_local_head.clone()));
+    let remote_head =
+        remote_head.or_else(|| previous.and_then(|state| state.last_known_remote_head.clone()));
+    (local_head, remote_head, SyncResult::Error(message), pending)
+}
+
+pub(super) fn log_game_sync_failure(
+    session: &CloudSyncSessionConfig,
+    game_name: &str,
+    operation: &str,
+    pending: PendingAction,
+    error_message: &str,
+) {
+    warn!(
+        target: "rgsm::cloud::diagnostics",
+        "Game cloud sync failed: game={game_name}, operation={operation}, backend_fingerprint={}, pending_action={pending:?}, error={error_message}",
+        session.fingerprint()
+    );
+}
+
+pub(super) fn log_config_sync_failure(
+    session: &CloudSyncSessionConfig,
+    operation: &str,
+    error_message: &str,
+) {
+    warn!(
+        target: "rgsm::cloud::diagnostics",
+        "Config cloud sync failed: operation={operation}, backend_fingerprint={}, error={error_message}",
+        session.fingerprint()
+    );
+}

--- a/crates/rgsm-core/src/cloud_sync/task_manager.rs
+++ b/crates/rgsm-core/src/cloud_sync/task_manager.rs
@@ -12,6 +12,7 @@ use tokio::sync::{Mutex, Notify, Semaphore};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+use super::state_recording::{log_config_sync_failure, log_game_sync_failure};
 use super::sync_state::{
     GameSyncState, PendingAction, SyncResult, build_game_sync_state, update_config_sync_state,
     update_game_sync_state, with_sync_state,
@@ -494,6 +495,15 @@ fn record_job_sync_state(job: &CloudSyncJob, result: &Result<(), CloudSyncExecut
             ..
         } => {
             let state = build_state_for_result(snapshots.current_device_head_cloned(), result);
+            if let Err(CloudSyncExecuteError::Backend(err)) = result {
+                log_game_sync_failure(
+                    &session,
+                    game_name,
+                    "queued_game_upload",
+                    PendingAction::RetryRequired,
+                    &err.to_string(),
+                );
+            }
             if let Err(err) = with_sync_state(|sync_state| {
                 update_game_sync_state(sync_state, &session, game_name, state);
             }) {
@@ -502,6 +512,20 @@ fn record_job_sync_state(job: &CloudSyncJob, result: &Result<(), CloudSyncExecut
         }
         CloudSyncJob::DeleteGameAndUploadConfig { game_name, .. } => {
             let config_state = build_state_for_result(None, result);
+            if let Err(CloudSyncExecuteError::Backend(err)) = result {
+                log_game_sync_failure(
+                    &session,
+                    game_name,
+                    "queued_delete_game",
+                    PendingAction::RetryRequired,
+                    &err.to_string(),
+                );
+                log_config_sync_failure(
+                    &session,
+                    "queued_delete_game_config_upload",
+                    &err.to_string(),
+                );
+            }
             if let Err(err) = with_sync_state(|sync_state| {
                 update_config_sync_state(sync_state, &session, config_state.clone());
                 if result.is_ok() {
@@ -513,6 +537,9 @@ fn record_job_sync_state(job: &CloudSyncJob, result: &Result<(), CloudSyncExecut
         }
         CloudSyncJob::UploadConfig { .. } => {
             let config_state = build_state_for_result(None, result);
+            if let Err(CloudSyncExecuteError::Backend(err)) = result {
+                log_config_sync_failure(&session, "queued_config_upload", &err.to_string());
+            }
             if let Err(err) = with_sync_state(|sync_state| {
                 update_config_sync_state(sync_state, &session, config_state);
             }) {

--- a/crates/rgsm-core/src/cloud_sync/utils.rs
+++ b/crates/rgsm-core/src/cloud_sync/utils.rs
@@ -11,7 +11,7 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
-use crate::backup::GameSnapshots;
+use crate::backup::{Game, GameSnapshots};
 use crate::cloud_sync::transfer::{CloudTransfer, path_to_remote_key};
 use crate::config::{Config, get_backup_path, get_config, resolve_backup_path, set_config_local};
 use crate::preclude::*;
@@ -134,11 +134,15 @@ pub async fn upload_game_snapshots(
 }
 
 pub async fn upload_config(op: &Operator) -> Result<(), BackendError> {
-    let transfer = CloudTransfer::new(op);
     let config = get_config()?;
+    upload_config_snapshot(op, &config).await
+}
+
+pub async fn upload_config_snapshot(op: &Operator, config: &Config) -> Result<(), BackendError> {
+    let transfer = CloudTransfer::new(op);
     transfer
         .upload_bytes_streaming(
-            &serde_json::to_vec_pretty(&config)?,
+            &serde_json::to_vec_pretty(config)?,
             "/GameSaveManager.config.json",
         )
         .await?;
@@ -147,18 +151,10 @@ pub async fn upload_config(op: &Operator) -> Result<(), BackendError> {
 
 pub async fn upload_game_data(
     op: &Operator,
-    game_name: &str,
+    game: &Game,
     max_concurrency: usize,
     token: Option<CancellationToken>,
 ) -> Result<GameSnapshots, SyncOperationError> {
-    let config = get_config().map_err(SyncOperationError::from)?;
-    let game = config
-        .games
-        .iter()
-        .find(|g| g.name == game_name)
-        .ok_or_else(|| BackendError::Unexpected(anyhow::anyhow!("Game '{}' not found", game_name)))
-        .map_err(SyncOperationError::Backend)?;
-
     let dir_name = game.backup_dir_name().into_owned();
     let backup_info = game
         .get_game_snapshots_info()
@@ -311,10 +307,26 @@ async fn replace_directory(stage_dir: &Path, final_dir: &Path) -> Result<(), Bac
     if let Some(parent) = final_dir.parent() {
         fs::create_dir_all(parent).await?;
     }
-    if final_dir.exists() {
-        fs::remove_dir_all(final_dir).await?;
+
+    let rollback_dir = final_dir.with_file_name(stage_dir_name("game-rollback"));
+    if rollback_dir.exists() {
+        fs::remove_dir_all(&rollback_dir).await?;
     }
-    fs::rename(stage_dir, final_dir).await?;
+
+    if final_dir.exists() {
+        fs::rename(final_dir, &rollback_dir).await?;
+    }
+
+    if let Err(err) = fs::rename(stage_dir, final_dir).await {
+        if rollback_dir.exists() {
+            let _ = fs::rename(&rollback_dir, final_dir).await;
+        }
+        return Err(err.into());
+    }
+
+    if rollback_dir.exists() {
+        fs::remove_dir_all(&rollback_dir).await?;
+    }
     Ok(())
 }
 
@@ -326,6 +338,73 @@ pub async fn replace_local_game_from_stage(
     let stage_game_dir = stage_root.join(storage_key);
     let local_game_dir = backup_root.join(storage_key);
     replace_directory(&stage_game_dir, &local_game_dir).await
+}
+
+fn final_snapshot_path(backup_root: &Path, storage_key: &str, snapshot_date: &str) -> String {
+    backup_root
+        .join(storage_key)
+        .join(format!("{snapshot_date}.zip"))
+        .to_string_lossy()
+        .to_string()
+}
+
+async fn rewrite_staged_snapshot_paths(
+    stage_root: &Path,
+    backup_root: &Path,
+    storage_key: &str,
+    info: &mut GameSnapshots,
+) -> Result<(), BackendError> {
+    for snapshot in &mut info.backups {
+        snapshot.path = final_snapshot_path(backup_root, storage_key, &snapshot.date);
+    }
+
+    let metadata_path = stage_root.join(storage_key).join("Backups.json");
+    fs::write(metadata_path, serde_json::to_vec_pretty(info)?).await?;
+    Ok(())
+}
+
+pub async fn replace_local_game_with_remote(
+    session: &crate::cloud_sync::CloudSyncSessionConfig,
+    game: &Game,
+    op: &Operator,
+    stage_prefix: &str,
+    token: Option<CancellationToken>,
+) -> Result<GameSnapshots, SyncOperationError> {
+    let backup_root = get_backup_path().map_err(SyncOperationError::from)?;
+    let storage_key = game.backup_dir_name().into_owned();
+    let stage_root = new_stage_root(&backup_root, stage_prefix);
+    if stage_root.exists() {
+        let _ = fs::remove_dir_all(&stage_root).await;
+    }
+    fs::create_dir_all(&stage_root)
+        .await
+        .map_err(BackendError::from)
+        .map_err(SyncOperationError::Backend)?;
+
+    let result = async {
+        let mut downloaded = stage_remote_game_download(
+            op,
+            &storage_key,
+            &stage_root,
+            session.normalized_max_concurrency(),
+            token,
+        )
+        .await?;
+        rewrite_staged_snapshot_paths(&stage_root, &backup_root, &storage_key, &mut downloaded)
+            .await
+            .map_err(SyncOperationError::Backend)?;
+        replace_local_game_from_stage(&stage_root, &backup_root, &storage_key)
+            .await
+            .map_err(SyncOperationError::Backend)?;
+        Ok(downloaded)
+    }
+    .await;
+
+    if stage_root.exists() {
+        let _ = fs::remove_dir_all(&stage_root).await;
+    }
+
+    result
 }
 
 pub async fn commit_staged_backup_root(

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -41,6 +41,14 @@ pub enum CompressError {
 pub enum BackendError {
     #[error("Backend is disabled")]
     Disabled,
+    #[error("Sync was cancelled")]
+    Cancelled,
+    #[error("Game not found: {0}")]
+    GameNotFound(String),
+    #[error("No unresolved cloud sync conflict for game: {0}")]
+    InvalidConflictState(String),
+    #[error("Unsupported cloud conflict resolution: {0}")]
+    UnsupportedConflictResolution(String),
     #[error("IO error: {0:#?}")]
     Io(#[from] io::Error),
     #[error("Opendal error: {0:#?}")]

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -1,12 +1,29 @@
 use tokio_util::sync::CancellationToken;
 
+use crate::backup::Game;
 use crate::cloud_sync::{
-    BatchSyncReport, CloudSyncSessionConfig, SyncGameOutcome, download_all_from_session,
-    sync_game_from_config, upload_all_from_session,
+    BatchSyncReport, CloudSyncSessionConfig, ConflictResolution, ConflictResolutionOutcome,
+    SyncGameOutcome, download_all_from_session, resolve_game_conflict as resolve_cloud_conflict,
+    sync_config as sync_cloud_config, sync_game as sync_cloud_game, upload_all_from_session,
 };
+use crate::config::{Config, get_config};
+use crate::hooks::{HookSource, MetadataChangedCtx};
 use crate::preclude::BackendError;
 
 use super::ServiceContext;
+
+fn cloud_session(config: &Config) -> CloudSyncSessionConfig {
+    CloudSyncSessionConfig::from(&config.settings.cloud_settings)
+}
+
+fn find_game(config: &Config, game_name: &str) -> Result<Game, BackendError> {
+    config
+        .games
+        .iter()
+        .find(|game| game.name == game_name)
+        .cloned()
+        .ok_or_else(|| BackendError::GameNotFound(game_name.to_string()))
+}
 
 impl ServiceContext {
     pub async fn check_cloud_backend(
@@ -33,6 +50,43 @@ impl ServiceContext {
     }
 
     pub async fn sync_game(&self, game_name: &str) -> Result<SyncGameOutcome, BackendError> {
-        sync_game_from_config(game_name).await
+        let config = get_config()?;
+        let session = cloud_session(&config);
+        let op = session.get_op()?;
+        let game = find_game(&config, game_name)?;
+        sync_cloud_game(&session, &op, &game).await
+    }
+
+    pub async fn resolve_game_conflict(
+        &self,
+        game_name: &str,
+        resolution: ConflictResolution,
+    ) -> Result<ConflictResolutionOutcome, BackendError> {
+        let config = get_config()?;
+        let session = cloud_session(&config);
+        let op = session.get_op()?;
+        let game = find_game(&config, game_name)?;
+        let outcome = resolve_cloud_conflict(&session, &op, &game, resolution).await?;
+
+        if outcome == ConflictResolutionOutcome::AcceptedRemote {
+            let snapshots = game.get_game_snapshots_info()?;
+            self.pipeline()
+                .fire_metadata_changed(&MetadataChangedCtx {
+                    config,
+                    source: HookSource::CloudSync,
+                    game,
+                    snapshots,
+                })
+                .await;
+        }
+
+        Ok(outcome)
+    }
+
+    pub async fn sync_config(&self) -> Result<(), BackendError> {
+        let config = get_config()?;
+        let session = cloud_session(&config);
+        let op = session.get_op()?;
+        sync_cloud_config(&session, &op, &config).await
     }
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -477,6 +477,9 @@
         "backend_hint": "Choose the service backend",
         "sync_success": "Successfully synced",
         "sync_failed": "Sync failed",
+        "config_retry": "Retry",
+        "config_sync_success": "Config synced",
+        "config_sync_failed": "Config sync failed",
         "sync_syncing": "Syncing",
         "notification": "If games are added/removed or settings are changed, you should manually overwrite cloud files. Multi end users should use with caution",
         "start_test": "Start testing. If there is no response for a long time, please check the settings and network connection",
@@ -534,6 +537,27 @@
             "status_disabled": "Disabled",
             "status_conflict": "Conflict",
             "status_unknown": "Unknown"
+        },
+        "conflict": {
+            "title": "Resolve cloud sync conflict",
+            "summary": "{game} has different local and cloud progress. Choose which progress should be kept.",
+            "local_title": "Local progress",
+            "cloud_title": "Cloud progress",
+            "snapshot": "Snapshot",
+            "device": "Device",
+            "current_device": "Current device",
+            "cloud_device": "Cloud",
+            "last_checked": "Last checked",
+            "not_synced": "Not checked yet",
+            "no_snapshot": "No snapshot recorded",
+            "keep_local": "Keep local",
+            "accept_remote": "Use cloud",
+            "decide_later": "Decide later",
+            "resolve": "Resolve",
+            "keep_local_confirm": "Keep local progress for {game}? This uploads local snapshots to cloud and clears the conflict after the upload succeeds.",
+            "accept_remote_confirm": "Use cloud progress for {game}? This replaces local snapshot data with staged cloud data after the download succeeds.",
+            "resolve_success": "Conflict resolved",
+            "resolve_failed": "Conflict resolution failed"
         },
         "backend_tab": {
             "tab": "Backend"

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -477,6 +477,9 @@
         "backend_hint": "选择云存档的服务后端",
         "sync_success": "同步成功",
         "sync_failed": "同步失败",
+        "config_retry": "重试",
+        "config_sync_success": "配置已同步",
+        "config_sync_failed": "配置同步失败",
         "sync_syncing": "同步中",
         "notification": "若增加/减少了游戏或调整了同步设置，则下一次上传会覆盖云端文件，多端用户请小心使用",
         "start_test": "开始测试，若长时间无响应请检查设置和网络连接",
@@ -534,6 +537,27 @@
             "status_disabled": "已禁用",
             "status_conflict": "冲突",
             "status_unknown": "未知"
+        },
+        "conflict": {
+            "title": "解决云同步冲突",
+            "summary": "{game} 的本地进度和云端进度不同，请选择保留哪一边。",
+            "local_title": "本地进度",
+            "cloud_title": "云端进度",
+            "snapshot": "快照",
+            "device": "设备",
+            "current_device": "当前设备",
+            "cloud_device": "云端",
+            "last_checked": "上次检查",
+            "not_synced": "尚未检查",
+            "no_snapshot": "没有记录快照",
+            "keep_local": "保留本地",
+            "accept_remote": "使用云端",
+            "decide_later": "稍后决定",
+            "resolve": "解决",
+            "keep_local_confirm": "确定保留 {game} 的本地进度吗？这会把本地快照上传到云端，上传成功后清除冲突。",
+            "accept_remote_confirm": "确定使用 {game} 的云端进度吗？这会在下载成功后用云端数据替换本地快照数据。",
+            "resolve_success": "冲突已解决",
+            "resolve_failed": "解决冲突失败"
         },
         "backend_tab": {
             "tab": "后端配置"


### PR DESCRIPTION
Follow-up:
- #413 tracks explicit cancel semantics for interrupted cloud sync jobs.
- #415 tracks fork-style cloud sync conflict resolution.
