### PR TITLE
refactor(config): persist configuration owners

### DIFF
--- a/crates/rgsm-core/src/backup/tests/utils.rs
+++ b/crates/rgsm-core/src/backup/tests/utils.rs
@@ -1,4 +1,7 @@
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tokio::sync::MutexGuard;
 
 use crate::config::Config;
@@ -10,6 +13,8 @@ pub(crate) fn lock_config_file() -> MutexGuard<'static, ()> {
 pub(crate) struct ConfigFileGuard {
     path: PathBuf,
     original_contents: Option<Vec<u8>>,
+    owner_backups: Vec<(PathBuf, Option<PathBuf>)>,
+    _owner_backup_root: temp_dir::TempDir,
 }
 
 impl ConfigFileGuard {
@@ -20,6 +25,30 @@ impl ConfigFileGuard {
     pub(crate) fn write_config(config: &Config) -> Result<Self, Box<dyn std::error::Error>> {
         let path = crate::app_dirs::resolve_app_path("GameSaveManager.config.json");
         let original_contents = fs::read(&path).ok();
+        let owner_paths = [
+            crate::config::owner_store::OWNER_DIRECTORY_NAME,
+            crate::config::owner_store::OWNER_STAGING_DIRECTORY_NAME,
+            crate::config::owner_store::OWNER_ROLLBACK_DIRECTORY_NAME,
+        ]
+        .into_iter()
+        .map(crate::app_dirs::resolve_app_path)
+        .collect::<Vec<_>>();
+        let owner_backup_root = temp_dir::TempDir::new()?;
+        let owner_backups = owner_paths
+            .iter()
+            .enumerate()
+            .map(|(index, owner_path)| {
+                if !owner_path.exists() {
+                    return Ok((owner_path.clone(), None));
+                }
+                let backup_path = owner_backup_root.path().join(index.to_string());
+                copy_directory(owner_path, &backup_path)?;
+                Ok((owner_path.clone(), Some(backup_path)))
+            })
+            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        for owner_path in owner_paths {
+            let _ = fs::remove_dir_all(owner_path);
+        }
 
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -30,16 +59,38 @@ impl ConfigFileGuard {
         Ok(Self {
             path,
             original_contents,
+            owner_backups,
+            _owner_backup_root: owner_backup_root,
         })
     }
 }
 
 impl Drop for ConfigFileGuard {
     fn drop(&mut self) {
+        for (owner_path, backup_path) in &self.owner_backups {
+            let _ = fs::remove_dir_all(owner_path);
+            if let Some(backup_path) = backup_path {
+                let _ = copy_directory(backup_path, owner_path);
+            }
+        }
         if let Some(contents) = &self.original_contents {
             let _ = fs::write(&self.path, contents);
         } else {
             let _ = fs::remove_file(&self.path);
         }
     }
+}
+
+fn copy_directory(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let target_path = target.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_directory(&entry.path(), &target_path)?;
+        } else {
+            fs::copy(entry.path(), target_path)?;
+        }
+    }
+    Ok(())
 }

--- a/crates/rgsm-core/src/cloud_sync/utils.rs
+++ b/crates/rgsm-core/src/cloud_sync/utils.rs
@@ -13,7 +13,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::backup::{Game, GameSnapshots, Snapshot, archive_file_name, remote_archive_path};
 use crate::cloud_sync::transfer::{CloudTransfer, path_to_remote_key};
-use crate::config::{Config, get_backup_path, get_config, resolve_backup_path, set_config_local};
+use crate::config::{
+    Config, get_backup_path, get_config, replace_config_local, resolve_backup_path,
+};
 use crate::preclude::*;
 
 #[derive(Debug, Error)]
@@ -434,7 +436,7 @@ pub async fn commit_staged_backup_root(
         return Err(err.into());
     }
 
-    if let Err(err) = set_config_local(remote_config) {
+    if let Err(err) = replace_config_local(remote_config) {
         let _ = fs::remove_dir_all(target_backup_root).await;
         if rollback_root.exists() {
             let _ = fs::rename(&rollback_root, target_backup_root).await;

--- a/crates/rgsm-core/src/config/backup.rs
+++ b/crates/rgsm-core/src/config/backup.rs
@@ -3,13 +3,17 @@ use std::path::PathBuf;
 
 use log::{info, warn};
 
-use crate::app_dirs::resolve_app_path;
+use crate::config::Config;
 
 const MAX_CONFIG_BACKUPS: usize = 5;
 const CONFIG_FILE_NAME: &str = "GameSaveManager.config.json";
 
 fn backup_path(index: usize) -> PathBuf {
-    resolve_app_path(&format!("{CONFIG_FILE_NAME}.backup.{index}"))
+    backup_path_in(crate::app_dirs::get_app_data_dir(), index)
+}
+
+fn backup_path_in(root: &std::path::Path, index: usize) -> PathBuf {
+    root.join(format!("{CONFIG_FILE_NAME}.backup.{index}"))
 }
 
 /// Rotate local config backups before saving.
@@ -17,16 +21,15 @@ fn backup_path(index: usize) -> PathBuf {
 /// Keeps up to `MAX_CONFIG_BACKUPS` copies:
 ///   .backup.0 = most recent, .backup.4 = oldest.
 /// Called before each config write so corruption is recoverable.
-pub fn rotate_config_backups() {
-    let config_path = resolve_app_path(CONFIG_FILE_NAME);
-    if !config_path.is_file() {
-        return;
-    }
+pub fn rotate_config_backups(config: &Config) {
+    rotate_config_backups_in(crate::app_dirs::get_app_data_dir(), config);
+}
 
+fn rotate_config_backups_in(root: &std::path::Path, config: &Config) {
     // Shift existing backups: .backup.4 is dropped, .backup.3 → .backup.4, etc.
     for i in (1..MAX_CONFIG_BACKUPS).rev() {
-        let src = backup_path(i - 1);
-        let dst = backup_path(i);
+        let src = backup_path_in(root, i - 1);
+        let dst = backup_path_in(root, i);
         if src.is_file() {
             // On Windows, fs::rename fails if destination exists; remove first.
             if dst.exists() {
@@ -42,8 +45,15 @@ pub fn rotate_config_backups() {
         }
     }
 
-    // Copy current config to .backup.0
-    if let Err(e) = fs::copy(&config_path, backup_path(0)) {
+    // Store the previous effective Config projection for the existing restore UI.
+    let serialized = match serde_json::to_vec_pretty(config) {
+        Ok(serialized) => serialized,
+        Err(e) => {
+            warn!("Failed to serialize config backup: {e}");
+            return;
+        }
+    };
+    if let Err(e) = fs::write(backup_path_in(root, 0), serialized) {
         warn!("Failed to create config backup: {e}");
     } else {
         info!("Config backup rotated (max {MAX_CONFIG_BACKUPS})");
@@ -58,11 +68,16 @@ pub fn list_config_backups() -> Vec<PathBuf> {
         .collect()
 }
 
-/// Restore config from a specific backup index.
-/// Returns `Ok(())` on success.
-pub fn restore_config_from_backup(index: usize) -> Result<(), std::io::Error> {
-    let src = backup_path(index);
-    let dst = resolve_app_path(CONFIG_FILE_NAME);
+/// Load the effective config projection stored in a specific backup.
+pub fn load_config_from_backup(index: usize) -> Result<Config, std::io::Error> {
+    load_config_from_backup_in(crate::app_dirs::get_app_data_dir(), index)
+}
+
+fn load_config_from_backup_in(
+    root: &std::path::Path,
+    index: usize,
+) -> Result<Config, std::io::Error> {
+    let src = backup_path_in(root, index);
     if !src.is_file() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -71,15 +86,13 @@ pub fn restore_config_from_backup(index: usize) -> Result<(), std::io::Error> {
     }
     // Validate the backup is parseable JSON before restoring
     let content = fs::read_to_string(&src)?;
-    serde_json::from_str::<serde_json::Value>(&content).map_err(|e| {
+    let config = serde_json::from_str::<Config>(&content).map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("Backup {index} is corrupt: {e}"),
         )
     })?;
-    fs::copy(&src, &dst)?;
-    info!("Config restored from backup index {index}");
-    Ok(())
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -100,5 +113,20 @@ mod tests {
         // list_config_backups should not panic even when no backup files exist
         let backups = list_config_backups();
         assert!(backups.len() <= MAX_CONFIG_BACKUPS);
+    }
+
+    #[test]
+    fn effective_config_backup_round_trips_without_legacy_file() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let config = Config {
+            backup_path: "device-specific-root".to_string(),
+            ..Default::default()
+        };
+
+        rotate_config_backups_in(root.path(), &config);
+        let restored = load_config_from_backup_in(root.path(), 0).unwrap();
+
+        assert_eq!(restored.backup_path, "device-specific-root");
+        assert!(!root.path().join("GameSaveManager.config.json").exists());
     }
 }

--- a/crates/rgsm-core/src/config/mod.rs
+++ b/crates/rgsm-core/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod app_config;
 pub mod backup;
+pub(crate) mod owner_store;
 mod ownership;
 #[cfg(test)]
 mod ownership_tests;
@@ -8,6 +9,7 @@ mod settings;
 mod utils;
 
 pub use app_config::{Config, FavoriteTreeNode};
+pub use owner_store::OwnerStoreError;
 pub use ownership::{
     ConfigurationOwners, DeviceBehaviorSettings, DeviceGameProfile, DeviceProfile,
     DeviceSaveUnitSettings, EffectiveConfiguration, LocalInterfaceSettings, LocalState,

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -1,0 +1,425 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use thiserror::Error;
+
+use crate::app_dirs::get_app_data_dir;
+use crate::device::{DeviceId, get_current_device_id};
+
+use super::{
+    Config, ConfigurationOwners, DeviceProfile, LocalState, OwnershipError, SharedLibrary,
+    V2_CONFIG_SCHEMA_VERSION,
+};
+
+pub(crate) const OWNER_DIRECTORY_NAME: &str = "GameSaveManager.config.v2";
+pub(crate) const OWNER_STAGING_DIRECTORY_NAME: &str = "GameSaveManager.config.v2.staging";
+pub(crate) const OWNER_ROLLBACK_DIRECTORY_NAME: &str = "GameSaveManager.config.v2.rollback";
+const SHARED_LIBRARY_FILE_NAME: &str = "shared-library.json";
+const LOCAL_STATE_FILE_NAME: &str = "local-state.json";
+const DEVICE_PROFILES_DIRECTORY_NAME: &str = "device-profiles";
+
+#[derive(Debug, Error)]
+pub enum OwnerStoreError {
+    #[error("Owner store I/O error: {0:#?}")]
+    Io(#[from] std::io::Error),
+    #[error("Owner store serialization error: {0:#?}")]
+    Serialization(#[from] serde_json::Error),
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+    #[error("Duplicate Device Profile identity: {0}")]
+    DuplicateDeviceProfile(DeviceId),
+    #[error("Device Profile file name does not match embedded Device ID: {0}")]
+    ProfileFileNameMismatch(DeviceId),
+}
+
+pub(crate) struct OwnerStore {
+    root: PathBuf,
+}
+
+impl OwnerStore {
+    pub(crate) fn runtime() -> Self {
+        Self::new(get_app_data_dir().clone())
+    }
+
+    fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub(crate) fn has_authoritative_state(&self) -> bool {
+        self.active_path().exists() || self.rollback_path().exists()
+    }
+
+    pub(crate) fn initialize_from_legacy(&self, config: &Config) -> Result<bool, OwnerStoreError> {
+        if self.has_authoritative_state() {
+            self.load()?;
+            return Ok(false);
+        }
+        let owners = ConfigurationOwners::from_legacy(config, get_current_device_id());
+        self.write(&owners)?;
+        Ok(true)
+    }
+
+    pub(crate) fn load_effective(&self) -> Result<Config, OwnerStoreError> {
+        self.load()?.assemble_effective().map_err(Into::into)
+    }
+
+    pub(crate) fn merge_effective(&self, config: &Config) -> Result<Config, OwnerStoreError> {
+        let mut owners = if self.has_authoritative_state() {
+            self.load()?
+        } else {
+            ConfigurationOwners::from_legacy(config, get_current_device_id())
+        };
+        owners.merge_effective(config)?;
+        let effective = owners.assemble_effective()?;
+        self.write(&owners)?;
+        Ok(effective)
+    }
+
+    pub(crate) fn replace_effective(&self, config: &Config) -> Result<Config, OwnerStoreError> {
+        let current_device_id = if self.has_authoritative_state() {
+            self.load()?.local_state.current_device_id
+        } else {
+            get_current_device_id().clone()
+        };
+        let owners = ConfigurationOwners::from_legacy(config, &current_device_id);
+        let effective = owners.assemble_effective()?;
+        self.write(&owners)?;
+        Ok(effective)
+    }
+
+    fn load(&self) -> Result<ConfigurationOwners, OwnerStoreError> {
+        self.recover()?;
+        let active = self.active_path();
+        let shared_library: SharedLibrary = read_json(&active.join(SHARED_LIBRARY_FILE_NAME))?;
+        let local_state: LocalState = read_json(&active.join(LOCAL_STATE_FILE_NAME))?;
+        let profiles_path = active.join(DEVICE_PROFILES_DIRECTORY_NAME);
+        let mut device_profiles = HashMap::new();
+        let mut profile_file_names = HashMap::new();
+        for entry in fs::read_dir(profiles_path)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file()
+                || entry.path().extension().and_then(|value| value.to_str()) != Some("json")
+            {
+                continue;
+            }
+            let profile: DeviceProfile = read_json(&entry.path())?;
+            let device_id = profile.device.id.clone();
+            if device_profiles.insert(device_id.clone(), profile).is_some() {
+                return Err(OwnerStoreError::DuplicateDeviceProfile(device_id));
+            }
+            profile_file_names.insert(device_id, entry.file_name());
+        }
+        for (device_id, file_name) in profile_file_names {
+            if file_name != profile_file_name(&device_id).as_str() {
+                return Err(OwnerStoreError::ProfileFileNameMismatch(device_id));
+            }
+        }
+        let owners = ConfigurationOwners {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            shared_library,
+            device_profiles,
+            local_state,
+        };
+        owners.validate()?;
+        Ok(owners)
+    }
+
+    fn write(&self, owners: &ConfigurationOwners) -> Result<(), OwnerStoreError> {
+        owners.validate()?;
+        let staging = self.staging_path();
+        let active = self.active_path();
+        let rollback = self.rollback_path();
+
+        remove_dir_if_exists(&staging)?;
+        fs::create_dir_all(staging.join(DEVICE_PROFILES_DIRECTORY_NAME))?;
+        write_json(
+            &staging.join(SHARED_LIBRARY_FILE_NAME),
+            &owners.shared_library,
+        )?;
+        write_json(&staging.join(LOCAL_STATE_FILE_NAME), &owners.local_state)?;
+        for (device_id, profile) in &owners.device_profiles {
+            write_json(
+                &staging
+                    .join(DEVICE_PROFILES_DIRECTORY_NAME)
+                    .join(profile_file_name(device_id)),
+                profile,
+            )?;
+        }
+
+        remove_dir_if_exists(&rollback)?;
+        if active.exists() {
+            fs::rename(&active, &rollback)?;
+        }
+        if let Err(error) = fs::rename(&staging, &active) {
+            if rollback.exists() {
+                let _ = fs::rename(&rollback, &active);
+            }
+            let _ = remove_dir_if_exists(&staging);
+            return Err(error.into());
+        }
+        remove_dir_if_exists(&rollback)?;
+        Ok(())
+    }
+
+    fn recover(&self) -> Result<(), OwnerStoreError> {
+        let active = self.active_path();
+        let rollback = self.rollback_path();
+        let staging = self.staging_path();
+        if active.exists() {
+            remove_dir_if_exists(&rollback)?;
+            remove_dir_if_exists(&staging)?;
+            return Ok(());
+        }
+        if rollback.exists() {
+            remove_dir_if_exists(&staging)?;
+            fs::rename(rollback, active)?;
+        }
+        Ok(())
+    }
+
+    fn active_path(&self) -> PathBuf {
+        self.root.join(OWNER_DIRECTORY_NAME)
+    }
+
+    fn staging_path(&self) -> PathBuf {
+        self.root.join(OWNER_STAGING_DIRECTORY_NAME)
+    }
+
+    fn rollback_path(&self) -> PathBuf {
+        self.root.join(OWNER_ROLLBACK_DIRECTORY_NAME)
+    }
+}
+
+fn read_json<T: DeserializeOwned>(path: &Path) -> Result<T, OwnerStoreError> {
+    Ok(serde_json::from_slice(&fs::read(path)?)?)
+}
+
+fn write_json<T: Serialize>(path: &Path, value: &T) -> Result<(), OwnerStoreError> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    fs::write(path, bytes)?;
+    fs::OpenOptions::new().write(true).open(path)?.sync_all()?;
+    Ok(())
+}
+
+fn remove_dir_if_exists(path: &Path) -> Result<(), std::io::Error> {
+    if path.exists() {
+        fs::remove_dir_all(path)?;
+    }
+    Ok(())
+}
+
+/// Encode a Device ID as a path-safe lowercase hexadecimal file stem.
+///
+/// Each UTF-8 byte becomes two characters, so both time and additional space
+/// are O(n) in the Device ID byte length.
+fn profile_file_name(device_id: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(device_id.len() * 2 + 5);
+    for byte in device_id.as_bytes() {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded.push_str(".json");
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+
+    fn store() -> (temp_dir::TempDir, OwnerStore) {
+        let root = temp_dir::TempDir::new().unwrap();
+        let store = OwnerStore::new(root.path().to_path_buf());
+        (root, store)
+    }
+
+    fn config(device_id: &str, backup_path: &str) -> Config {
+        let mut config = Config {
+            backup_path: backup_path.to_string(),
+            ..Default::default()
+        };
+        config.devices.insert(
+            device_id.to_string(),
+            Device {
+                id: device_id.to_string(),
+                name: device_id.to_string(),
+                resources: Vec::new(),
+                next_resource_id: 0,
+            },
+        );
+        config
+    }
+
+    fn add_device(config: &mut Config, device_id: &str, name: &str) {
+        config.devices.insert(
+            device_id.to_string(),
+            Device {
+                id: device_id.to_string(),
+                name: name.to_string(),
+                resources: Vec::new(),
+                next_resource_id: 0,
+            },
+        );
+    }
+
+    #[test]
+    fn writes_separate_owner_files_and_loads_effective_config() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "D:/Backups");
+
+        assert!(store.initialize_from_legacy(&input).unwrap());
+        let active = store.active_path();
+        assert!(active.join(SHARED_LIBRARY_FILE_NAME).is_file());
+        assert!(active.join(LOCAL_STATE_FILE_NAME).is_file());
+        assert!(
+            active
+                .join(DEVICE_PROFILES_DIRECTORY_NAME)
+                .join(profile_file_name(get_current_device_id()))
+                .is_file()
+        );
+        assert_eq!(
+            store.load_effective().unwrap().backup_path,
+            input.backup_path
+        );
+    }
+
+    #[test]
+    fn rollback_directory_recovers_after_interrupted_activation() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        fs::rename(store.active_path(), store.rollback_path()).unwrap();
+        fs::create_dir_all(store.staging_path()).unwrap();
+        fs::write(store.staging_path().join("partial.json"), b"{}").unwrap();
+
+        let recovered = store.load_effective().unwrap();
+
+        assert_eq!(recovered.backup_path, "before");
+        assert!(store.active_path().is_dir());
+        assert!(!store.rollback_path().exists());
+        assert!(!store.staging_path().exists());
+    }
+
+    #[test]
+    fn malformed_active_store_does_not_fall_back_to_rollback() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        copy_directory(&store.active_path(), &store.rollback_path()).unwrap();
+        fs::remove_file(store.active_path().join(SHARED_LIBRARY_FILE_NAME)).unwrap();
+
+        let result = store.load_effective();
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn profile_file_names_do_not_contain_raw_device_ids() {
+        assert_eq!(profile_file_name("../Deck"), "2e2e2f4465636b.json");
+    }
+
+    #[test]
+    fn normal_merge_preserves_another_devices_private_profile() {
+        let (_root, store) = store();
+        let mut input = config(get_current_device_id(), "before");
+        add_device(&mut input, "steam-deck", "Steam Deck");
+        store.initialize_from_legacy(&input).unwrap();
+        let mut owners = store.load().unwrap();
+        owners
+            .device_profiles
+            .get_mut("steam-deck")
+            .unwrap()
+            .quick_action
+            .quick_action_game_id = Some("deck-only".to_string());
+        store.write(&owners).unwrap();
+        let mut edited = store.load_effective().unwrap();
+        edited.quick_action.quick_action_game_id = Some("current-only".to_string());
+
+        store.merge_effective(&edited).unwrap();
+
+        let persisted = store.load().unwrap();
+        assert_eq!(
+            persisted.device_profiles["steam-deck"]
+                .quick_action
+                .quick_action_game_id
+                .as_deref(),
+            Some("deck-only")
+        );
+    }
+
+    #[test]
+    fn explicit_replacement_rebuilds_all_device_profiles() {
+        let (_root, store) = store();
+        let mut input = config(get_current_device_id(), "before");
+        add_device(&mut input, "steam-deck", "Old Deck");
+        store.initialize_from_legacy(&input).unwrap();
+        input.devices.get_mut("steam-deck").unwrap().name = "Replacement Deck".to_string();
+
+        store.replace_effective(&input).unwrap();
+
+        assert_eq!(
+            store.load_effective().unwrap().devices["steam-deck"].name,
+            "Replacement Deck"
+        );
+    }
+
+    #[test]
+    fn unsupported_schema_fails_closed() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        let shared_path = store.active_path().join(SHARED_LIBRARY_FILE_NAME);
+        let mut shared: serde_json::Value =
+            serde_json::from_slice(&fs::read(&shared_path).unwrap()).unwrap();
+        shared["schema_version"] = serde_json::json!(99);
+        fs::write(shared_path, serde_json::to_vec_pretty(&shared).unwrap()).unwrap();
+
+        let result = store.load_effective();
+
+        assert!(matches!(
+            result,
+            Err(OwnerStoreError::Ownership(
+                OwnershipError::UnsupportedSchema { found: 99, .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn duplicate_device_profile_identity_is_rejected() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        let profiles = store.active_path().join(DEVICE_PROFILES_DIRECTORY_NAME);
+        fs::copy(
+            profiles.join(profile_file_name(get_current_device_id())),
+            profiles.join("duplicate.json"),
+        )
+        .unwrap();
+
+        let result = store.load_effective();
+
+        assert!(matches!(
+            result,
+            Err(OwnerStoreError::DuplicateDeviceProfile(device_id))
+                if device_id == *get_current_device_id()
+        ));
+    }
+
+    fn copy_directory(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+        fs::create_dir_all(target)?;
+        for entry in fs::read_dir(source)? {
+            let entry = entry?;
+            let target_path = target.join(entry.file_name());
+            if entry.file_type()?.is_dir() {
+                copy_directory(&entry.path(), &target_path)?;
+            } else {
+                fs::copy(entry.path(), target_path)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -27,6 +27,12 @@ pub type EffectiveConfiguration = Config;
 pub enum OwnershipError {
     #[error("Device Profile not found: {0}")]
     MissingDeviceProfile(DeviceId),
+    #[error("Unsupported {owner} schema version: {found}")]
+    UnsupportedSchema { owner: String, found: u32 },
+    #[error("Device Profile key {key} does not match embedded Device ID {embedded}")]
+    ProfileIdentityMismatch { key: DeviceId, embedded: DeviceId },
+    #[error("Shared Library contains duplicate Game identity: {0}")]
+    DuplicateSharedGame(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
@@ -227,9 +233,87 @@ impl ConfigurationOwners {
         }
     }
 
+    pub fn validate(&self) -> Result<(), OwnershipError> {
+        validate_schema("Configuration Owners", self.schema_version)?;
+        validate_schema("Shared Library", self.shared_library.schema_version)?;
+        validate_schema("Local State", self.local_state.schema_version)?;
+
+        let mut game_ids = HashSet::new();
+        for game in &self.shared_library.games {
+            if !game_ids.insert(&game.storage_key) {
+                return Err(OwnershipError::DuplicateSharedGame(
+                    game.storage_key.clone(),
+                ));
+            }
+        }
+        for (device_id, profile) in &self.device_profiles {
+            validate_schema(
+                &format!("Device Profile {device_id}"),
+                profile.schema_version,
+            )?;
+            if &profile.device.id != device_id {
+                return Err(OwnershipError::ProfileIdentityMismatch {
+                    key: device_id.clone(),
+                    embedded: profile.device.id.clone(),
+                });
+            }
+        }
+        if !self
+            .device_profiles
+            .contains_key(&self.local_state.current_device_id)
+        {
+            return Err(OwnershipError::MissingDeviceProfile(
+                self.local_state.current_device_id.clone(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Apply an effective-configuration save without granting the current
+    /// Device permission to rewrite another Device's private Profile fields.
+    pub fn merge_effective(&mut self, config: &Config) -> Result<(), OwnershipError> {
+        self.validate()?;
+        let current_device_id = self.local_state.current_device_id.clone();
+        let mut incoming = Self::from_legacy(config, &current_device_id);
+        let current_profile = incoming
+            .device_profiles
+            .remove(&current_device_id)
+            .ok_or_else(|| OwnershipError::MissingDeviceProfile(current_device_id.clone()))?;
+        let incoming_device_ids = incoming
+            .device_profiles
+            .keys()
+            .cloned()
+            .collect::<HashSet<_>>();
+
+        self.shared_library = incoming.shared_library;
+        self.local_state = incoming.local_state;
+        self.device_profiles.retain(|device_id, _| {
+            device_id == &current_device_id || incoming_device_ids.contains(device_id)
+        });
+        for (device_id, profile) in incoming.device_profiles {
+            self.device_profiles.entry(device_id).or_insert(profile);
+        }
+        self.device_profiles
+            .insert(current_device_id, current_profile);
+
+        let shared_game_ids = self
+            .shared_library
+            .games
+            .iter()
+            .map(|game| game.storage_key.as_str())
+            .collect::<HashSet<_>>();
+        for profile in self.device_profiles.values_mut() {
+            profile
+                .games
+                .retain(|game_id, _| shared_game_ids.contains(game_id.as_str()));
+        }
+        self.validate()
+    }
+
     /// Join the selected Device Profile with shared and local data for existing
     /// application services that still consume the flat configuration model.
     pub fn assemble_effective(&self) -> Result<EffectiveConfiguration, OwnershipError> {
+        self.validate()?;
         let current_device_id = &self.local_state.current_device_id;
         let current = self
             .device_profiles
@@ -333,6 +417,17 @@ impl ConfigurationOwners {
             ludusavi_meta: shared.ludusavi_meta.clone(),
             device_bindings,
         }
+    }
+}
+
+fn validate_schema(owner: &str, found: u32) -> Result<(), OwnershipError> {
+    if found == V2_CONFIG_SCHEMA_VERSION {
+        Ok(())
+    } else {
+        Err(OwnershipError::UnsupportedSchema {
+            owner: owner.to_string(),
+            found,
+        })
     }
 }
 

--- a/crates/rgsm-core/src/config/ownership_tests.rs
+++ b/crates/rgsm-core/src/config/ownership_tests.rs
@@ -121,3 +121,71 @@ fn assembly_requires_the_selected_device_profile() {
         Err(OwnershipError::MissingDeviceProfile(id)) if id == windows_id
     ));
 }
+
+#[test]
+fn normal_save_preserves_other_device_private_profile_fields() {
+    let (config, windows_id, deck_id) = dual_device_config();
+    let mut owners = ConfigurationOwners::from_legacy(&config, &windows_id);
+    owners
+        .device_profiles
+        .get_mut(&deck_id)
+        .unwrap()
+        .quick_action
+        .quick_action_game_id = Some("deck-only-selection".to_string());
+    owners
+        .device_profiles
+        .get_mut(&deck_id)
+        .unwrap()
+        .behavior
+        .max_extra_backup_count = 37;
+    let mut edited = owners.assemble_effective().unwrap();
+    edited.quick_action.quick_action_game_id = Some("windows-selection".to_string());
+    edited.settings.max_extra_backup_count = 9;
+
+    owners.merge_effective(&edited).unwrap();
+
+    let windows = &owners.device_profiles[&windows_id];
+    let deck = &owners.device_profiles[&deck_id];
+    assert_eq!(
+        windows.quick_action.quick_action_game_id.as_deref(),
+        Some("windows-selection")
+    );
+    assert_eq!(windows.behavior.max_extra_backup_count, 9);
+    assert_eq!(
+        deck.quick_action.quick_action_game_id.as_deref(),
+        Some("deck-only-selection")
+    );
+    assert_eq!(deck.behavior.max_extra_backup_count, 37);
+}
+
+#[test]
+fn normal_save_removes_an_explicitly_deleted_device_profile() {
+    let (config, windows_id, deck_id) = dual_device_config();
+    let mut owners = ConfigurationOwners::from_legacy(&config, &windows_id);
+    let mut edited = owners.assemble_effective().unwrap();
+    edited.devices.remove(&deck_id);
+    edited.games[0].game_paths.remove(&deck_id);
+    if let crate::backup::SaveUnitSource::Concrete { paths, .. } =
+        &mut edited.games[0].save_paths[0].source
+    {
+        paths.remove(&deck_id);
+    }
+
+    owners.merge_effective(&edited).unwrap();
+
+    assert!(!owners.device_profiles.contains_key(&deck_id));
+}
+
+#[test]
+fn validation_rejects_unsupported_owner_schema() {
+    let (config, windows_id, _) = dual_device_config();
+    let mut owners = ConfigurationOwners::from_legacy(&config, &windows_id);
+    owners.shared_library.schema_version = 99;
+
+    let result = owners.validate();
+
+    assert!(matches!(
+        result,
+        Err(OwnershipError::UnsupportedSchema { found: 99, .. })
+    ));
+}

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -1,18 +1,19 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::{LazyLock, Mutex as StdMutex};
 #[cfg(test)]
-use std::sync::LazyLock;
-#[cfg(test)]
-use tokio::sync::{Mutex, MutexGuard};
+use tokio::sync::{Mutex as TokioMutex, MutexGuard};
 
 use crate::app_dirs::resolve_app_path;
-use crate::config::Config;
+use crate::config::owner_store::OwnerStore;
+use crate::config::{Config, backup};
 use crate::preclude::*;
 use crate::updater::update_config;
 use log::info;
 
 #[cfg(test)]
-static CONFIG_FILE_TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+static CONFIG_FILE_TEST_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
+static CONFIG_STORE_LOCK: LazyLock<StdMutex<()>> = LazyLock::new(|| StdMutex::new(()));
 
 #[cfg(test)]
 pub(crate) fn lock_config_test_file() -> MutexGuard<'static, ()> {
@@ -45,6 +46,17 @@ fn init_config() -> Result<(), ConfigError> {
 
 /// Get the current config file
 pub fn get_config() -> Result<Config, ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    get_config_unlocked()
+}
+
+fn get_config_unlocked() -> Result<Config, ConfigError> {
+    let owner_store = OwnerStore::runtime();
+    if owner_store.has_authoritative_state() {
+        return Ok(owner_store.load_effective()?);
+    }
     let config_path = resolve_app_path("GameSaveManager.config.json");
     let content = fs::read_to_string(config_path)?;
     Ok(serde_json::from_str(&content)?)
@@ -52,14 +64,37 @@ pub fn get_config() -> Result<Config, ConfigError> {
 
 /// Replace the config file with a new config struct without triggering cloud sync.
 pub fn set_config_local(config: &Config) -> Result<(), ConfigError> {
-    // Rotate backups before overwriting
-    crate::config::backup::rotate_config_backups();
-    let config_path = resolve_app_path("GameSaveManager.config.json");
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
     let mut normalized = config.clone();
     for game in &mut normalized.games {
         game.normalize_save_unit_ids();
     }
-    fs::write(config_path, serde_json::to_string_pretty(&normalized)?)?;
+    if let Ok(previous) = get_config_unlocked() {
+        backup::rotate_config_backups(&previous);
+    }
+    OwnerStore::runtime().merge_effective(&normalized)?;
+    Ok(())
+}
+
+/// Replace every local owner from one effective Config.
+///
+/// This is intentionally narrower than `set_config_local`: only explicit V1
+/// remote acceptance, import, or recovery flows should replace other Devices'
+/// Profiles.
+pub fn replace_config_local(config: &Config) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    let mut normalized = config.clone();
+    for game in &mut normalized.games {
+        game.normalize_save_unit_ids();
+    }
+    if let Ok(previous) = get_config_unlocked() {
+        backup::rotate_config_backups(&previous);
+    }
+    OwnerStore::runtime().replace_effective(&normalized)?;
     Ok(())
 }
 
@@ -74,6 +109,18 @@ pub async fn set_config(config: &Config) -> Result<(), ConfigError> {
 /// if not, then create one
 /// then send the config to the front end
 pub fn config_check() -> Result<ConfigCheckOutcome, ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    let owner_store = OwnerStore::runtime();
+    if owner_store.has_authoritative_state() {
+        let config = owner_store.load_effective()?;
+        rust_i18n::set_locale(&config.settings.locale);
+        return Ok(ConfigCheckOutcome {
+            config_migrated: false,
+        });
+    }
+
     let config_path = resolve_app_path("GameSaveManager.config.json");
     info!("Config file path: {}", config_path.display());
 
@@ -82,8 +129,10 @@ pub fn config_check() -> Result<ConfigCheckOutcome, ConfigError> {
     }
     // 执行配置迁移与升级
     let config_migrated = update_config(&config_path)?;
-    // 重新加载配置
-    let config = get_config()?;
+    let content = fs::read_to_string(&config_path)?;
+    let config: Config = serde_json::from_str(&content)?;
+    owner_store.initialize_from_legacy(&config)?;
+    let config = owner_store.load_effective()?;
     // 应用本地化语言
     rust_i18n::set_locale(&config.settings.locale);
     Ok(ConfigCheckOutcome { config_migrated })

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -160,6 +160,10 @@ pub enum ConfigError {
     Io(#[from] io::Error),
     #[error("Backend error: {0:#?}")]
     Backend(Box<BackendError>),
+    #[error("Configuration store lock is poisoned")]
+    StoreLockPoisoned,
+    #[error(transparent)]
+    OwnerStore(#[from] crate::config::OwnerStoreError),
     #[error(transparent)]
     Updater(#[from] UpdaterError),
 }

--- a/crates/rgsm-core/src/services/config.rs
+++ b/crates/rgsm-core/src/services/config.rs
@@ -18,7 +18,8 @@ impl ServiceContext {
     }
 
     pub fn restore_config_backup(&self, index: usize) -> Result<Config, ConfigError> {
-        config::backup::restore_config_from_backup(index)?;
+        let backup = config::backup::load_config_from_backup(index)?;
+        config::replace_config_local(&backup)?;
         get_config()
     }
 


### PR DESCRIPTION
## 概要

- 将 Shared Library、Local State 与 Device Profile 持久化为独立的本地 owner 文件
- 增加整组配置的事务提交与中断恢复
- 保留 Effective Config 兼容接口，并区分普通设备保存与 V1 全量替换
