### PR TITLE
Fix registry open button

### DIFF
--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -629,7 +629,13 @@ devices?: Partial<{ [key in string]: Device }> }
 /**
  * What the user chose to do when a conflict is detected.
  */
-export type ConflictResolution = "keep_local" | "accept_remote" | "fork" | "cancelled"
+export type ConflictResolution = "keep_local" | "accept_remote" | 
+/**
+ * Preserve both local and remote branches without merging.
+ * 
+ * TODO: implement branch selection and upload semantics for this git-like fork workflow.
+ */
+"fork" | "cancelled"
 export type ConflictResolutionOutcome = "cancelled" | "kept_local" | "accepted_remote"
 /**
  * Tracks how a snapshot was created.
@@ -903,7 +909,7 @@ export type SaveUnitDraft = { id?: number | null; unit_type: SaveUnitType; paths
  */
 export type SaveUnitType = "File" | "Folder" | 
 /**
- * Windows Registry key tree (stored as `registry.json` inside the archive).
+ * Windows Registry key tree (stored as `registry.reg` inside new archives).
  */
 "WinRegistry"
 export type Settings = { prompt_when_not_described?: boolean; extra_backup_when_apply?: boolean; show_edit_button?: boolean; prompt_when_auto_backup?: boolean; exit_to_tray?: boolean; cloud_settings?: CloudSettings; locale?: string; default_delete_before_apply?: boolean; default_expend_favorites_tree?: boolean; home_page?: string; log_to_file?: boolean; add_new_to_favorites?: boolean; vn_scan_dirs?: string[]; save_list_expand_behavior?: SaveListExpandBehavior; save_list_last_expanded?: boolean; max_auto_backup_count?: number; 

--- a/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
+++ b/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
@@ -181,13 +181,29 @@ function updateGameLaunchPath(deviceId: string, path: string) {
   hasUnsavedChanges.value = true;
 }
 
-async function openPath(path: string) {
+function notifyOpenPathFailed(detail?: unknown) {
+  notifyError(
+    $t('error.open_path_failed'),
+    typeof detail === 'string' ? detail : detail instanceof Error ? detail.message : undefined
+  );
+}
+
+async function openManagedPath(path: string) {
   if (!path.trim()) return;
 
-  const result = await commands.openFileOrFolder(path);
-  if (result.status === 'error') {
-    notifyError($t('error.open_url_failed'));
+  try {
+    const result = await commands.openFileOrFolder(path);
+    if (result.status === 'error') {
+      notifyOpenPathFailed(result.error);
+    }
+  } catch (e) {
+    error(`Error opening path: ${e}`);
+    notifyOpenPathFailed(e);
   }
+}
+
+async function openPath(path: string) {
+  await openManagedPath(path);
 }
 
 function switchDeleteBeforeApply(_unit: SaveUnit) {
@@ -401,25 +417,11 @@ async function handleOpenPath(e: MouseEvent, path: string, unit?: SaveUnit) {
     const normalized = path.replace(/\\/g, '/');
     const idx = normalized.lastIndexOf('/');
     const parent = idx > -1 ? normalized.substring(0, idx) : normalized;
-    try {
-      const result = await commands.openFileOrFolder(parent);
-      if (result.status === 'error') {
-        showError({ message: $t('error.open_url_failed') });
-      }
-    } catch {
-      showError({ message: $t('error.open_url_failed') });
-    }
+    await openManagedPath(parent);
     return;
   }
 
-  try {
-    const result = await commands.openFileOrFolder(path);
-    if (result.status === 'error') {
-      showError({ message: $t('error.open_url_failed') });
-    }
-  } catch {
-    showError({ message: $t('error.open_url_failed') });
-  }
+  await openManagedPath(path);
 }
 </script>
 

--- a/crates/rgsm-core/src/path_launcher.rs
+++ b/crates/rgsm-core/src/path_launcher.rs
@@ -83,10 +83,7 @@ fn open_registry_key(path: &str) -> Result<()> {
     use winreg::RegKey;
     use winreg::enums::HKEY_CURRENT_USER;
 
-    let last_key = format!(
-        "Computer\\{}",
-        crate::backup::registry::normalize_registry_path(path)
-    );
+    let last_key = registry_editor_last_key(path);
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let (regedit_key, _) = hkcu
         .create_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Regedit")
@@ -95,10 +92,27 @@ fn open_registry_key(path: &str) -> Result<()> {
         .set_value("LastKey", &last_key)
         .context("Failed to set Regedit LastKey")?;
 
-    Command::new("regedit.exe")
-        .spawn()
-        .context("Failed to launch regedit.exe")?;
+    let regedit_exe = registry_editor_executable();
+    open::that_detached(&regedit_exe)
+        .with_context(|| format!("Failed to launch '{}'", regedit_exe.display()))?;
     Ok(())
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn registry_editor_last_key(path: &str) -> String {
+    format!(
+        "Computer\\{}",
+        crate::backup::registry::normalize_registry_path(path)
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn registry_editor_executable() -> PathBuf {
+    std::env::var_os("SystemRoot")
+        .or_else(|| std::env::var_os("windir"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(r"C:\Windows"))
+        .join("regedit.exe")
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -132,6 +146,9 @@ fn should_run_directly(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "windows")]
+    use super::registry_editor_executable;
+    use super::registry_editor_last_key;
     use super::{LaunchStrategy, ManagedLaunchTarget, launch_strategy, managed_launch_target};
     use crate::config::Config;
     use std::fs;
@@ -211,6 +228,26 @@ mod tests {
             target,
             ManagedLaunchTarget::Registry("HKEY_CURRENT_USER\\Software\\RGSM Test".to_string())
         );
+    }
+
+    #[test]
+    fn formats_registry_editor_last_key_from_ludusavi_path() {
+        assert_eq!(
+            registry_editor_last_key("REGISTRY:HKEY_CURRENT_USER/Software/RGSM Test"),
+            "Computer\\HKEY_CURRENT_USER\\Software\\RGSM Test"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn uses_absolute_registry_editor_path() {
+        let regedit_exe = registry_editor_executable();
+
+        assert_eq!(
+            regedit_exe.file_name().and_then(|name| name.to_str()),
+            Some("regedit.exe")
+        );
+        assert!(regedit_exe.is_absolute());
     }
 
     #[test]

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -608,6 +608,7 @@
     },
     "error": {
         "open_url_failed": "Unable to open url",
+        "open_path_failed": "Unable to open path",
         "update_device_failed": "Failed to update device information",
         "get_devices_failed": "Failed to get device list",
         "import_paths_failed": "Failed to import paths",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -608,6 +608,7 @@
     },
     "error": {
         "open_url_failed": "无法打开链接",
+        "open_path_failed": "无法打开路径",
         "config_load_failed": "配置文件加载失败，可能是因为配置文件损坏或者不存在",
         "choose_save_dir_error": "选择存档文件夹时发生错误",
         "choose_save_file_error": "选择存档文件时发生错误",


### PR DESCRIPTION
Closed: Windows Registry Editor does not provide a reliable built-in command-line way to open a specific key. The available LastKey workaround is context-dependent and not robust enough for this feature.