### PR TITLE
fix(backup): :bug: gate no-atime file opens to Linux

### DIFF
--- a/crates/rgsm-core/Cargo.toml
+++ b/crates/rgsm-core/Cargo.toml
@@ -53,5 +53,5 @@ keyvalues-serde = "0.2"
 winreg.workspace = true
 windows-sys.workspace = true
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true

--- a/crates/rgsm-core/src/backup/archive/seven_z.rs
+++ b/crates/rgsm-core/src/backup/archive/seven_z.rs
@@ -455,7 +455,7 @@ fn to_nt_time(time: SystemTime) -> Result<NtTime, CompressError> {
     })
 }
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 fn open_without_atime(path: &Path) -> std::io::Result<File> {
     use std::fs::OpenOptions;
     use std::os::unix::fs::OpenOptionsExt;
@@ -470,7 +470,7 @@ fn open_without_atime(path: &Path) -> std::io::Result<File> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(target_os = "linux"))]
 fn open_without_atime(path: &Path) -> std::io::Result<File> {
     File::open(path)
 }


### PR DESCRIPTION
Limit `O_NOATIME` to Linux so macOS nightly builds use the portable file-open path.