### PR TITLE
feat(cloud-sync): add V2 manifest foundation

### DIFF
--- a/crates/rgsm-core/src/cloud_sync/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/mod.rs
@@ -9,6 +9,7 @@ pub mod sync_state;
 mod task_manager;
 pub mod transfer;
 mod utils;
+pub mod v2;
 
 pub use backend::{
     Backend, CloudBackendCheckItem, CloudBackendCheckItemStatus, CloudBackendCheckOutcome,

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion.rs
@@ -1,0 +1,329 @@
+use std::path::Path;
+
+use async_trait::async_trait;
+use opendal::Operator;
+use thiserror::Error;
+
+use super::{CloudManifestRepository, DeletionKind, ManifestRepositoryError, ManifestTransport};
+
+#[async_trait]
+pub trait ArchiveDeletionBackend: Send + Sync {
+    async fn remove_local(&self, path: &Path) -> Result<(), ArchiveDeletionError>;
+    async fn remove_cloud(&self, path: &str) -> Result<(), ArchiveDeletionError>;
+    async fn cloud_exists(&self, path: &str) -> Result<bool, ArchiveDeletionError>;
+}
+
+pub struct OpenDalArchiveDeletionBackend {
+    operator: Operator,
+}
+
+impl OpenDalArchiveDeletionBackend {
+    pub fn new(operator: Operator) -> Self {
+        Self { operator }
+    }
+}
+
+#[async_trait]
+impl ArchiveDeletionBackend for OpenDalArchiveDeletionBackend {
+    async fn remove_local(&self, path: &Path) -> Result<(), ArchiveDeletionError> {
+        match tokio::fs::remove_file(path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn remove_cloud(&self, path: &str) -> Result<(), ArchiveDeletionError> {
+        self.operator.delete(path).await?;
+        Ok(())
+    }
+
+    async fn cloud_exists(&self, path: &str) -> Result<bool, ArchiveDeletionError> {
+        Ok(self.operator.exists(path).await?)
+    }
+}
+
+pub struct GlobalSnapshotDeletion;
+
+pub struct SnapshotDeletionRequest<'a> {
+    pub game_id: &'a str,
+    pub snapshot_id: &'a str,
+    pub acting_device: &'a str,
+    pub kind: DeletionKind,
+    pub local_archive_path: &'a Path,
+    pub cloud_archive_path: &'a str,
+}
+
+impl GlobalSnapshotDeletion {
+    pub async fn execute<T: ManifestTransport, B: ArchiveDeletionBackend>(
+        repository: &CloudManifestRepository<T>,
+        backend: &B,
+        request: SnapshotDeletionRequest<'_>,
+    ) -> Result<(), GlobalSnapshotDeletionError> {
+        if repository
+            .load()
+            .await?
+            .games
+            .get(request.game_id)
+            .is_some_and(|game| game.is_final_tombstone(request.snapshot_id))
+        {
+            return Ok(());
+        }
+
+        repository
+            .mutate(|manifest| {
+                manifest.game_mut(request.game_id).begin_deletion(
+                    request.snapshot_id,
+                    request.acting_device,
+                    request.kind.clone(),
+                )?;
+                Ok(())
+            })
+            .await?;
+
+        backend.remove_local(request.local_archive_path).await?;
+        repository
+            .mutate(|manifest| {
+                manifest
+                    .game_mut(request.game_id)
+                    .mark_acting_local_removed(request.snapshot_id, request.acting_device)
+            })
+            .await?;
+
+        backend.remove_cloud(request.cloud_archive_path).await?;
+        if backend.cloud_exists(request.cloud_archive_path).await? {
+            return Err(GlobalSnapshotDeletionError::CloudArchiveStillPresent(
+                request.cloud_archive_path.to_string(),
+            ));
+        }
+        repository
+            .mutate(|manifest| {
+                manifest
+                    .game_mut(request.game_id)
+                    .mark_cloud_absent(request.snapshot_id, request.acting_device)
+            })
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ArchiveDeletionError {
+    #[error("Local Archive deletion error: {0}")]
+    Local(#[from] std::io::Error),
+    #[error("Cloud Archive deletion error: {0}")]
+    Cloud(#[from] opendal::Error),
+}
+
+#[derive(Debug, Error)]
+pub enum GlobalSnapshotDeletionError {
+    #[error(transparent)]
+    Repository(#[from] ManifestRepositoryError),
+    #[error(transparent)]
+    Archive(#[from] ArchiveDeletionError),
+    #[error("Cloud Archive is still provider-visible after deletion: {0}")]
+    CloudArchiveStillPresent(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::CreatedBy;
+    use crate::cloud_sync::v2::{
+        ArchiveIntegrity, CloudManifest, GameManifest, ManifestTransport, SnapshotNode,
+        SnapshotState,
+    };
+
+    struct MemoryManifestTransport {
+        bytes: std::sync::Mutex<Option<Vec<u8>>>,
+    }
+
+    #[async_trait]
+    impl ManifestTransport for MemoryManifestTransport {
+        async fn read(&self) -> Result<Option<Vec<u8>>, opendal::Error> {
+            Ok(self.bytes.lock().unwrap().clone())
+        }
+
+        async fn write(&self, bytes: &[u8]) -> Result<(), opendal::Error> {
+            *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    struct FailLocalOnce<B> {
+        inner: B,
+        fail: AtomicBool,
+    }
+
+    struct ReportCloudPresentOnce<B> {
+        inner: B,
+        report_present: AtomicBool,
+    }
+
+    #[async_trait]
+    impl<B: ArchiveDeletionBackend> ArchiveDeletionBackend for FailLocalOnce<B> {
+        async fn remove_local(&self, path: &Path) -> Result<(), ArchiveDeletionError> {
+            if self.fail.swap(false, Ordering::SeqCst) {
+                return Err(std::io::Error::other("injected local failure").into());
+            }
+            self.inner.remove_local(path).await
+        }
+
+        async fn remove_cloud(&self, path: &str) -> Result<(), ArchiveDeletionError> {
+            self.inner.remove_cloud(path).await
+        }
+
+        async fn cloud_exists(&self, path: &str) -> Result<bool, ArchiveDeletionError> {
+            self.inner.cloud_exists(path).await
+        }
+    }
+
+    #[async_trait]
+    impl<B: ArchiveDeletionBackend> ArchiveDeletionBackend for ReportCloudPresentOnce<B> {
+        async fn remove_local(&self, path: &Path) -> Result<(), ArchiveDeletionError> {
+            self.inner.remove_local(path).await
+        }
+
+        async fn remove_cloud(&self, path: &str) -> Result<(), ArchiveDeletionError> {
+            self.inner.remove_cloud(path).await
+        }
+
+        async fn cloud_exists(&self, path: &str) -> Result<bool, ArchiveDeletionError> {
+            if self.report_present.swap(false, Ordering::SeqCst) {
+                return Ok(true);
+            }
+            self.inner.cloud_exists(path).await
+        }
+    }
+
+    async fn repository() -> CloudManifestRepository<MemoryManifestTransport> {
+        let transport = MemoryManifestTransport {
+            bytes: std::sync::Mutex::new(None),
+        };
+        let repository = CloudManifestRepository::with_transport(transport, 2);
+        repository
+            .mutate(|manifest| {
+                let game = manifest
+                    .games
+                    .entry("game".into())
+                    .or_insert_with(|| GameManifest::new("game"));
+                game.upsert_live(SnapshotNode::live(
+                    "snapshot",
+                    None,
+                    ArchiveIntegrity {
+                        size: 1,
+                        xxh3_64: "0000000000000000".into(),
+                    },
+                    CreatedBy::Manual,
+                ))?;
+                game.set_head("pc".into(), "snapshot".into());
+                game.report_local_archive("pc".into(), "snapshot".into(), true);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        repository
+    }
+
+    fn memory_operator() -> Operator {
+        Operator::new(services::Memory::default()).unwrap().finish()
+    }
+
+    #[tokio::test]
+    async fn deletion_is_pending_before_bytes_and_retry_reaches_final() {
+        let repository = repository().await;
+        let operator = memory_operator();
+        operator.write("archive.7z", b"x".to_vec()).await.unwrap();
+        let root = temp_dir::TempDir::new().unwrap();
+        let local = root.path().join("archive.7z");
+        tokio::fs::write(&local, b"x").await.unwrap();
+        let backend = FailLocalOnce {
+            inner: OpenDalArchiveDeletionBackend::new(operator.clone()),
+            fail: AtomicBool::new(true),
+        };
+
+        assert!(
+            GlobalSnapshotDeletion::execute(
+                &repository,
+                &backend,
+                SnapshotDeletionRequest {
+                    game_id: "game",
+                    snapshot_id: "snapshot",
+                    acting_device: "pc",
+                    kind: DeletionKind::User,
+                    local_archive_path: &local,
+                    cloud_archive_path: "archive.7z",
+                },
+            )
+            .await
+            .is_err()
+        );
+        let pending = repository.load().await.unwrap();
+        assert!(matches!(
+            pending.games["game"].snapshots["snapshot"].state,
+            SnapshotState::PendingTombstone(_)
+        ));
+        assert!(local.exists());
+        assert!(operator.exists("archive.7z").await.unwrap());
+
+        GlobalSnapshotDeletion::execute(
+            &repository,
+            &backend,
+            SnapshotDeletionRequest {
+                game_id: "game",
+                snapshot_id: "snapshot",
+                acting_device: "pc",
+                kind: DeletionKind::User,
+                local_archive_path: &local,
+                cloud_archive_path: "archive.7z",
+            },
+        )
+        .await
+        .unwrap();
+
+        let final_manifest: CloudManifest = repository.load().await.unwrap();
+        assert!(final_manifest.games["game"].is_final_tombstone("snapshot"));
+        assert!(!local.exists());
+        assert!(!operator.exists("archive.7z").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn provider_visibility_failure_remains_pending_and_is_retryable() {
+        let repository = repository().await;
+        let operator = memory_operator();
+        operator.write("archive.7z", b"x".to_vec()).await.unwrap();
+        let root = temp_dir::TempDir::new().unwrap();
+        let local = root.path().join("archive.7z");
+        tokio::fs::write(&local, b"x").await.unwrap();
+        let backend = ReportCloudPresentOnce {
+            inner: OpenDalArchiveDeletionBackend::new(operator),
+            report_present: AtomicBool::new(true),
+        };
+        let request = || SnapshotDeletionRequest {
+            game_id: "game",
+            snapshot_id: "snapshot",
+            acting_device: "pc",
+            kind: DeletionKind::User,
+            local_archive_path: &local,
+            cloud_archive_path: "archive.7z",
+        };
+
+        assert!(matches!(
+            GlobalSnapshotDeletion::execute(&repository, &backend, request()).await,
+            Err(GlobalSnapshotDeletionError::CloudArchiveStillPresent(_))
+        ));
+        assert!(matches!(
+            repository.load().await.unwrap().games["game"].snapshots["snapshot"].state,
+            SnapshotState::PendingTombstone(_)
+        ));
+
+        GlobalSnapshotDeletion::execute(&repository, &backend, request())
+            .await
+            .unwrap();
+        assert!(repository.load().await.unwrap().games["game"].is_final_tombstone("snapshot"));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/integrity.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/integrity.rs
@@ -1,0 +1,101 @@
+use std::fs::File;
+use std::hash::Hasher;
+use std::io::Read;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use xxhash_rust::xxh3::Xxh3;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchiveIntegrity {
+    pub size: u64,
+    pub xxh3_64: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ArchiveIntegrityError {
+    #[error("Archive integrity I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error(
+        "Archive integrity mismatch: expected {expected_size} bytes/{expected_hash}, \
+         got {actual_size} bytes/{actual_hash}"
+    )]
+    Mismatch {
+        expected_size: u64,
+        expected_hash: String,
+        actual_size: u64,
+        actual_hash: String,
+    },
+}
+
+impl ArchiveIntegrity {
+    /// Stream a file once and calculate both its byte size and XXH3-64 digest.
+    ///
+    /// Time is O(n) and additional space is O(1) for an n-byte Archive.
+    pub fn from_file(path: &Path) -> Result<Self, ArchiveIntegrityError> {
+        let mut file = File::open(path)?;
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut hasher = Xxh3::new();
+        let mut size = 0_u64;
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            hasher.write(&buffer[..read]);
+            size = size
+                .checked_add(read as u64)
+                .ok_or_else(|| std::io::Error::other("Archive size overflow"))?;
+        }
+        Ok(Self {
+            size,
+            xxh3_64: format!("{:016x}", hasher.finish()),
+        })
+    }
+
+    pub fn verify_file(&self, path: &Path) -> Result<(), ArchiveIntegrityError> {
+        let actual = Self::from_file(path)?;
+        if actual == *self {
+            return Ok(());
+        }
+        Err(ArchiveIntegrityError::Mismatch {
+            expected_size: self.size,
+            expected_hash: self.xxh3_64.clone(),
+            actual_size: actual.size,
+            actual_hash: actual.xxh3_64,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_integrity_covers_size_and_hash() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let path = root.path().join("snapshot.7z");
+        std::fs::write(&path, b"archive-bytes").unwrap();
+
+        let integrity = ArchiveIntegrity::from_file(&path).unwrap();
+
+        assert_eq!(integrity.size, 13);
+        assert_eq!(integrity.xxh3_64.len(), 16);
+        integrity.verify_file(&path).unwrap();
+    }
+
+    #[test]
+    fn verification_rejects_same_size_corruption() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let path = root.path().join("snapshot.7z");
+        std::fs::write(&path, b"before").unwrap();
+        let integrity = ArchiveIntegrity::from_file(&path).unwrap();
+        std::fs::write(&path, b"after!").unwrap();
+
+        assert!(matches!(
+            integrity.verify_file(&path),
+            Err(ArchiveIntegrityError::Mismatch { .. })
+        ));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
@@ -1,0 +1,564 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::ArchiveIntegrity;
+use crate::backup::CreatedBy;
+use crate::device::DeviceId;
+
+pub const CLOUD_MANIFEST_SCHEMA_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudManifest {
+    pub schema_version: u32,
+    pub revision: u64,
+    pub games: BTreeMap<String, GameManifest>,
+}
+
+impl Default for CloudManifest {
+    fn default() -> Self {
+        Self {
+            schema_version: CLOUD_MANIFEST_SCHEMA_VERSION,
+            revision: 0,
+            games: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GameManifest {
+    pub game_id: String,
+    pub snapshots: BTreeMap<String, SnapshotNode>,
+    pub device_heads: BTreeMap<DeviceId, String>,
+    pub local_archives: BTreeMap<DeviceId, BTreeSet<String>>,
+}
+
+impl GameManifest {
+    pub fn new(game_id: impl Into<String>) -> Self {
+        Self {
+            game_id: game_id.into(),
+            snapshots: BTreeMap::new(),
+            device_heads: BTreeMap::new(),
+            local_archives: BTreeMap::new(),
+        }
+    }
+
+    pub fn upsert_live(&mut self, node: SnapshotNode) -> Result<(), ManifestError> {
+        if !node.state.is_live() {
+            return Err(ManifestError::ExpectedLive(node.snapshot_id));
+        }
+        if self
+            .snapshots
+            .get(&node.snapshot_id)
+            .is_some_and(|existing| !existing.state.is_live())
+        {
+            return Err(ManifestError::TombstoneResurrection(node.snapshot_id));
+        }
+        self.snapshots.insert(node.snapshot_id.clone(), node);
+        Ok(())
+    }
+
+    pub fn set_head(&mut self, device_id: DeviceId, snapshot_id: String) {
+        self.device_heads.insert(device_id, snapshot_id);
+    }
+
+    pub fn report_local_archive(
+        &mut self,
+        device_id: DeviceId,
+        snapshot_id: String,
+        present: bool,
+    ) {
+        let report = self.local_archives.entry(device_id).or_default();
+        let accepts_presence = self
+            .snapshots
+            .get(&snapshot_id)
+            .is_some_and(|node| node.state.is_live());
+        if present && accepts_presence {
+            report.insert(snapshot_id);
+        } else {
+            report.remove(&snapshot_id);
+        }
+    }
+
+    pub fn begin_deletion(
+        &mut self,
+        snapshot_id: &str,
+        acting_device: &str,
+        kind: DeletionKind,
+    ) -> Result<bool, ManifestError> {
+        let node = self
+            .snapshots
+            .get_mut(snapshot_id)
+            .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id.to_string()))?;
+        match &node.state {
+            SnapshotState::FinalTombstone { kind: existing } if existing == &kind => {
+                return Ok(false);
+            }
+            SnapshotState::PendingTombstone(existing)
+                if existing.kind == kind && existing.acting_device == acting_device =>
+            {
+                return Ok(false);
+            }
+            SnapshotState::Live(_) => {}
+            _ => return Err(ManifestError::DeletionConflict(snapshot_id.to_string())),
+        }
+        node.state = SnapshotState::PendingTombstone(PendingTombstone {
+            kind,
+            acting_device: acting_device.to_string(),
+            acting_local_removed: false,
+            cloud_archive_absent: false,
+        });
+        self.device_heads.retain(|_, head| head != snapshot_id);
+        for report in self.local_archives.values_mut() {
+            report.remove(snapshot_id);
+        }
+        Ok(true)
+    }
+
+    pub fn mark_acting_local_removed(
+        &mut self,
+        snapshot_id: &str,
+        acting_device: &str,
+    ) -> Result<(), ManifestError> {
+        {
+            let pending = self.pending_mut(snapshot_id, acting_device)?;
+            pending.acting_local_removed = true;
+        }
+        self.report_local_archive(acting_device.to_string(), snapshot_id.to_string(), false);
+        Ok(())
+    }
+
+    pub fn mark_cloud_absent(
+        &mut self,
+        snapshot_id: &str,
+        acting_device: &str,
+    ) -> Result<(), ManifestError> {
+        let node = self
+            .snapshots
+            .get_mut(snapshot_id)
+            .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id.to_string()))?;
+        let SnapshotState::PendingTombstone(pending) = &mut node.state else {
+            return if matches!(node.state, SnapshotState::FinalTombstone { .. }) {
+                Ok(())
+            } else {
+                Err(ManifestError::DeletionConflict(snapshot_id.to_string()))
+            };
+        };
+        if pending.acting_device != acting_device {
+            return Err(ManifestError::DeletionConflict(snapshot_id.to_string()));
+        }
+        pending.cloud_archive_absent = true;
+        if pending.acting_local_removed {
+            node.state = SnapshotState::FinalTombstone {
+                kind: pending.kind.clone(),
+            };
+        }
+        Ok(())
+    }
+
+    fn pending_mut(
+        &mut self,
+        snapshot_id: &str,
+        acting_device: &str,
+    ) -> Result<&mut PendingTombstone, ManifestError> {
+        let node = self
+            .snapshots
+            .get_mut(snapshot_id)
+            .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id.to_string()))?;
+        if matches!(node.state, SnapshotState::FinalTombstone { .. }) {
+            return Err(ManifestError::DeletionAlreadyFinal(snapshot_id.to_string()));
+        }
+        let SnapshotState::PendingTombstone(pending) = &mut node.state else {
+            return Err(ManifestError::DeletionConflict(snapshot_id.to_string()));
+        };
+        if pending.acting_device != acting_device {
+            return Err(ManifestError::DeletionConflict(snapshot_id.to_string()));
+        }
+        Ok(pending)
+    }
+
+    pub fn is_final_tombstone(&self, snapshot_id: &str) -> bool {
+        self.snapshots
+            .get(snapshot_id)
+            .is_some_and(|node| matches!(node.state, SnapshotState::FinalTombstone { .. }))
+    }
+
+    /// Return whether `ancestor` is the same node as, or an ancestor of, `descendant`.
+    ///
+    /// Time is O(V) and safety space is O(V) for V Snapshot nodes.
+    pub fn is_ancestor_or_equal(
+        &self,
+        ancestor: &str,
+        descendant: &str,
+    ) -> Result<bool, ManifestError> {
+        if !self.snapshots.contains_key(ancestor) {
+            return Err(ManifestError::MissingSnapshot(ancestor.to_string()));
+        }
+        let mut cursor = descendant;
+        let mut visited = HashSet::new();
+        loop {
+            if cursor == ancestor {
+                return Ok(true);
+            }
+            if !visited.insert(cursor) {
+                return Err(ManifestError::ParentCycle(cursor.to_string()));
+            }
+            let node = self
+                .snapshots
+                .get(cursor)
+                .ok_or_else(|| ManifestError::MissingSnapshot(cursor.to_string()))?;
+            let Some(parent) = node.parent.as_deref() else {
+                return Ok(false);
+            };
+            cursor = parent;
+        }
+    }
+
+    /// Return distinct Device Head values that are not ancestors of another Head.
+    ///
+    /// For H Heads and V nodes this intentionally simple implementation is
+    /// O(H²V) time and O(H + V) additional space.
+    pub fn maximal_heads(&self) -> Result<BTreeSet<String>, ManifestError> {
+        self.validate()?;
+        let heads = self.device_heads.values().cloned().collect::<BTreeSet<_>>();
+        let mut maximal = BTreeSet::new();
+        for candidate in &heads {
+            let mut dominated = false;
+            for other in &heads {
+                if candidate != other && self.is_ancestor_or_equal(candidate, other)? {
+                    dominated = true;
+                    break;
+                }
+            }
+            if !dominated {
+                maximal.insert(candidate.clone());
+            }
+        }
+        Ok(maximal)
+    }
+
+    fn validate_parent_chain(&self, start: &str) -> Result<(), ManifestError> {
+        let mut cursor = start;
+        let mut visited = HashSet::new();
+        loop {
+            if !visited.insert(cursor) {
+                return Err(ManifestError::ParentCycle(cursor.to_string()));
+            }
+            let node = self
+                .snapshots
+                .get(cursor)
+                .ok_or_else(|| ManifestError::MissingSnapshot(cursor.to_string()))?;
+            let Some(parent) = node.parent.as_deref() else {
+                return Ok(());
+            };
+            cursor = parent;
+        }
+    }
+
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        for (snapshot_id, node) in &self.snapshots {
+            if snapshot_id != &node.snapshot_id {
+                return Err(ManifestError::SnapshotIdentityMismatch {
+                    key: snapshot_id.clone(),
+                    embedded: node.snapshot_id.clone(),
+                });
+            }
+            if let Some(parent) = &node.parent
+                && !self.snapshots.contains_key(parent)
+            {
+                return Err(ManifestError::MissingParent {
+                    snapshot: snapshot_id.clone(),
+                    parent: parent.clone(),
+                });
+            }
+            if let SnapshotState::Live(live) = &node.state
+                && (live.integrity.xxh3_64.len() != 16
+                    || !live
+                        .integrity
+                        .xxh3_64
+                        .bytes()
+                        .all(|byte| byte.is_ascii_hexdigit()))
+            {
+                return Err(ManifestError::InvalidIntegrity(snapshot_id.clone()));
+            }
+        }
+        for snapshot_id in self.snapshots.keys() {
+            self.validate_parent_chain(snapshot_id)?;
+        }
+        for (device_id, head) in &self.device_heads {
+            let node = self
+                .snapshots
+                .get(head)
+                .ok_or_else(|| ManifestError::InvalidHead {
+                    device: device_id.clone(),
+                    snapshot: head.clone(),
+                })?;
+            if !node.state.is_live() {
+                return Err(ManifestError::InvalidHead {
+                    device: device_id.clone(),
+                    snapshot: head.clone(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SnapshotNode {
+    pub snapshot_id: String,
+    pub parent: Option<String>,
+    pub state: SnapshotState,
+}
+
+impl SnapshotNode {
+    pub fn live(
+        snapshot_id: impl Into<String>,
+        parent: Option<String>,
+        integrity: ArchiveIntegrity,
+        created_by: CreatedBy,
+    ) -> Self {
+        Self {
+            snapshot_id: snapshot_id.into(),
+            parent,
+            state: SnapshotState::Live(LiveSnapshot {
+                integrity,
+                cloud_archive_verified: false,
+                created_by,
+                retention_protected: false,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SnapshotState {
+    Live(LiveSnapshot),
+    PendingTombstone(PendingTombstone),
+    FinalTombstone { kind: DeletionKind },
+}
+
+impl SnapshotState {
+    pub fn is_live(&self) -> bool {
+        matches!(self, Self::Live(_))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LiveSnapshot {
+    pub integrity: ArchiveIntegrity,
+    pub cloud_archive_verified: bool,
+    pub created_by: CreatedBy,
+    pub retention_protected: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingTombstone {
+    pub kind: DeletionKind,
+    pub acting_device: DeviceId,
+    pub acting_local_removed: bool,
+    pub cloud_archive_absent: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeletionKind {
+    User,
+    Retention,
+    GameDeletion,
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ManifestError {
+    #[error("Unsupported Cloud Manifest schema {found}; expected {expected}")]
+    UnsupportedSchema { expected: u32, found: u32 },
+    #[error("Game identity mismatch: key {key}, embedded {embedded}")]
+    GameIdentityMismatch { key: String, embedded: String },
+    #[error("Snapshot identity mismatch: key {key}, embedded {embedded}")]
+    SnapshotIdentityMismatch { key: String, embedded: String },
+    #[error("Snapshot {snapshot} references missing parent {parent}")]
+    MissingParent { snapshot: String, parent: String },
+    #[error("Snapshot parent cycle contains {0}")]
+    ParentCycle(String),
+    #[error("Device {device} Head references missing or non-live Snapshot {snapshot}")]
+    InvalidHead { device: DeviceId, snapshot: String },
+    #[error("Snapshot does not exist: {0}")]
+    MissingSnapshot(String),
+    #[error("Expected a live Snapshot: {0}")]
+    ExpectedLive(String),
+    #[error("Snapshot has invalid XXH3-64 integrity: {0}")]
+    InvalidIntegrity(String),
+    #[error("Tombstoned Snapshot cannot be resurrected: {0}")]
+    TombstoneResurrection(String),
+    #[error("Snapshot deletion conflicts with existing Tombstone state: {0}")]
+    DeletionConflict(String),
+    #[error("Snapshot deletion is already Final: {0}")]
+    DeletionAlreadyFinal(String),
+}
+
+impl CloudManifest {
+    pub fn validate(&self) -> Result<(), ManifestError> {
+        if self.schema_version != CLOUD_MANIFEST_SCHEMA_VERSION {
+            return Err(ManifestError::UnsupportedSchema {
+                expected: CLOUD_MANIFEST_SCHEMA_VERSION,
+                found: self.schema_version,
+            });
+        }
+        for (game_id, game) in &self.games {
+            if game_id != &game.game_id {
+                return Err(ManifestError::GameIdentityMismatch {
+                    key: game_id.clone(),
+                    embedded: game.game_id.clone(),
+                });
+            }
+            game.validate()?;
+        }
+        Ok(())
+    }
+
+    pub fn game_mut(&mut self, game_id: &str) -> &mut GameManifest {
+        self.games
+            .entry(game_id.to_string())
+            .or_insert_with(|| GameManifest::new(game_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn integrity() -> ArchiveIntegrity {
+        ArchiveIntegrity {
+            size: 10,
+            xxh3_64: "0123456789abcdef".into(),
+        }
+    }
+
+    fn live(id: &str, parent: Option<&str>) -> SnapshotNode {
+        SnapshotNode::live(
+            id,
+            parent.map(str::to_string),
+            integrity(),
+            CreatedBy::Manual,
+        )
+    }
+
+    #[test]
+    fn parallel_heads_return_only_maximal_lineages() {
+        let mut game = GameManifest::new("game");
+        for node in [
+            live("root", None),
+            live("a", Some("root")),
+            live("a2", Some("a")),
+            live("b", Some("root")),
+        ] {
+            game.upsert_live(node).unwrap();
+        }
+        game.set_head("pc".into(), "a".into());
+        game.set_head("deck".into(), "a2".into());
+        game.set_head("laptop".into(), "b".into());
+
+        assert_eq!(
+            game.maximal_heads().unwrap(),
+            BTreeSet::from(["a2".to_string(), "b".to_string()])
+        );
+        assert!(matches!(
+            game.is_ancestor_or_equal("missing", "root"),
+            Err(ManifestError::MissingSnapshot(_))
+        ));
+    }
+
+    #[test]
+    fn malformed_graphs_fail_closed() {
+        let mut missing = GameManifest::new("game");
+        missing.upsert_live(live("child", Some("missing"))).unwrap();
+        assert!(matches!(
+            missing.validate(),
+            Err(ManifestError::MissingParent { .. })
+        ));
+
+        let mut cycle = GameManifest::new("game");
+        cycle.upsert_live(live("a", Some("b"))).unwrap();
+        cycle.upsert_live(live("b", Some("a"))).unwrap();
+        assert!(matches!(
+            cycle.validate(),
+            Err(ManifestError::ParentCycle(_))
+        ));
+
+        let mut invalid_head = GameManifest::new("game");
+        invalid_head.set_head("pc".into(), "missing".into());
+        assert!(matches!(
+            invalid_head.validate(),
+            Err(ManifestError::InvalidHead { .. })
+        ));
+    }
+
+    #[test]
+    fn tombstone_dominates_stale_live_upsert() {
+        let mut game = GameManifest::new("game");
+        game.upsert_live(live("snapshot", None)).unwrap();
+        game.begin_deletion("snapshot", "pc", DeletionKind::User)
+            .unwrap();
+        game.report_local_archive("deck".into(), "snapshot".into(), true);
+        assert!(!game.local_archives["deck"].contains("snapshot"));
+
+        assert_eq!(
+            game.upsert_live(live("snapshot", None)),
+            Err(ManifestError::TombstoneResurrection("snapshot".to_string()))
+        );
+
+        game.mark_acting_local_removed("snapshot", "pc").unwrap();
+        game.mark_cloud_absent("snapshot", "pc").unwrap();
+        assert!(game.is_final_tombstone("snapshot"));
+        assert_eq!(
+            game.upsert_live(live("snapshot", None)),
+            Err(ManifestError::TombstoneResurrection("snapshot".to_string()))
+        );
+    }
+
+    #[test]
+    fn unsupported_schema_fails_closed() {
+        let mut manifest = CloudManifest::default();
+        manifest.schema_version += 1;
+
+        assert!(matches!(
+            manifest.validate(),
+            Err(ManifestError::UnsupportedSchema { .. })
+        ));
+
+        let mut invalid_integrity = CloudManifest::default();
+        invalid_integrity
+            .game_mut("game")
+            .upsert_live(SnapshotNode::live(
+                "snapshot",
+                None,
+                ArchiveIntegrity {
+                    size: 1,
+                    xxh3_64: "not-a-hash".into(),
+                },
+                CreatedBy::Manual,
+            ))
+            .unwrap();
+        assert!(matches!(
+            invalid_integrity.validate(),
+            Err(ManifestError::InvalidIntegrity(_))
+        ));
+    }
+
+    #[test]
+    fn deterministic_manifest_round_trip() {
+        let mut manifest = CloudManifest::default();
+        let game = manifest.game_mut("game");
+        game.upsert_live(live("root", None)).unwrap();
+        game.report_local_archive("pc".into(), "root".into(), true);
+        manifest.validate().unwrap();
+
+        let first = serde_json::to_vec_pretty(&manifest).unwrap();
+        let decoded: CloudManifest = serde_json::from_slice(&first).unwrap();
+        let second = serde_json::to_vec_pretty(&decoded).unwrap();
+
+        assert_eq!(first, second);
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,0 +1,17 @@
+mod deletion;
+mod integrity;
+mod manifest;
+mod repository;
+
+pub use deletion::{
+    ArchiveDeletionBackend, ArchiveDeletionError, GlobalSnapshotDeletion,
+    GlobalSnapshotDeletionError, OpenDalArchiveDeletionBackend, SnapshotDeletionRequest,
+};
+pub use integrity::{ArchiveIntegrity, ArchiveIntegrityError};
+pub use manifest::{
+    CLOUD_MANIFEST_SCHEMA_VERSION, CloudManifest, DeletionKind, GameManifest, LiveSnapshot,
+    ManifestError, PendingTombstone, SnapshotNode, SnapshotState,
+};
+pub use repository::{
+    CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,
+};

--- a/crates/rgsm-core/src/cloud_sync/v2/repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/repository.rs
@@ -1,0 +1,211 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use opendal::{ErrorKind, Operator};
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use super::{CloudManifest, ManifestError};
+
+#[async_trait]
+pub trait ManifestTransport: Send + Sync {
+    async fn read(&self) -> Result<Option<Vec<u8>>, opendal::Error>;
+    async fn write(&self, bytes: &[u8]) -> Result<(), opendal::Error>;
+}
+
+pub struct OpenDalManifestTransport {
+    operator: Operator,
+    object_key: String,
+}
+
+impl OpenDalManifestTransport {
+    pub fn new(operator: Operator, object_key: impl Into<String>) -> Self {
+        Self {
+            operator,
+            object_key: object_key.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl ManifestTransport for OpenDalManifestTransport {
+    async fn read(&self) -> Result<Option<Vec<u8>>, opendal::Error> {
+        match self.operator.read(&self.object_key).await {
+            Ok(bytes) => Ok(Some(bytes.to_vec())),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn write(&self, bytes: &[u8]) -> Result<(), opendal::Error> {
+        self.operator
+            .write(&self.object_key, bytes.to_vec())
+            .await?;
+        Ok(())
+    }
+}
+
+pub struct CloudManifestRepository<T: ManifestTransport> {
+    transport: Arc<T>,
+    writer_lock: Mutex<()>,
+    max_attempts: usize,
+}
+
+impl CloudManifestRepository<OpenDalManifestTransport> {
+    pub fn new(operator: Operator, object_key: impl Into<String>, max_attempts: usize) -> Self {
+        Self::with_transport(
+            OpenDalManifestTransport::new(operator, object_key),
+            max_attempts,
+        )
+    }
+}
+
+impl<T: ManifestTransport> CloudManifestRepository<T> {
+    pub fn with_transport(transport: T, max_attempts: usize) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            writer_lock: Mutex::new(()),
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn load(&self) -> Result<CloudManifest, ManifestRepositoryError> {
+        let manifest = match self.transport.read().await? {
+            Some(bytes) => serde_json::from_slice(&bytes)?,
+            None => CloudManifest::default(),
+        };
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Apply one idempotent mutation to the latest remote Manifest.
+    ///
+    /// Each retry re-reads and re-applies the mutation. In-process writers are
+    /// serialized; cross-process safety is bounded by read-back visibility.
+    pub async fn mutate<F>(&self, mutation: F) -> Result<CloudManifest, ManifestRepositoryError>
+    where
+        F: Fn(&mut CloudManifest) -> Result<(), ManifestError>,
+    {
+        let _guard = self.writer_lock.lock().await;
+        for _ in 0..self.max_attempts {
+            let mut manifest = self.load().await?;
+            mutation(&mut manifest)?;
+            manifest.revision = manifest
+                .revision
+                .checked_add(1)
+                .ok_or(ManifestRepositoryError::RevisionOverflow)?;
+            manifest.validate()?;
+            let expected = serde_json::to_vec_pretty(&manifest)?;
+            self.transport.write(&expected).await?;
+            if self.transport.read().await?.as_deref() == Some(expected.as_slice()) {
+                return Ok(manifest);
+            }
+        }
+        Err(ManifestRepositoryError::RetryExhausted {
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ManifestRepositoryError {
+    #[error("Cloud Manifest transport error: {0}")]
+    Transport(#[from] opendal::Error),
+    #[error("Cloud Manifest serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error("Cloud Manifest revision overflow")]
+    RevisionOverflow,
+    #[error("Cloud Manifest read-back verification failed after {attempts} attempts")]
+    RetryExhausted { attempts: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+
+    use super::*;
+
+    struct FakeState {
+        bytes: Option<Vec<u8>>,
+        overwrite_writes: usize,
+    }
+
+    struct FakeTransport {
+        state: StdMutex<FakeState>,
+    }
+
+    impl FakeTransport {
+        fn new(overwrite_writes: usize) -> Self {
+            Self {
+                state: StdMutex::new(FakeState {
+                    bytes: None,
+                    overwrite_writes,
+                }),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ManifestTransport for FakeTransport {
+        async fn read(&self) -> Result<Option<Vec<u8>>, opendal::Error> {
+            Ok(self.state.lock().unwrap().bytes.clone())
+        }
+
+        async fn write(&self, bytes: &[u8]) -> Result<(), opendal::Error> {
+            let mut state = self.state.lock().unwrap();
+            if state.overwrite_writes > 0 {
+                state.overwrite_writes -= 1;
+                let external = CloudManifest {
+                    revision: 100 + state.overwrite_writes as u64,
+                    ..CloudManifest::default()
+                };
+                state.bytes = Some(serde_json::to_vec_pretty(&external).unwrap());
+            } else {
+                state.bytes = Some(bytes.to_vec());
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn mutation_reapplies_after_read_back_mismatch() {
+        let repository = CloudManifestRepository::with_transport(FakeTransport::new(1), 3);
+
+        let stored = repository
+            .mutate(|manifest| {
+                manifest.game_mut("game");
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert!(stored.games.contains_key("game"));
+        assert!(stored.revision > 100);
+    }
+
+    #[tokio::test]
+    async fn bounded_mismatch_returns_typed_error() {
+        let repository = CloudManifestRepository::with_transport(FakeTransport::new(10), 2);
+
+        let result = repository.mutate(|_| Ok(())).await;
+
+        assert!(matches!(
+            result,
+            Err(ManifestRepositoryError::RetryExhausted { attempts: 2 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn malformed_remote_manifest_fails_closed() {
+        let transport = FakeTransport::new(0);
+        transport.state.lock().unwrap().bytes = Some(b"{broken".to_vec());
+        let repository = CloudManifestRepository::with_transport(transport, 2);
+
+        assert!(matches!(
+            repository.load().await,
+            Err(ManifestRepositoryError::Serialization(_))
+        ));
+    }
+}


### PR DESCRIPTION
## 概要

- 增加未激活的 V2 Cloud Manifest、Snapshot 图校验与确定性序列化
- 增加强制大小/XXH3-64 完整性与写后读重试仓库
- 增加 Pending/Final Tombstone 和可重试的 Tombstone-first 删除原语