### PR TITLE
Registry save unit interop

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -207,13 +207,7 @@ pub async fn open_file_or_folder(path: String) -> Result<(), String> {
     info!(target:"rgsm::ipc", "Opening file or folder: {}", path);
 
     let config = get_config().map_err(|e| e.to_string())?;
-    let path = path_resolver::resolve_path(&path, None, &config).map_err(|e| {
-        error!(target:"rgsm::ipc", "Failed to resolve url: {:?}", e);
-        e.to_string()
-    })?;
-
-    debug!(target:"rgsm::ipc", "Resolved url: {}", path.display());
-    rgsm_core::path_launcher::open_path(&path).map_err(|e| {
+    rgsm_core::path_launcher::open_managed_location(&path, None, &config).map_err(|e| {
         error!(target:"rgsm::ipc", "Failed to open file or folder: {:?}", e);
         e.to_string()
     })

--- a/crates/rgsm-core/src/backup/archive/compress.rs
+++ b/crates/rgsm-core/src/backup/archive/compress.rs
@@ -105,8 +105,8 @@ where
     Ok(())
 }
 
-/// Append a Windows Registry save unit: export the key tree to JSON
-/// and store it as `{id}/registry.json` inside the archive.
+/// Append a Windows Registry save unit: export the key tree to a standard
+/// `.reg` file and store it as `{id}/registry.reg` inside the archive.
 fn append_registry_unit<T>(
     writer: &mut ZipWriter<T>,
     save_unit: &SaveUnit,
@@ -127,11 +127,11 @@ where
         }
         Err(e) => return Err(BackupFileError::RegistryError(e.to_string())),
     };
-    let json_bytes =
-        serde_json::to_vec_pretty(&reg_data).map_err(|e| BackupFileError::Unexpected(e.into()))?;
+    let reg_bytes = registry::serialize_reg_file(&reg_data)
+        .map_err(|e| BackupFileError::RegistryError(e.to_string()))?;
     write_bytes_entry(
         writer,
-        &json_bytes,
+        &reg_bytes,
         &id_prefix.join(registry::REGISTRY_DATA_FILENAME),
         preset,
     )

--- a/crates/rgsm-core/src/backup/archive/decompress.rs
+++ b/crates/rgsm-core/src/backup/archive/decompress.rs
@@ -236,8 +236,9 @@ fn emit_skip_notification(
 
 /// Restore a Windows Registry save unit from the extracted temp directory.
 ///
-/// Reads `{id}/registry.json`, parses it, and imports the values back into
-/// the Windows Registry. On non-Windows platforms the restore is skipped.
+/// Reads `{id}/registry.reg` (or legacy `{id}/registry.json`), parses it, and
+/// imports the values back into the Windows Registry. On non-Windows platforms
+/// the restore is skipped.
 fn restore_registry_unit(
     unit: &SaveUnit,
     version: ArchiveVersion,
@@ -249,17 +250,23 @@ fn restore_registry_unit(
         return Ok(RestoreOutcome::Skipped(SkipReason::LegacyArchiveFormat));
     }
 
-    let reg_json_path = temp_root
-        .join(unit.id.to_string())
-        .join(registry::REGISTRY_DATA_FILENAME);
+    let reg_unit_root = temp_root.join(unit.id.to_string());
+    let reg_path = reg_unit_root.join(registry::REGISTRY_DATA_FILENAME);
+    let legacy_json_path = reg_unit_root.join(registry::LEGACY_REGISTRY_DATA_FILENAME);
 
-    if !reg_json_path.exists() {
+    if !reg_path.exists() && !legacy_json_path.exists() {
         return Ok(RestoreOutcome::Skipped(SkipReason::MissingArchiveEntry));
     }
 
-    let json_bytes = fs::read(&reg_json_path)?;
-    let reg_data: registry::RegistryData =
-        serde_json::from_slice(&json_bytes).map_err(|e| BackupFileError::Unexpected(e.into()))?;
+    let reg_data = if reg_path.exists() {
+        let reg_bytes = fs::read(&reg_path)?;
+        registry::deserialize_reg_file(&reg_bytes)
+            .map_err(|e| BackupFileError::RegistryError(e.to_string()))?
+    } else {
+        let json_bytes = fs::read(&legacy_json_path)?;
+        serde_json::from_slice::<registry::RegistryData>(&json_bytes)
+            .map_err(|e| BackupFileError::Unexpected(e.into()))?
+    };
 
     match registry::import_registry_data(&reg_data) {
         Ok(()) => Ok(RestoreOutcome::Restored),

--- a/crates/rgsm-core/src/backup/registry.rs
+++ b/crates/rgsm-core/src/backup/registry.rs
@@ -1,8 +1,8 @@
 //! Windows Registry export and import for `SaveUnitType::WinRegistry`.
 //!
-//! Registry data is serialized as JSON (`RegistryData`) and stored inside
-//! the ZIP archive at `{save_unit_id}/registry.json`. The JSON format uses
-//! a `format_version` field for future-proofing.
+//! Registry data is represented as `RegistryData` internally and stored inside
+//! new ZIP archives at `{save_unit_id}/registry.reg`. Legacy `registry.json`
+//! archive entries remain readable for backward compatibility.
 //!
 //! On non-Windows platforms, export/import return `RegistryError::UnsupportedPlatform`.
 
@@ -10,6 +10,10 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use specta::Type;
+
+mod reg_file;
+
+pub use reg_file::{deserialize_reg_file, serialize_reg_file};
 
 /// Root structure for serialized registry data inside an archive.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -43,8 +47,46 @@ pub enum RegistryValue {
     Binary { name: String, data: String },
 }
 
-/// Name of the registry data file inside a save-unit's ZIP directory.
-pub const REGISTRY_DATA_FILENAME: &str = "registry.json";
+/// Name of the standard registry data file inside a save-unit's ZIP directory.
+pub const REGISTRY_DATA_FILENAME: &str = "registry.reg";
+
+/// Legacy registry data file used by older archives.
+pub const LEGACY_REGISTRY_DATA_FILENAME: &str = "registry.json";
+
+const HIVE_PREFIXES: [&str; 5] = [
+    "HKEY_CURRENT_USER",
+    "HKEY_LOCAL_MACHINE",
+    "HKEY_CLASSES_ROOT",
+    "HKEY_USERS",
+    "HKEY_CURRENT_CONFIG",
+];
+
+pub fn is_registry_path(path: &str) -> bool {
+    let normalized = normalize_registry_path(path);
+    let upper = normalized.to_ascii_uppercase();
+    HIVE_PREFIXES.iter().any(|prefix| {
+        upper == *prefix
+            || upper
+                .strip_prefix(prefix)
+                .is_some_and(|rest| rest.starts_with('\\'))
+    })
+}
+
+pub fn normalize_registry_path(path: &str) -> String {
+    let trimmed = path.trim();
+    let without_prefix = if trimmed
+        .get(.."REGISTRY:".len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("REGISTRY:"))
+    {
+        &trimmed["REGISTRY:".len()..]
+    } else {
+        trimmed
+    };
+
+    without_prefix
+        .trim_start_matches(['/', '\\'])
+        .replace('/', "\\")
+}
 
 // ── Error type ──────────────────────────────────────────────────────────────
 
@@ -64,6 +106,10 @@ pub enum RegistryError {
     Json(#[from] serde_json::Error),
     #[error("Base64 decode error: {0}")]
     Base64(#[from] base64::DecodeError),
+    #[error("Invalid registry file: {0}")]
+    InvalidRegFile(String),
+    #[error("Unsupported registry file value type: {0}")]
+    UnsupportedRegValueType(String),
     #[cfg(target_os = "windows")]
     #[error(
         "Invalid registry value data length for '{name}': expected at least {expected} bytes, got {actual}"
@@ -102,10 +148,7 @@ mod platform {
     ///
     /// Also handles the Ludusavi `"REGISTRY:"` prefix format and normalizes `/` to `\`.
     pub(crate) fn parse_registry_path(path: &str) -> Result<(winreg::HKEY, String), RegistryError> {
-        // Strip optional Ludusavi "REGISTRY:" prefix
-        let path = path.strip_prefix("REGISTRY:").unwrap_or(path);
-        let path = path.trim_start_matches(['/', '\\']);
-        let path = path.replace('/', "\\");
+        let path = normalize_registry_path(path);
 
         let sep = path
             .find('\\')

--- a/crates/rgsm-core/src/backup/registry/reg_file.rs
+++ b/crates/rgsm-core/src/backup/registry/reg_file.rs
@@ -1,0 +1,566 @@
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use std::fmt::Write as _;
+
+use super::{
+    RegistryData, RegistryError, RegistryKeyEntry, RegistryValue, normalize_registry_path,
+};
+
+const REG_FILE_HEADER: &str = "Windows Registry Editor Version 5.00";
+
+pub fn serialize_reg_file(data: &RegistryData) -> Result<Vec<u8>, RegistryError> {
+    let text = serialize_reg_text(data)?;
+    Ok(encode_utf16le_with_bom(&text))
+}
+
+pub fn deserialize_reg_file(bytes: &[u8]) -> Result<RegistryData, RegistryError> {
+    let text = decode_reg_file_text(bytes)?;
+    deserialize_reg_text(&text)
+}
+
+fn serialize_reg_text(data: &RegistryData) -> Result<String, RegistryError> {
+    let root_key = normalize_registry_path(&data.root_key);
+    if root_key.is_empty() {
+        return Err(RegistryError::InvalidRegFile(
+            "registry root key cannot be empty".to_string(),
+        ));
+    }
+
+    let mut out = String::new();
+    writeln!(out, "{REG_FILE_HEADER}\r").expect("writing to String cannot fail");
+
+    for entry in &data.entries {
+        writeln!(out).expect("writing to String cannot fail");
+        writeln!(out, "[{}]\r", entry_key_path(&root_key, &entry.subkey))
+            .expect("writing to String cannot fail");
+        for value in &entry.values {
+            writeln!(out, "{}\r", serialize_value(value)?).expect("writing to String cannot fail");
+        }
+    }
+
+    Ok(out)
+}
+
+fn encode_utf16le_with_bom(text: &str) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(2 + text.len() * 2);
+    bytes.extend_from_slice(&[0xff, 0xfe]);
+    for unit in text.encode_utf16() {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    bytes
+}
+
+fn decode_reg_file_text(bytes: &[u8]) -> Result<String, RegistryError> {
+    if let Some(rest) = bytes.strip_prefix(&[0xff, 0xfe]) {
+        return decode_utf16_units(rest, u16::from_le_bytes);
+    }
+    if let Some(rest) = bytes.strip_prefix(&[0xfe, 0xff]) {
+        return decode_utf16_units(rest, u16::from_be_bytes);
+    }
+
+    String::from_utf8(bytes.to_vec())
+        .map_err(|e| RegistryError::InvalidRegFile(format!("invalid UTF-8 registry file: {e}")))
+}
+
+fn decode_utf16_units(
+    bytes: &[u8],
+    read_unit: fn([u8; 2]) -> u16,
+) -> Result<String, RegistryError> {
+    if bytes.len() % 2 != 0 {
+        return Err(RegistryError::InvalidRegFile(
+            "UTF-16 registry file has an odd byte length".to_string(),
+        ));
+    }
+
+    let units = bytes
+        .chunks_exact(2)
+        .map(|chunk| read_unit([chunk[0], chunk[1]]))
+        .collect::<Vec<_>>();
+    String::from_utf16(&units)
+        .map_err(|e| RegistryError::InvalidRegFile(format!("invalid UTF-16 registry file: {e}")))
+}
+
+fn entry_key_path(root_key: &str, subkey: &str) -> String {
+    let subkey = normalize_registry_path(subkey);
+    if subkey.is_empty() {
+        root_key.to_string()
+    } else {
+        format!("{root_key}\\{subkey}")
+    }
+}
+
+fn serialize_value(value: &RegistryValue) -> Result<String, RegistryError> {
+    let (name, body) = match value {
+        RegistryValue::Sz { name, data } => (
+            serialize_value_name(name),
+            format!("\"{}\"", escape_string(data)),
+        ),
+        RegistryValue::ExpandSz { name, data } => (
+            serialize_value_name(name),
+            format!("hex(2):{}", format_hex_bytes(&string_to_reg_sz_bytes(data))),
+        ),
+        RegistryValue::MultiSz { name, data } => (
+            serialize_value_name(name),
+            format!("hex(7):{}", format_hex_bytes(&multi_sz_to_bytes(data))),
+        ),
+        RegistryValue::Dword { name, data } => {
+            (serialize_value_name(name), format!("dword:{data:08x}"))
+        }
+        RegistryValue::Qword { name, data } => (
+            serialize_value_name(name),
+            format!("hex(b):{}", format_hex_bytes(&data.to_le_bytes())),
+        ),
+        RegistryValue::Binary { name, data } => {
+            let bytes = BASE64.decode(data)?;
+            (
+                serialize_value_name(name),
+                format!("hex:{}", format_hex_bytes(&bytes)),
+            )
+        }
+    };
+
+    Ok(format!("{name}={body}"))
+}
+
+fn serialize_value_name(name: &str) -> String {
+    if name.is_empty() {
+        "@".to_string()
+    } else {
+        format!("\"{}\"", escape_string(name))
+    }
+}
+
+fn escape_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn string_to_reg_sz_bytes(value: &str) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for unit in value.encode_utf16().chain(std::iter::once(0)) {
+        bytes.extend_from_slice(&unit.to_le_bytes());
+    }
+    bytes
+}
+
+fn multi_sz_to_bytes(values: &[String]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    for value in values {
+        for unit in value.encode_utf16().chain(std::iter::once(0)) {
+            bytes.extend_from_slice(&unit.to_le_bytes());
+        }
+    }
+    bytes.extend_from_slice(&0u16.to_le_bytes());
+    bytes
+}
+
+fn format_hex_bytes(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn deserialize_reg_text(text: &str) -> Result<RegistryData, RegistryError> {
+    let lines = logical_lines(text);
+    let mut iter = lines
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty() && !line.starts_with(';'));
+
+    let Some(header) = iter.next() else {
+        return Err(RegistryError::InvalidRegFile(
+            "registry file is empty".to_string(),
+        ));
+    };
+    if header != REG_FILE_HEADER {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "missing {REG_FILE_HEADER} header"
+        )));
+    }
+
+    let mut root_key: Option<String> = None;
+    let mut current_entry: Option<RegistryKeyEntry> = None;
+    let mut entries = Vec::new();
+
+    for line in iter {
+        if let Some(key) = parse_key_header(line)? {
+            if let Some(entry) = current_entry.take() {
+                entries.push(entry);
+            }
+
+            let normalized_key = normalize_registry_path(&key);
+            let root = root_key.get_or_insert_with(|| normalized_key.clone());
+            let subkey = relative_subkey(root, &normalized_key)?;
+            current_entry = Some(RegistryKeyEntry {
+                subkey,
+                values: Vec::new(),
+            });
+            continue;
+        }
+
+        let Some(entry) = current_entry.as_mut() else {
+            return Err(RegistryError::InvalidRegFile(
+                "value appears before any registry key header".to_string(),
+            ));
+        };
+        entry.values.push(parse_value_line(line)?);
+    }
+
+    if let Some(entry) = current_entry {
+        entries.push(entry);
+    }
+
+    let root_key =
+        root_key.ok_or_else(|| RegistryError::InvalidRegFile("missing key header".to_string()))?;
+
+    Ok(RegistryData {
+        format_version: 1,
+        root_key,
+        entries,
+    })
+}
+
+fn logical_lines(text: &str) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for raw in text.lines() {
+        let line = raw.trim_end_matches('\r');
+        let trimmed = line.trim_end();
+        if trimmed.ends_with('\\') {
+            current.push_str(trimmed.trim_end_matches('\\').trim_end());
+            continue;
+        }
+
+        current.push_str(line.trim());
+        lines.push(std::mem::take(&mut current));
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    lines
+}
+
+fn parse_key_header(line: &str) -> Result<Option<String>, RegistryError> {
+    if !line.starts_with('[') {
+        return Ok(None);
+    }
+    if !line.ends_with(']') {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "invalid registry key header: {line}"
+        )));
+    }
+    if line.starts_with("[-") {
+        return Err(RegistryError::UnsupportedRegValueType(
+            "key deletion entries are not supported".to_string(),
+        ));
+    }
+
+    Ok(Some(line[1..line.len() - 1].to_string()))
+}
+
+fn relative_subkey(root: &str, key: &str) -> Result<String, RegistryError> {
+    if key == root {
+        return Ok(String::new());
+    }
+
+    let prefix = format!("{root}\\");
+    key.strip_prefix(&prefix)
+        .map(ToString::to_string)
+        .ok_or_else(|| {
+            RegistryError::InvalidRegFile(format!(
+                "registry key '{key}' is outside root key '{root}'"
+            ))
+        })
+}
+
+fn parse_value_line(line: &str) -> Result<RegistryValue, RegistryError> {
+    let (name, body) = parse_value_assignment(line)?;
+    if let Some(rest) = body.strip_prefix('"') {
+        let (data, trailing) = parse_quoted_after_open_quote(rest)?;
+        ensure_blank(trailing, "string value")?;
+        return Ok(RegistryValue::Sz { name, data });
+    }
+
+    let lower = body.to_ascii_lowercase();
+    if let Some(hex) = lower.strip_prefix("dword:") {
+        let data = u32::from_str_radix(hex, 16).map_err(|e| {
+            RegistryError::InvalidRegFile(format!("invalid DWORD value '{body}': {e}"))
+        })?;
+        return Ok(RegistryValue::Dword { name, data });
+    }
+
+    if lower.starts_with("hex") {
+        return parse_hex_value(name, body);
+    }
+
+    Err(RegistryError::UnsupportedRegValueType(body.to_string()))
+}
+
+fn parse_value_assignment(line: &str) -> Result<(String, &str), RegistryError> {
+    if let Some(rest) = line.strip_prefix('@') {
+        let rest = rest.trim_start();
+        let Some(body) = rest.strip_prefix('=') else {
+            return Err(RegistryError::InvalidRegFile(format!(
+                "invalid default value assignment: {line}"
+            )));
+        };
+        return Ok((String::new(), body.trim_start()));
+    }
+
+    let Some(rest) = line.strip_prefix('"') else {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "invalid registry value name: {line}"
+        )));
+    };
+    let (name, trailing) = parse_quoted_after_open_quote(rest)?;
+    let trailing = trailing.trim_start();
+    let Some(body) = trailing.strip_prefix('=') else {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "missing '=' after registry value name: {line}"
+        )));
+    };
+
+    Ok((name, body.trim_start()))
+}
+
+fn parse_quoted_after_open_quote(input: &str) -> Result<(String, &str), RegistryError> {
+    let mut escaped = false;
+    let mut out = String::new();
+
+    for (index, ch) in input.char_indices() {
+        if escaped {
+            out.push(ch);
+            escaped = false;
+            continue;
+        }
+
+        match ch {
+            '\\' => escaped = true,
+            '"' => return Ok((out, &input[index + ch.len_utf8()..])),
+            _ => out.push(ch),
+        }
+    }
+
+    Err(RegistryError::InvalidRegFile(
+        "unterminated quoted string".to_string(),
+    ))
+}
+
+fn ensure_blank(trailing: &str, context: &str) -> Result<(), RegistryError> {
+    if trailing.trim().is_empty() {
+        Ok(())
+    } else {
+        Err(RegistryError::InvalidRegFile(format!(
+            "unexpected trailing data after {context}: {trailing}"
+        )))
+    }
+}
+
+fn parse_hex_value(name: String, body: &str) -> Result<RegistryValue, RegistryError> {
+    let Some((kind, bytes_text)) = body.split_once(':') else {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "invalid hex registry value: {body}"
+        )));
+    };
+    let bytes = parse_hex_bytes(bytes_text)?;
+    match kind.to_ascii_lowercase().as_str() {
+        "hex" => Ok(RegistryValue::Binary {
+            name,
+            data: BASE64.encode(bytes),
+        }),
+        "hex(2)" => Ok(RegistryValue::ExpandSz {
+            name,
+            data: decode_reg_sz_bytes(&bytes)?,
+        }),
+        "hex(7)" => Ok(RegistryValue::MultiSz {
+            name,
+            data: decode_multi_sz_bytes(&bytes)?,
+        }),
+        "hex(b)" => {
+            let data = bytes
+                .as_slice()
+                .try_into()
+                .map(u64::from_le_bytes)
+                .map_err(|_| {
+                    RegistryError::InvalidRegFile(format!(
+                        "QWORD value must contain 8 bytes, got {}",
+                        bytes.len()
+                    ))
+                })?;
+            Ok(RegistryValue::Qword { name, data })
+        }
+        other => Err(RegistryError::UnsupportedRegValueType(other.to_string())),
+    }
+}
+
+fn parse_hex_bytes(input: &str) -> Result<Vec<u8>, RegistryError> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            u8::from_str_radix(part, 16).map_err(|e| {
+                RegistryError::InvalidRegFile(format!("invalid hex byte '{part}': {e}"))
+            })
+        })
+        .collect()
+}
+
+fn decode_reg_sz_bytes(bytes: &[u8]) -> Result<String, RegistryError> {
+    let mut units = decode_utf16le_bytes(bytes)?;
+    while units.last() == Some(&0) {
+        units.pop();
+    }
+    String::from_utf16(&units)
+        .map_err(|e| RegistryError::InvalidRegFile(format!("invalid REG_SZ data: {e}")))
+}
+
+fn decode_multi_sz_bytes(bytes: &[u8]) -> Result<Vec<String>, RegistryError> {
+    let units = decode_utf16le_bytes(bytes)?;
+    let mut values = Vec::new();
+    let mut start = 0;
+
+    for (index, unit) in units.iter().enumerate() {
+        if *unit != 0 {
+            continue;
+        }
+        if index == start {
+            break;
+        }
+        values.push(String::from_utf16(&units[start..index]).map_err(|e| {
+            RegistryError::InvalidRegFile(format!("invalid REG_MULTI_SZ data: {e}"))
+        })?);
+        start = index + 1;
+    }
+
+    Ok(values)
+}
+
+fn decode_utf16le_bytes(bytes: &[u8]) -> Result<Vec<u16>, RegistryError> {
+    if bytes.len() % 2 != 0 {
+        return Err(RegistryError::InvalidRegFile(format!(
+            "UTF-16 value has odd byte length {}",
+            bytes.len()
+        )));
+    }
+
+    Ok(bytes
+        .chunks_exact(2)
+        .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_registry_data() -> RegistryData {
+        RegistryData {
+            format_version: 1,
+            root_key: "REGISTRY:HKEY_CURRENT_USER/Software/RGSM Test".to_string(),
+            entries: vec![
+                RegistryKeyEntry {
+                    subkey: String::new(),
+                    values: vec![
+                        RegistryValue::Sz {
+                            name: String::new(),
+                            data: "default value".to_string(),
+                        },
+                        RegistryValue::ExpandSz {
+                            name: "InstallDir".to_string(),
+                            data: "%USERPROFILE%\\Game".to_string(),
+                        },
+                        RegistryValue::MultiSz {
+                            name: "Profiles".to_string(),
+                            data: vec!["alpha".to_string(), "beta".to_string()],
+                        },
+                        RegistryValue::Dword {
+                            name: "Enabled".to_string(),
+                            data: 1,
+                        },
+                        RegistryValue::Qword {
+                            name: "Ticks".to_string(),
+                            data: 9_999_999_999,
+                        },
+                        RegistryValue::Binary {
+                            name: "Blob".to_string(),
+                            data: BASE64.encode([0, 1, 2, 0xff]),
+                        },
+                    ],
+                },
+                RegistryKeyEntry {
+                    subkey: "Child".to_string(),
+                    values: vec![RegistryValue::Sz {
+                        name: "Quoted".to_string(),
+                        data: "a \"quote\" and slash \\".to_string(),
+                    }],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn registry_data_reg_file_roundtrip() {
+        let original = sample_registry_data();
+        let bytes = serialize_reg_file(&original).unwrap();
+        assert!(bytes.starts_with(&[0xff, 0xfe]));
+
+        let parsed = deserialize_reg_file(&bytes).unwrap();
+        assert_eq!(
+            parsed.root_key,
+            "HKEY_CURRENT_USER\\Software\\RGSM Test".to_string()
+        );
+        assert_eq!(parsed.entries, original.entries);
+    }
+
+    #[test]
+    fn parses_utf8_reg_file_with_continued_hex_lines() {
+        let text = r#"Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\RGSM Test]
+"Blob"=hex:00,01,\
+  02,ff
+"Enabled"=dword:0000002a
+"Name"="Game"
+"Path"=hex(2):25,00,55,00,53,00,45,00,52,00,50,00,52,00,4f,00,46,00,49,00,4c,00,45,00,25,00,00,00
+"Profiles"=hex(7):61,00,00,00,62,00,00,00,00,00
+"Ticks"=hex(b):ff,e3,0b,54,02,00,00,00
+"#;
+
+        let parsed = deserialize_reg_file(text.as_bytes()).unwrap();
+        assert_eq!(parsed.root_key, "HKEY_CURRENT_USER\\Software\\RGSM Test");
+        assert_eq!(parsed.entries.len(), 1);
+        assert_eq!(
+            parsed.entries[0].values,
+            vec![
+                RegistryValue::Binary {
+                    name: "Blob".to_string(),
+                    data: BASE64.encode([0, 1, 2, 0xff]),
+                },
+                RegistryValue::Dword {
+                    name: "Enabled".to_string(),
+                    data: 42,
+                },
+                RegistryValue::Sz {
+                    name: "Name".to_string(),
+                    data: "Game".to_string(),
+                },
+                RegistryValue::ExpandSz {
+                    name: "Path".to_string(),
+                    data: "%USERPROFILE%".to_string(),
+                },
+                RegistryValue::MultiSz {
+                    name: "Profiles".to_string(),
+                    data: vec!["a".to_string(), "b".to_string()],
+                },
+                RegistryValue::Qword {
+                    name: "Ticks".to_string(),
+                    data: 9_999_999_999,
+                },
+            ]
+        );
+    }
+}

--- a/crates/rgsm-core/src/backup/save_unit.rs
+++ b/crates/rgsm-core/src/backup/save_unit.rs
@@ -13,7 +13,7 @@ use crate::preclude::BackupFileError;
 pub enum SaveUnitType {
     File,
     Folder,
-    /// Windows Registry key tree (stored as `registry.json` inside the archive).
+    /// Windows Registry key tree (stored as `registry.reg` inside new archives).
     WinRegistry,
 }
 

--- a/crates/rgsm-core/src/backup/tests/mod.rs
+++ b/crates/rgsm-core/src/backup/tests/mod.rs
@@ -1,3 +1,4 @@
 mod archive;
 mod game;
+mod registry_archive;
 mod utils;

--- a/crates/rgsm-core/src/backup/tests/registry_archive.rs
+++ b/crates/rgsm-core/src/backup/tests/registry_archive.rs
@@ -1,0 +1,205 @@
+#[cfg(target_os = "windows")]
+mod tests {
+    use super::super::utils::{ConfigFileGuard, lock_config_file};
+    use crate::backup::archive::{
+        ArchiveMeta, CompressionPreset, compress_to_file, decompress_from_file,
+    };
+    use crate::backup::{SaveUnit, SaveUnitType};
+    use crate::device::get_current_device_id;
+    use std::{
+        collections::HashMap,
+        fs::{self, File},
+        io::{Read, Write},
+        time::SystemTime,
+    };
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
+    use zip::{ZipWriter, write::SimpleFileOptions};
+
+    fn build_registry_save_unit_with_id(path: &str, id: u32) -> SaveUnit {
+        let mut paths = HashMap::new();
+        paths.insert(get_current_device_id().clone(), path.to_string());
+        SaveUnit {
+            id,
+            unit_type: SaveUnitType::WinRegistry,
+            paths,
+            delete_before_apply: false,
+            enabled: true,
+        }
+    }
+
+    fn unique_registry_path(prefix: &str) -> Result<(String, String), Box<dyn std::error::Error>> {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_nanos();
+        let subkey = format!("Software\\{prefix}_{unique}");
+        let path = format!("HKEY_CURRENT_USER\\{subkey}");
+        Ok((subkey, path))
+    }
+
+    #[test]
+    fn registry_snapshot_writes_reg_file() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backup::registry;
+
+        let _config_lock = lock_config_file();
+        let _config_guard = ConfigFileGuard::write_default_config()?;
+
+        let temp_dir = temp_dir::TempDir::new()?;
+        let temp_path = temp_dir.path();
+        let backup_dir = temp_path.join("backup");
+        fs::create_dir_all(&backup_dir)?;
+        let zip_path = backup_dir.join("registry_reg_entry.zip");
+
+        let (reg_subkey, reg_path) = unique_registry_path("RGSM_REG_ENTRY")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let (key, _) = hkcu.create_subkey(&reg_subkey)?;
+            key.set_value("ManualRestore", &"standard-reg-file")?;
+
+            let save_units = [build_registry_save_unit_with_id(&reg_path, 0)];
+            compress_to_file(&save_units, &zip_path, CompressionPreset::Standard, None)?;
+
+            let zip_file = File::open(&zip_path)?;
+            let mut archive = zip::ZipArchive::new(zip_file)?;
+            assert!(archive.by_name("0/registry.reg").is_ok());
+            assert!(archive.by_name("0/registry.json").is_err());
+
+            let mut reg_entry = archive.by_name("0/registry.reg")?;
+            let mut reg_bytes = Vec::new();
+            reg_entry.read_to_end(&mut reg_bytes)?;
+            let parsed = registry::deserialize_reg_file(&reg_bytes)?;
+            assert_eq!(parsed.root_key, reg_path);
+            assert!(
+                parsed.entries[0].values.iter().any(
+                    |value| matches!(value, registry::RegistryValue::Sz { name, data } if name == "ManualRestore" && data == "standard-reg-file")
+                )
+            );
+            Ok(())
+        })();
+
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+        result
+    }
+
+    #[test]
+    fn registry_restore_reads_legacy_json_entry() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backup::registry::{RegistryData, RegistryKeyEntry, RegistryValue};
+
+        let _config_lock = lock_config_file();
+        let _config_guard = ConfigFileGuard::write_default_config()?;
+
+        let temp_dir = temp_dir::TempDir::new()?;
+        let temp_path = temp_dir.path();
+        let backup_dir = temp_path.join("backup");
+        fs::create_dir_all(&backup_dir)?;
+        let date = "legacy_registry_json";
+        let zip_path = backup_dir.join(format!("{date}.zip"));
+
+        let (reg_subkey, reg_path) = unique_registry_path("RGSM_LEGACY_JSON")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let legacy_data = RegistryData {
+                format_version: 1,
+                root_key: reg_path.clone(),
+                entries: vec![RegistryKeyEntry {
+                    subkey: String::new(),
+                    values: vec![RegistryValue::Sz {
+                        name: "Restored".to_string(),
+                        data: "from-json".to_string(),
+                    }],
+                }],
+            };
+
+            let mut zip_writer = ZipWriter::new(File::create(&zip_path)?);
+            zip_writer.start_file(
+                "0/registry.json",
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Bzip2),
+            )?;
+            zip_writer.write_all(&serde_json::to_vec_pretty(&legacy_data)?)?;
+            zip_writer.set_comment(ArchiveMeta::new(CompressionPreset::Standard).to_comment());
+            zip_writer.finish()?;
+
+            let save_units = [build_registry_save_unit_with_id(&reg_path, 0)];
+            decompress_from_file(&save_units, &backup_dir, date, None)?;
+
+            let restored_key = hkcu.open_subkey(&reg_subkey)?;
+            let restored: String = restored_key.get_value("Restored")?;
+            assert_eq!(restored, "from-json");
+            Ok(())
+        })();
+
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+        result
+    }
+
+    #[test]
+    fn registry_restore_prefers_reg_entry() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backup::registry::{
+            RegistryData, RegistryKeyEntry, RegistryValue, serialize_reg_file,
+        };
+
+        let _config_lock = lock_config_file();
+        let _config_guard = ConfigFileGuard::write_default_config()?;
+
+        let temp_dir = temp_dir::TempDir::new()?;
+        let temp_path = temp_dir.path();
+        let backup_dir = temp_path.join("backup");
+        fs::create_dir_all(&backup_dir)?;
+        let date = "prefer_registry_reg";
+        let zip_path = backup_dir.join(format!("{date}.zip"));
+
+        let (reg_subkey, reg_path) = unique_registry_path("RGSM_PREFER_REG")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let reg_data = RegistryData {
+                format_version: 1,
+                root_key: reg_path.clone(),
+                entries: vec![RegistryKeyEntry {
+                    subkey: String::new(),
+                    values: vec![RegistryValue::Sz {
+                        name: "Restored".to_string(),
+                        data: "from-reg".to_string(),
+                    }],
+                }],
+            };
+            let legacy_data = RegistryData {
+                format_version: 1,
+                root_key: reg_path.clone(),
+                entries: vec![RegistryKeyEntry {
+                    subkey: String::new(),
+                    values: vec![RegistryValue::Sz {
+                        name: "Restored".to_string(),
+                        data: "from-json".to_string(),
+                    }],
+                }],
+            };
+
+            let mut zip_writer = ZipWriter::new(File::create(&zip_path)?);
+            let options =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Bzip2);
+            zip_writer.start_file("0/registry.reg", options)?;
+            zip_writer.write_all(&serialize_reg_file(&reg_data)?)?;
+            zip_writer.start_file("0/registry.json", options)?;
+            zip_writer.write_all(&serde_json::to_vec_pretty(&legacy_data)?)?;
+            zip_writer.set_comment(ArchiveMeta::new(CompressionPreset::Standard).to_comment());
+            zip_writer.finish()?;
+
+            let save_units = [build_registry_save_unit_with_id(&reg_path, 0)];
+            decompress_from_file(&save_units, &backup_dir, date, None)?;
+
+            let restored_key = hkcu.open_subkey(&reg_subkey)?;
+            let restored: String = restored_key.get_value("Restored")?;
+            assert_eq!(restored, "from-reg");
+            Ok(())
+        })();
+
+        let _ = hkcu.delete_subkey_all(&reg_subkey);
+        result
+    }
+}

--- a/crates/rgsm-core/src/path_launcher.rs
+++ b/crates/rgsm-core/src/path_launcher.rs
@@ -2,10 +2,19 @@ use anyhow::{Context, Result};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use crate::config::Config;
+use crate::path_resolver::{self, PathContext};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum LaunchStrategy {
     OpenWithSystem,
     RunDirectly { working_dir: PathBuf },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ManagedLaunchTarget {
+    Filesystem(PathBuf),
+    Registry(String),
 }
 
 pub fn open_path(path: &Path) -> Result<()> {
@@ -30,6 +39,17 @@ pub fn open_path(path: &Path) -> Result<()> {
     Ok(())
 }
 
+pub fn open_managed_location(
+    raw_path: &str,
+    path_ctx: Option<&PathContext>,
+    config: &Config,
+) -> Result<()> {
+    match managed_launch_target(raw_path, path_ctx, config)? {
+        ManagedLaunchTarget::Filesystem(path) => open_path(&path),
+        ManagedLaunchTarget::Registry(path) => open_registry_key(&path),
+    }
+}
+
 fn launch_strategy(path: &Path) -> LaunchStrategy {
     if should_run_directly(path) {
         let working_dir = path
@@ -40,6 +60,50 @@ fn launch_strategy(path: &Path) -> LaunchStrategy {
     } else {
         LaunchStrategy::OpenWithSystem
     }
+}
+
+fn managed_launch_target(
+    raw_path: &str,
+    path_ctx: Option<&PathContext>,
+    config: &Config,
+) -> Result<ManagedLaunchTarget> {
+    if crate::backup::registry::is_registry_path(raw_path) {
+        return Ok(ManagedLaunchTarget::Registry(
+            crate::backup::registry::normalize_registry_path(raw_path),
+        ));
+    }
+
+    let path = path_resolver::resolve_path(raw_path, path_ctx, config)
+        .with_context(|| format!("Failed to resolve path '{raw_path}'"))?;
+    Ok(ManagedLaunchTarget::Filesystem(path))
+}
+
+#[cfg(target_os = "windows")]
+fn open_registry_key(path: &str) -> Result<()> {
+    use winreg::RegKey;
+    use winreg::enums::HKEY_CURRENT_USER;
+
+    let last_key = format!(
+        "Computer\\{}",
+        crate::backup::registry::normalize_registry_path(path)
+    );
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let (regedit_key, _) = hkcu
+        .create_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit")
+        .context("Failed to open Regedit state key")?;
+    regedit_key
+        .set_value("LastKey", &last_key)
+        .context("Failed to set Regedit LastKey")?;
+
+    Command::new("regedit.exe")
+        .spawn()
+        .context("Failed to launch regedit.exe")?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn open_registry_key(_path: &str) -> Result<()> {
+    anyhow::bail!("Registry paths are not supported on this platform")
 }
 
 #[cfg(target_os = "windows")]
@@ -68,7 +132,8 @@ fn should_run_directly(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{LaunchStrategy, launch_strategy};
+    use super::{LaunchStrategy, ManagedLaunchTarget, launch_strategy, managed_launch_target};
+    use crate::config::Config;
     use std::fs;
     use temp_dir::TempDir;
 
@@ -131,5 +196,27 @@ mod tests {
             launch_strategy(&shortcut_path),
             LaunchStrategy::OpenWithSystem
         );
+    }
+
+    #[test]
+    fn routes_registry_locations_without_filesystem_resolution() {
+        let target = managed_launch_target(
+            "REGISTRY:HKEY_CURRENT_USER/Software/RGSM Test",
+            None,
+            &Config::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            target,
+            ManagedLaunchTarget::Registry("HKEY_CURRENT_USER\\Software\\RGSM Test".to_string())
+        );
+    }
+
+    #[test]
+    fn routes_filesystem_locations_through_path_resolution() {
+        let target = managed_launch_target("<home>", None, &Config::default()).unwrap();
+
+        assert!(matches!(target, ManagedLaunchTarget::Filesystem(_)));
     }
 }

--- a/crates/rgsm-core/src/path_resolver.rs
+++ b/crates/rgsm-core/src/path_resolver.rs
@@ -72,7 +72,7 @@ pub enum PathCheckResult {
 /// Check a single path: resolve variables and check filesystem status
 pub fn check_path(raw_path: &str, ctx: Option<&PathContext>, config: &Config) -> PathCheckResult {
     // Handle registry paths
-    if raw_path.starts_with("REGISTRY:") || raw_path.starts_with("HKEY_") {
+    if crate::backup::registry::is_registry_path(raw_path) {
         #[cfg(target_os = "windows")]
         {
             let exists = crate::backup::registry::registry_key_exists(raw_path).unwrap_or(false);


### PR DESCRIPTION
Closes #347.
Closes #351.

- Store registry snapshots as `.reg` with legacy `registry.json` restore fallback.
- Open registry Save Units from managed locations on Windows.