### PR TITLE
fix(cloud-sync): upload migrated config on startup

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -63,7 +63,7 @@ impl SyncEventEmitter for TauriSyncEmitter {
 
 pub fn run() -> anyhow::Result<()> {
     info!("{}", t!("home.hello_world"));
-    config_check()?;
+    let config_status = config_check()?;
 
     // 将 panic 信息记录到日志中
     std::panic::set_hook(Box::new(|panic_info| {
@@ -206,7 +206,16 @@ pub fn run() -> anyhow::Result<()> {
                 hooks::build_builtin_pipeline(app.handle(), cloud_sync_manager.clone(), &config);
             app.manage(hooks::HookPipelineState::new(pipeline));
 
+            let startup_cloud_sync_manager = cloud_sync_manager.clone();
             app.manage(cloud_sync_manager);
+            if config_status.config_migrated {
+                let migrated_config = config.clone();
+                tauri::async_runtime::spawn(async move {
+                    startup_cloud_sync_manager
+                        .enqueue_config_upload_if_enabled(&migrated_config, "config_migration")
+                        .await;
+                });
+            }
 
             sound::setup(app).expect("Cannot setup sound manager");
             // 处理快捷备份，包括托盘、定时、快捷键

--- a/apps/rgsm-tui/src/app.rs
+++ b/apps/rgsm-tui/src/app.rs
@@ -105,6 +105,18 @@ impl App {
         self.should_quit
     }
 
+    pub async fn enqueue_config_migration_sync(&self) -> Result<()> {
+        if !self.settings.auto_enqueue_cloud_on_change {
+            return Ok(());
+        }
+
+        let config = rgsm_core::config::get_config()?;
+        self.cloud_sync_manager
+            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .await;
+        Ok(())
+    }
+
     pub fn selected_game(&self) -> Option<rgsm_core::backup::Game> {
         let indices = self.visible_game_indices();
         indices

--- a/apps/rgsm-tui/src/main.rs
+++ b/apps/rgsm-tui/src/main.rs
@@ -38,7 +38,8 @@ async fn main() -> Result<()> {
     rgsm_core::app_dirs::set_app_data_dir_override(data_dir.clone())
         .context("failed to set RGSM TUI profile directory")?;
 
-    rgsm_core::config::config_check().context("failed to initialize RGSM config")?;
+    let config_status =
+        rgsm_core::config::config_check().context("failed to initialize RGSM config")?;
     if let Some(source) = &options.import_gui_config {
         let report = profile_import::import_gui_profile(source, &data_dir)
             .context("failed to import GUI profile")?;
@@ -60,6 +61,11 @@ async fn main() -> Result<()> {
     let mut app = App::new(data_dir, settings)
         .await
         .context("failed to initialize TUI state")?;
+    if config_status.config_migrated {
+        app.enqueue_config_migration_sync()
+            .await
+            .context("failed to enqueue migrated config cloud sync")?;
+    }
     let mut terminal = TerminalGuard::enter().context("failed to enter terminal UI")?;
 
     while !app.should_quit() {

--- a/crates/rgsm-core/src/cloud_sync/task_manager.rs
+++ b/crates/rgsm-core/src/cloud_sync/task_manager.rs
@@ -225,6 +225,23 @@ impl CloudSyncTaskManager {
             .await;
     }
 
+    pub async fn enqueue_config_upload_if_enabled(
+        &self,
+        config: &crate::config::Config,
+        context: impl Into<String>,
+    ) {
+        let backend = match &config.settings.cloud_settings.backend {
+            Backend::Disabled => return,
+            backend => backend.clone(),
+        };
+
+        self.enqueue(CloudSyncJob::UploadConfig {
+            backend,
+            context: context.into(),
+        })
+        .await;
+    }
+
     pub async fn cancel_all(&self) -> CancelCloudSyncResult {
         let mut had_active = self.running_count.load(Ordering::Relaxed) > 0;
         {
@@ -714,6 +731,63 @@ async fn execute_job_once(
             let op = backend.get_op().map_err(CloudSyncExecuteError::Backend)?;
             run_cancellable(token, upload_config(&op)).await?;
             Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoopEmitter;
+
+    impl SyncEventEmitter for NoopEmitter {
+        fn emit_status(&self, _status: &CloudSyncStatus) {}
+        fn emit_error(&self, _error: &CloudSyncError) {}
+    }
+
+    fn manager() -> Arc<CloudSyncTaskManager> {
+        CloudSyncTaskManager::new(Arc::new(NoopEmitter))
+    }
+
+    #[tokio::test]
+    async fn config_upload_enqueue_skips_disabled_backend() {
+        let manager = manager();
+        let config = crate::config::Config::default();
+
+        manager
+            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .await;
+
+        let state = manager.state.lock().await;
+        assert!(state.queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn config_upload_enqueue_uses_config_backend() {
+        let manager = manager();
+        let mut config = crate::config::Config::default();
+        config.settings.cloud_settings.backend = Backend::WebDAV {
+            endpoint: "https://example.invalid/dav".to_string(),
+            username: "user".to_string(),
+            password: "pass".to_string(),
+        };
+
+        manager
+            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .await;
+
+        let state = manager.state.lock().await;
+        assert_eq!(state.queue.len(), 1);
+        match &state.queue[0].job {
+            CloudSyncJob::UploadConfig {
+                backend: Backend::WebDAV { endpoint, .. },
+                context,
+            } => {
+                assert_eq!(endpoint, "https://example.invalid/dav");
+                assert_eq!(context, "config_migration");
+            }
+            other => panic!("expected config upload job, got {other:?}"),
         }
     }
 }

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -19,6 +19,11 @@ pub(crate) fn lock_config_test_file() -> MutexGuard<'static, ()> {
     CONFIG_FILE_TEST_LOCK.blocking_lock()
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConfigCheckOutcome {
+    pub config_migrated: bool,
+}
+
 /// Set settings to original state
 pub async fn reset_settings() -> Result<(), ConfigError> {
     let settings = Config::default().settings;
@@ -68,7 +73,7 @@ pub async fn set_config(config: &Config) -> Result<(), ConfigError> {
 /// Check the config file exists or not
 /// if not, then create one
 /// then send the config to the front end
-pub fn config_check() -> Result<(), ConfigError> {
+pub fn config_check() -> Result<ConfigCheckOutcome, ConfigError> {
     let config_path = resolve_app_path("GameSaveManager.config.json");
     info!("Config file path: {}", config_path.display());
 
@@ -76,12 +81,12 @@ pub fn config_check() -> Result<(), ConfigError> {
         init_config()?;
     }
     // 执行配置迁移与升级
-    update_config(&config_path)?;
+    let config_migrated = update_config(&config_path)?;
     // 重新加载配置
     let config = get_config()?;
     // 应用本地化语言
     rust_i18n::set_locale(&config.settings.locale);
-    Ok(())
+    Ok(ConfigCheckOutcome { config_migrated })
 }
 
 /// Get the resolved backup path from the config

--- a/crates/rgsm-core/src/updater/migration.rs
+++ b/crates/rgsm-core/src/updater/migration.rs
@@ -31,9 +31,10 @@ use crate::updater::{
 /// * `path` - Path to the config file
 ///
 /// # Returns
-/// * `Ok(())` - If migration succeeds or not needed
+/// * `Ok(true)` - If migration succeeds and writes an updated config
+/// * `Ok(false)` - If no migration is needed
 /// * `Err(UpdaterError)` - If any step fails
-pub fn update_config<P: AsRef<Path>>(path: P) -> Result<(), UpdaterError> {
+pub fn update_config<P: AsRef<Path>>(path: P) -> Result<bool, UpdaterError> {
     let path: &Path = path.as_ref();
     let version = probe_config_version(path)?;
     let current = Version::parse(CURRENT_VERSION)?;
@@ -73,7 +74,7 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<(), UpdaterError> {
         });
     }
     if version == current {
-        return Ok(());
+        return Ok(false);
     }
 
     warn!(target: "rgsm::updater", "Config version is older than current version, updating...");
@@ -113,7 +114,7 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<(), UpdaterError> {
     // Write new config
     fs::write(path, serde_json::to_string_pretty(&new_cfg)?)?;
     info!(target: "rgsm::updater", "Config updated successfully to version {}", CURRENT_VERSION);
-    Ok(())
+    Ok(true)
 }
 
 /// Migrate config content based on its version
@@ -764,6 +765,44 @@ mod tests {
         assert!(message.contains("999.0.0"));
         assert!(message.contains(CURRENT_VERSION));
 
+        Ok(())
+    }
+
+    #[test]
+    fn update_config_reports_no_migration_for_current_config()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = temp_dir::TempDir::new()?;
+        let config_path = temp_dir.path().join("GameSaveManager.config.json");
+        fs::write(
+            &config_path,
+            serde_json::to_string_pretty(&Config::default())?,
+        )?;
+
+        let migrated = update_config(&config_path)?;
+
+        assert!(!migrated);
+        Ok(())
+    }
+
+    #[test]
+    fn update_config_reports_migration_when_version_changes()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = temp_dir::TempDir::new()?;
+        let config_path = temp_dir.path().join("GameSaveManager.config.json");
+        let backup_path = temp_dir.path().join("backup");
+        let mut config = Config {
+            version: VERSION_1_8_1.to_string(),
+            backup_path: backup_path.to_string_lossy().to_string(),
+            ..Config::default()
+        };
+        config.settings.cloud_settings.backend = crate::cloud_sync::Backend::Disabled;
+        fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+
+        let migrated = update_config(&config_path)?;
+
+        assert!(migrated);
+        let migrated_config: Config = serde_json::from_str(&fs::read_to_string(&config_path)?)?;
+        assert_eq!(migrated_config.version, CURRENT_VERSION);
         Ok(())
     }
 


### PR DESCRIPTION
Closes #195.

Uploads the migrated config after startup migration finishes and the cloud sync queue is available, so version upgrades do not leave the cloud copy stale.

Validated with `cargo fmt --check`, `cargo test -p rgsm-core --lib`, `cargo check --workspace`, and `cargo clippy --workspace --all-targets --all-features -- -D warnings`.