### PR TITLE
feat(cloud-sync): add V2 bootstrap domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5681,6 +5681,7 @@ dependencies = [
  "filetime",
  "font-kit",
  "fs_extra",
+ "futures-util",
  "globetter",
  "globset",
  "hostname",

--- a/crates/rgsm-core/Cargo.toml
+++ b/crates/rgsm-core/Cargo.toml
@@ -45,6 +45,7 @@ base64 = "0.22.1"
 globetter = "0.2.0"
 globset = "0.4.15"
 async-trait.workspace = true
+futures-util = "0.3.32"
 specta.workspace = true
 rust-i18n.workspace = true
 keyvalues-serde = "0.2"

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -24,7 +24,7 @@ use crate::preclude::*;
 ///
 /// These fields are **device-independent** (directory names and IDs, not paths)
 /// and are safe to persist in config and sync across devices.
-#[derive(Debug, Serialize, Deserialize, Clone, Type, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LudusaviMeta {
     /// Install directory names from the manifest's `installDir` field.

--- a/crates/rgsm-core/src/backup/tests/game.rs
+++ b/crates/rgsm-core/src/backup/tests/game.rs
@@ -726,8 +726,16 @@ fn delete_game_clears_legacy_quick_action_reference_by_name() -> TestResult {
         let backup_root = temp_dir.path().join("backup");
         fs::create_dir_all(&backup_root)?;
 
-        let deleted_game = make_test_game("Legacy Deleted Game", &backup_root)?;
-        let remaining_game = make_test_game("Legacy Remaining Game", &backup_root)?;
+        let deleted_game = make_test_game_with_storage_key(
+            "Legacy Deleted Game",
+            "legacy-deleted-game",
+            &backup_root,
+        )?;
+        let remaining_game = make_test_game_with_storage_key(
+            "Legacy Remaining Game",
+            "legacy-remaining-game",
+            &backup_root,
+        )?;
         let mut config = Config {
             backup_path: backup_root.to_string_lossy().to_string(),
             games: vec![deleted_game.clone(), remaining_game.clone()],

--- a/crates/rgsm-core/src/cloud_sync/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/mod.rs
@@ -11,6 +11,9 @@ pub mod transfer;
 mod utils;
 pub mod v2;
 
+pub const V1_CONFIG_PATH: &str = "/GameSaveManager.config.json";
+pub const V1_SAVE_DATA_PREFIX: &str = "save_data/";
+
 pub use backend::{
     Backend, CloudBackendCheckItem, CloudBackendCheckItemStatus, CloudBackendCheckOutcome,
     CloudBackendCheckReport, CloudBackendCheckStep, CloudSyncSessionConfig, S3AddressingStyle,

--- a/crates/rgsm-core/src/cloud_sync/utils.rs
+++ b/crates/rgsm-core/src/cloud_sync/utils.rs
@@ -13,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::backup::{Game, GameSnapshots, Snapshot, archive_file_name, remote_archive_path};
 use crate::cloud_sync::transfer::{CloudTransfer, path_to_remote_key};
+use crate::cloud_sync::{V1_CONFIG_PATH, V1_SAVE_DATA_PREFIX};
 use crate::config::{
     Config, get_backup_path, get_config, replace_config_local, resolve_backup_path,
 };
@@ -76,7 +77,7 @@ pub fn is_not_found(err: &BackendError) -> bool {
 }
 
 pub fn game_cloud_metadata_path(storage_key: &str) -> Result<String, BackendError> {
-    let backups_json = PathBuf::from("save_data")
+    let backups_json = PathBuf::from(V1_SAVE_DATA_PREFIX)
         .join(storage_key)
         .join("Backups.json");
     path_to_remote_key(&backups_json)
@@ -98,11 +99,8 @@ pub async fn load_remote_config(
     token: Option<&CancellationToken>,
 ) -> Result<Config, SyncOperationError> {
     let transfer = CloudTransfer::new(op);
-    let config_bytes = run_with_optional_cancel(
-        token,
-        transfer.download_bytes_streaming("/GameSaveManager.config.json"),
-    )
-    .await?;
+    let config_bytes =
+        run_with_optional_cancel(token, transfer.download_bytes_streaming(V1_CONFIG_PATH)).await?;
     serde_json::from_slice(&config_bytes)
         .map_err(BackendError::from)
         .map_err(Into::into)
@@ -147,10 +145,7 @@ pub async fn upload_config(op: &Operator) -> Result<(), BackendError> {
 pub async fn upload_config_snapshot(op: &Operator, config: &Config) -> Result<(), BackendError> {
     let transfer = CloudTransfer::new(op);
     transfer
-        .upload_bytes_streaming(
-            &serde_json::to_vec_pretty(config)?,
-            "/GameSaveManager.config.json",
-        )
+        .upload_bytes_streaming(&serde_json::to_vec_pretty(config)?, V1_CONFIG_PATH)
         .await?;
     Ok(())
 }

--- a/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
@@ -1,0 +1,269 @@
+use std::collections::BTreeMap;
+use std::hash::Hasher;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+use xxhash_rust::xxh3::Xxh3;
+
+use crate::config::{OwnershipError, SharedGame, SharedLibrary, SharedSaveUnitSource};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum GameJoinClassification {
+    Same,
+    LocalOnly,
+    PossibleDuplicate,
+    GameDefinitionConflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct GameJoinCandidate {
+    pub local: SharedGame,
+    pub cloud_candidates: Vec<SharedGame>,
+    pub classification: GameJoinClassification,
+}
+
+#[derive(Debug, Error)]
+pub enum GameJoinComparisonError {
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+    #[error("Portable Game serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+}
+
+impl SharedGame {
+    /// Clone into the canonical comparison shape without rewriting semantic
+    /// identity, display, path-pattern, or Save Unit values.
+    pub fn normalized_portable(&self) -> Self {
+        let mut normalized = self.clone();
+        for unit in &mut normalized.save_units {
+            if let SharedSaveUnitSource::ManifestPattern { constraints, .. } = &mut unit.source {
+                constraints
+                    .alternatives
+                    .sort_by_key(|condition| (condition.os, condition.store));
+                constraints.alternatives.dedup();
+            }
+        }
+        normalized
+    }
+
+    pub fn portable_fingerprint(&self) -> Result<String, serde_json::Error> {
+        let bytes = serde_json::to_vec(&self.normalized_portable())?;
+        let mut hasher = Xxh3::new();
+        hasher.write(&bytes);
+        Ok(format!("{:016x}", hasher.finish()))
+    }
+}
+
+/// Compare local portable Games against the accepted cloud baseline.
+///
+/// For L local and C cloud Games, indexing and lookup are
+/// O((L + C) log C + L log L), plus O(D) to normalize and compare D bytes of
+/// portable definitions. Output ordering is deterministic by stable Game ID.
+pub fn compare_join_libraries(
+    local: &SharedLibrary,
+    cloud: &SharedLibrary,
+) -> Result<Vec<GameJoinCandidate>, GameJoinComparisonError> {
+    local.validate()?;
+    cloud.validate()?;
+
+    let cloud_by_id = cloud
+        .games
+        .iter()
+        .map(|game| (game.storage_key.as_str(), game))
+        .collect::<BTreeMap<_, _>>();
+    let mut cloud_by_name = BTreeMap::<&str, Vec<&SharedGame>>::new();
+    for game in &cloud.games {
+        cloud_by_name.entry(&game.name).or_default().push(game);
+    }
+
+    let mut local_games = local.games.iter().collect::<Vec<_>>();
+    local_games.sort_by(|left, right| left.storage_key.cmp(&right.storage_key));
+    let mut candidates = Vec::with_capacity(local_games.len());
+    for local_game in local_games {
+        let (classification, cloud_candidates) =
+            if let Some(cloud_game) = cloud_by_id.get(local_game.storage_key.as_str()) {
+                let same = local_game.normalized_portable() == cloud_game.normalized_portable();
+                (
+                    if same {
+                        GameJoinClassification::Same
+                    } else {
+                        GameJoinClassification::GameDefinitionConflict
+                    },
+                    vec![(*cloud_game).clone()],
+                )
+            } else if let Some(same_name) = cloud_by_name.get(local_game.name.as_str()) {
+                let mut matches = same_name
+                    .iter()
+                    .map(|game| (*game).clone())
+                    .collect::<Vec<_>>();
+                matches.sort_by(|left, right| left.storage_key.cmp(&right.storage_key));
+                (GameJoinClassification::PossibleDuplicate, matches)
+            } else {
+                (GameJoinClassification::LocalOnly, Vec::new())
+            };
+        candidates.push(GameJoinCandidate {
+            local: local_game.clone(),
+            cloud_candidates,
+            classification,
+        });
+    }
+    Ok(candidates)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backup::{LudusaviMeta, StoreGameId};
+    use crate::config::{SharedSaveUnit, V2_CONFIG_SCHEMA_VERSION};
+    use crate::path_pattern::{ManifestPathCondition, ManifestPathConstraints, StoreKind};
+
+    use super::*;
+
+    fn game(id: &str, name: &str) -> SharedGame {
+        SharedGame {
+            name: name.into(),
+            storage_key: id.into(),
+            save_units: vec![
+                SharedSaveUnit {
+                    id: 2,
+                    source: SharedSaveUnitSource::ManifestPattern {
+                        pattern: crate::path_pattern::ManifestPathPattern::new("<home>/save"),
+                        constraints: ManifestPathConstraints {
+                            alternatives: vec![
+                                ManifestPathCondition {
+                                    os: None,
+                                    store: Some(StoreKind::Gog),
+                                },
+                                ManifestPathCondition {
+                                    os: None,
+                                    store: Some(StoreKind::Steam),
+                                },
+                            ],
+                        },
+                    },
+                },
+                SharedSaveUnit {
+                    id: 1,
+                    source: SharedSaveUnitSource::Concrete {
+                        unit_type: crate::backup::SaveUnitType::Folder,
+                    },
+                },
+            ],
+            next_save_unit_id: 3,
+            ludusavi_meta: Some(LudusaviMeta {
+                install_dirs: vec!["B".into(), "A".into()],
+                store_game_ids: vec![
+                    StoreGameId {
+                        store: StoreKind::Gog,
+                        id: "2".into(),
+                    },
+                    StoreGameId {
+                        store: StoreKind::Steam,
+                        id: "1".into(),
+                    },
+                ],
+            }),
+        }
+    }
+
+    fn library(games: Vec<SharedGame>) -> SharedLibrary {
+        SharedLibrary {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            games,
+        }
+    }
+
+    #[test]
+    fn normalization_ignores_only_unordered_portable_values() {
+        let original = game("game", "Game");
+        let mut reordered = original.clone();
+        for unit in &mut reordered.save_units {
+            if let SharedSaveUnitSource::ManifestPattern { constraints, .. } = &mut unit.source {
+                constraints.alternatives.reverse();
+            }
+        }
+
+        assert_eq!(
+            original.portable_fingerprint().unwrap(),
+            reordered.portable_fingerprint().unwrap()
+        );
+
+        reordered.save_units.reverse();
+        assert_ne!(
+            original.portable_fingerprint().unwrap(),
+            reordered.portable_fingerprint().unwrap()
+        );
+    }
+
+    #[test]
+    fn join_classification_follows_identity_then_definition() {
+        let same = game("same", "Same");
+        let mut conflict = game("conflict", "Conflict");
+        let cloud_conflict = conflict.clone();
+        conflict.next_save_unit_id += 1;
+        let possible = game("local-duplicate", "Duplicate");
+        let local_only = game("local-only", "Local");
+        let local = library(vec![local_only, possible, conflict, same.clone()]);
+        let cloud = library(vec![
+            game("remote-duplicate-b", "Duplicate"),
+            same,
+            cloud_conflict,
+            game("remote-duplicate-a", "Duplicate"),
+            game("remote-only", "Remote"),
+        ]);
+
+        let compared = compare_join_libraries(&local, &cloud).unwrap();
+
+        assert_eq!(
+            compared
+                .iter()
+                .map(|candidate| (
+                    candidate.local.storage_key.as_str(),
+                    candidate.classification
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("conflict", GameJoinClassification::GameDefinitionConflict),
+                ("local-duplicate", GameJoinClassification::PossibleDuplicate),
+                ("local-only", GameJoinClassification::LocalOnly),
+                ("same", GameJoinClassification::Same),
+            ]
+        );
+        assert_eq!(
+            compared[1]
+                .cloud_candidates
+                .iter()
+                .map(|game| game.storage_key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["remote-duplicate-a", "remote-duplicate-b"]
+        );
+    }
+
+    #[test]
+    fn standalone_library_validation_rejects_invalid_portable_identity() {
+        let mut empty_id = library(vec![game("", "Game")]);
+        assert!(matches!(
+            empty_id.validate(),
+            Err(OwnershipError::EmptySharedGameId)
+        ));
+
+        empty_id.games[0].storage_key = "game".into();
+        empty_id.games.push(empty_id.games[0].clone());
+        assert!(matches!(
+            empty_id.validate(),
+            Err(OwnershipError::DuplicateSharedGame(game_id)) if game_id == "game"
+        ));
+
+        empty_id.games.pop();
+        let duplicate = empty_id.games[0].save_units[0].clone();
+        empty_id.games[0].save_units.push(duplicate);
+        assert!(matches!(
+            empty_id.validate(),
+            Err(OwnershipError::DuplicateSharedSaveUnit {
+                game_id,
+                save_unit_id: 2
+            }) if game_id == "game"
+        ));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,16 +1,27 @@
 mod deletion;
+mod game_comparison;
 mod integrity;
 mod manifest;
+mod namespace;
 mod repository;
 
 pub use deletion::{
     ArchiveDeletionBackend, ArchiveDeletionError, GlobalSnapshotDeletion,
     GlobalSnapshotDeletionError, OpenDalArchiveDeletionBackend, SnapshotDeletionRequest,
 };
+pub use game_comparison::{
+    GameJoinCandidate, GameJoinClassification, GameJoinComparisonError, compare_join_libraries,
+};
 pub use integrity::{ArchiveIntegrity, ArchiveIntegrityError};
 pub use manifest::{
     CLOUD_MANIFEST_SCHEMA_VERSION, CloudManifest, DeletionKind, GameManifest, LiveSnapshot,
     ManifestError, PendingTombstone, SnapshotNode, SnapshotState,
+};
+pub use namespace::{
+    CLOUD_ARCHIVES_PREFIX, CLOUD_MANIFEST_PATH, CloudNamespaceClassification,
+    CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError, NamespaceTransport,
+    OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_DEVICE_PROFILES_PREFIX,
+    V2_NAMESPACE_DESCRIPTOR_PATH, V2_NAMESPACE_PREFIX, V2_NAMESPACE_SCHEMA_VERSION,
 };
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -1,0 +1,489 @@
+use async_trait::async_trait;
+use futures_util::TryStreamExt;
+use opendal::{ErrorKind, Operator};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::super::V1_CONFIG_PATH;
+#[cfg(test)]
+use super::super::V1_SAVE_DATA_PREFIX;
+use super::{CloudManifest, ManifestError};
+use crate::config::{Config, OwnershipError, SharedLibrary};
+
+pub const V2_NAMESPACE_SCHEMA_VERSION: u32 = 2;
+pub const V2_NAMESPACE_PREFIX: &str = "v2/";
+pub const V2_NAMESPACE_DESCRIPTOR_PATH: &str = "v2/namespace.json";
+pub const SHARED_LIBRARY_PATH: &str = "v2/shared-library.json";
+pub const V2_DEVICE_PROFILES_PREFIX: &str = "v2/device-profiles/";
+pub const CLOUD_MANIFEST_PATH: &str = "v2/cloud-manifest.json";
+pub const CLOUD_ARCHIVES_PREFIX: &str = "v2/archives/";
+const CLASSIFICATION_ENTRY_SAMPLE_LIMIT: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudNamespaceDescriptor {
+    pub schema_version: u32,
+}
+
+impl Default for CloudNamespaceDescriptor {
+    fn default() -> Self {
+        Self {
+            schema_version: V2_NAMESPACE_SCHEMA_VERSION,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum CloudNamespaceClassification {
+    SupportedV2 {
+        descriptor: CloudNamespaceDescriptor,
+        shared_library: SharedLibrary,
+        manifest: CloudManifest,
+    },
+    V1Only {
+        config: Box<Config>,
+    },
+    Empty,
+}
+
+#[async_trait]
+pub trait NamespaceTransport: Send + Sync {
+    async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error>;
+    async fn list_sample(&self, prefix: &str, limit: usize) -> Result<Vec<String>, opendal::Error>;
+}
+
+pub struct OpenDalNamespaceTransport {
+    operator: Operator,
+}
+
+impl OpenDalNamespaceTransport {
+    pub fn new(operator: Operator) -> Self {
+        Self { operator }
+    }
+}
+
+#[async_trait]
+impl NamespaceTransport for OpenDalNamespaceTransport {
+    async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+        match self.operator.read(path).await {
+            Ok(bytes) => Ok(Some(bytes.to_vec())),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn list_sample(&self, prefix: &str, limit: usize) -> Result<Vec<String>, opendal::Error> {
+        let mut lister = self.operator.lister(prefix).await?;
+        let mut paths = Vec::with_capacity(limit);
+        while paths.len() < limit {
+            let Some(entry) = lister.try_next().await? else {
+                break;
+            };
+            paths.push(entry.path().to_string());
+        }
+        Ok(paths)
+    }
+}
+
+pub struct CloudNamespaceClassifier<T: NamespaceTransport> {
+    transport: T,
+}
+
+impl CloudNamespaceClassifier<OpenDalNamespaceTransport> {
+    pub fn new(operator: Operator) -> Self {
+        Self::with_transport(OpenDalNamespaceTransport::new(operator))
+    }
+}
+
+impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
+    pub fn with_transport(transport: T) -> Self {
+        Self { transport }
+    }
+
+    /// Classify without writing, deleting, or interpreting provider errors as
+    /// absence. Empty requires a successful listing of the entire root.
+    pub async fn classify(&self) -> Result<CloudNamespaceClassification, CloudNamespaceError> {
+        if let Some(bytes) = self.transport.read(V2_NAMESPACE_DESCRIPTOR_PATH).await? {
+            return self.classify_v2(&bytes).await;
+        }
+
+        let v2_entries = self
+            .transport
+            .list_sample(V2_NAMESPACE_PREFIX, CLASSIFICATION_ENTRY_SAMPLE_LIMIT)
+            .await?;
+        if !v2_entries.is_empty() {
+            return Err(CloudNamespaceError::PartialV2(v2_entries));
+        }
+
+        if let Some(bytes) = self.transport.read(V1_CONFIG_PATH).await? {
+            let config = parse_json(V1_CONFIG_PATH, &bytes)?;
+            return Ok(CloudNamespaceClassification::V1Only {
+                config: Box::new(config),
+            });
+        }
+
+        let root_entries = self
+            .transport
+            .list_sample(".", CLASSIFICATION_ENTRY_SAMPLE_LIMIT)
+            .await?;
+        if root_entries.is_empty() {
+            Ok(CloudNamespaceClassification::Empty)
+        } else {
+            Err(CloudNamespaceError::UnrecognizedRoot(root_entries))
+        }
+    }
+
+    async fn classify_v2(
+        &self,
+        descriptor_bytes: &[u8],
+    ) -> Result<CloudNamespaceClassification, CloudNamespaceError> {
+        let descriptor: CloudNamespaceDescriptor =
+            parse_json(V2_NAMESPACE_DESCRIPTOR_PATH, descriptor_bytes)?;
+        if descriptor.schema_version != V2_NAMESPACE_SCHEMA_VERSION {
+            return Err(CloudNamespaceError::UnsupportedSchema {
+                object: V2_NAMESPACE_DESCRIPTOR_PATH,
+                found: descriptor.schema_version,
+            });
+        }
+
+        let shared_bytes = self.required_object(SHARED_LIBRARY_PATH).await?;
+        let shared_library: SharedLibrary = parse_json(SHARED_LIBRARY_PATH, &shared_bytes)?;
+        shared_library.validate()?;
+
+        let manifest_bytes = self.required_object(CLOUD_MANIFEST_PATH).await?;
+        let manifest: CloudManifest = parse_json(CLOUD_MANIFEST_PATH, &manifest_bytes)?;
+        manifest.validate()?;
+
+        Ok(CloudNamespaceClassification::SupportedV2 {
+            descriptor,
+            shared_library,
+            manifest,
+        })
+    }
+
+    async fn required_object(&self, path: &'static str) -> Result<Vec<u8>, CloudNamespaceError> {
+        self.transport
+            .read(path)
+            .await?
+            .ok_or(CloudNamespaceError::MissingRequiredObject(path))
+    }
+}
+
+fn parse_json<T: for<'de> Deserialize<'de>>(
+    path: &'static str,
+    bytes: &[u8],
+) -> Result<T, CloudNamespaceError> {
+    serde_json::from_slice(bytes)
+        .map_err(|source| CloudNamespaceError::MalformedObject { path, source })
+}
+
+#[derive(Debug, Error)]
+pub enum CloudNamespaceError {
+    #[error("Cloud namespace transport error: {0}")]
+    Transport(#[from] opendal::Error),
+    #[error("Malformed cloud object {path}: {source}")]
+    MalformedObject {
+        path: &'static str,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error("Unsupported schema {found} in {object}")]
+    UnsupportedSchema { object: &'static str, found: u32 },
+    #[error("V2 namespace is missing required object {0}")]
+    MissingRequiredObject(&'static str),
+    #[error("V2 namespace descriptor is absent but V2 objects remain: {0:?}")]
+    PartialV2(Vec<String>),
+    #[error("Cloud root is non-empty but is not recognized: {0:?}")]
+    UnrecognizedRoot(Vec<String>),
+    #[error(transparent)]
+    SharedLibrary(#[from] OwnershipError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use opendal::services;
+
+    use super::*;
+    use crate::config::V2_CONFIG_SCHEMA_VERSION;
+
+    #[derive(Default)]
+    struct FakeTransport {
+        objects: BTreeMap<String, Vec<u8>>,
+        fail_read: Option<String>,
+        fail_list: Option<String>,
+    }
+
+    #[async_trait]
+    impl NamespaceTransport for FakeTransport {
+        async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+            if self.fail_read.as_deref() == Some(path) {
+                return Err(opendal::Error::new(
+                    ErrorKind::Unexpected,
+                    "injected read failure",
+                ));
+            }
+            Ok(self.objects.get(path).cloned())
+        }
+
+        async fn list_sample(
+            &self,
+            prefix: &str,
+            limit: usize,
+        ) -> Result<Vec<String>, opendal::Error> {
+            if self.fail_list.as_deref() == Some(prefix) {
+                return Err(opendal::Error::new(
+                    ErrorKind::Unexpected,
+                    "injected list failure",
+                ));
+            }
+            Ok(self
+                .objects
+                .keys()
+                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+    }
+
+    fn shared_library() -> SharedLibrary {
+        SharedLibrary {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            games: Vec::new(),
+        }
+    }
+
+    fn complete_v2() -> FakeTransport {
+        let mut transport = FakeTransport::default();
+        transport.objects.insert(
+            V2_NAMESPACE_DESCRIPTOR_PATH.into(),
+            serde_json::to_vec(&CloudNamespaceDescriptor::default()).unwrap(),
+        );
+        transport.objects.insert(
+            SHARED_LIBRARY_PATH.into(),
+            serde_json::to_vec(&shared_library()).unwrap(),
+        );
+        transport.objects.insert(
+            CLOUD_MANIFEST_PATH.into(),
+            serde_json::to_vec(&CloudManifest::default()).unwrap(),
+        );
+        transport
+    }
+
+    #[tokio::test]
+    async fn complete_v2_v1_and_empty_roots_are_distinct() {
+        let v2 = CloudNamespaceClassifier::with_transport(complete_v2())
+            .classify()
+            .await
+            .unwrap();
+        assert!(matches!(
+            v2,
+            CloudNamespaceClassification::SupportedV2 { .. }
+        ));
+
+        let mut legacy = FakeTransport::default();
+        legacy.objects.insert(
+            V1_CONFIG_PATH.into(),
+            serde_json::to_vec(&Config::default()).unwrap(),
+        );
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(legacy)
+                .classify()
+                .await
+                .unwrap(),
+            CloudNamespaceClassification::V1Only { .. }
+        ));
+
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(FakeTransport::default())
+                .classify()
+                .await
+                .unwrap(),
+            CloudNamespaceClassification::Empty
+        ));
+    }
+
+    #[tokio::test]
+    async fn v2_required_objects_and_schema_fail_closed() {
+        let mut missing = complete_v2();
+        missing.objects.remove(SHARED_LIBRARY_PATH);
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(missing)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::MissingRequiredObject(
+                SHARED_LIBRARY_PATH
+            ))
+        ));
+
+        let mut unsupported = complete_v2();
+        unsupported.objects.insert(
+            V2_NAMESPACE_DESCRIPTOR_PATH.into(),
+            serde_json::to_vec(&CloudNamespaceDescriptor {
+                schema_version: V2_NAMESPACE_SCHEMA_VERSION + 1,
+            })
+            .unwrap(),
+        );
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(unsupported)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::UnsupportedSchema { .. })
+        ));
+
+        let mut corrupt = complete_v2();
+        corrupt
+            .objects
+            .insert(CLOUD_MANIFEST_PATH.into(), b"{broken".to_vec());
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(corrupt)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::MalformedObject {
+                path: CLOUD_MANIFEST_PATH,
+                ..
+            })
+        ));
+
+        let mut invalid_library = complete_v2();
+        let mut library = shared_library();
+        library.games.push(crate::config::SharedGame {
+            name: "Game".into(),
+            storage_key: String::new(),
+            save_units: Vec::new(),
+            next_save_unit_id: 0,
+            ludusavi_meta: None,
+        });
+        invalid_library.objects.insert(
+            SHARED_LIBRARY_PATH.into(),
+            serde_json::to_vec(&library).unwrap(),
+        );
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(invalid_library)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::SharedLibrary(
+                OwnershipError::EmptySharedGameId
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn partial_unknown_and_provider_failures_never_become_empty() {
+        let mut partial = FakeTransport::default();
+        partial
+            .objects
+            .insert(SHARED_LIBRARY_PATH.into(), b"{}".to_vec());
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(partial)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::PartialV2(_))
+        ));
+
+        let mut unknown = FakeTransport::default();
+        unknown.objects.insert("other/file".into(), Vec::new());
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(unknown)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::UnrecognizedRoot(_))
+        ));
+
+        let failed = FakeTransport {
+            fail_list: Some(V2_NAMESPACE_PREFIX.into()),
+            ..FakeTransport::default()
+        };
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(failed)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::Transport(_))
+        ));
+
+        let failed_descriptor_read = FakeTransport {
+            fail_read: Some(V2_NAMESPACE_DESCRIPTOR_PATH.into()),
+            ..FakeTransport::default()
+        };
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(failed_descriptor_read)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::Transport(_))
+        ));
+
+        let failed_v1_read = FakeTransport {
+            fail_read: Some(V1_CONFIG_PATH.into()),
+            ..FakeTransport::default()
+        };
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(failed_v1_read)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::Transport(_))
+        ));
+
+        let failed_root_list = FakeTransport {
+            fail_list: Some(".".into()),
+            ..FakeTransport::default()
+        };
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(failed_root_list)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::Transport(_))
+        ));
+
+        let mut corrupt_legacy = FakeTransport::default();
+        corrupt_legacy
+            .objects
+            .insert(V1_CONFIG_PATH.into(), b"{broken".to_vec());
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(corrupt_legacy)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::MalformedObject {
+                path: V1_CONFIG_PATH,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn v1_and_v2_paths_are_disjoint() {
+        for v2_path in [
+            V2_NAMESPACE_DESCRIPTOR_PATH,
+            SHARED_LIBRARY_PATH,
+            V2_DEVICE_PROFILES_PREFIX,
+            CLOUD_MANIFEST_PATH,
+            CLOUD_ARCHIVES_PREFIX,
+        ] {
+            assert!(v2_path.starts_with(V2_NAMESPACE_PREFIX));
+            assert_ne!(v2_path, V1_CONFIG_PATH);
+            assert!(!v2_path.starts_with(V1_SAVE_DATA_PREFIX));
+        }
+    }
+
+    #[tokio::test]
+    async fn opendal_adapter_classifies_current_v1_object_path() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        operator
+            .write(
+                V1_CONFIG_PATH,
+                serde_json::to_vec(&Config::default()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            CloudNamespaceClassifier::new(operator)
+                .classify()
+                .await
+                .unwrap(),
+            CloudNamespaceClassification::V1Only { .. }
+        ));
+    }
+}

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -33,6 +33,10 @@ pub enum OwnershipError {
     ProfileIdentityMismatch { key: DeviceId, embedded: DeviceId },
     #[error("Shared Library contains duplicate Game identity: {0}")]
     DuplicateSharedGame(String),
+    #[error("Shared Library contains an empty Game identity")]
+    EmptySharedGameId,
+    #[error("Shared Game {game_id} contains duplicate Save Unit ID {save_unit_id}")]
+    DuplicateSharedSaveUnit { game_id: String, save_unit_id: u32 },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
@@ -43,13 +47,13 @@ pub struct ConfigurationOwners {
     pub local_state: LocalState,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, PartialEq, Eq)]
 pub struct SharedLibrary {
     pub schema_version: u32,
     pub games: Vec<SharedGame>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, PartialEq, Eq)]
 pub struct SharedGame {
     pub name: String,
     pub storage_key: String,
@@ -58,13 +62,13 @@ pub struct SharedGame {
     pub ludusavi_meta: Option<LudusaviMeta>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, PartialEq, Eq)]
 pub struct SharedSaveUnit {
     pub id: u32,
     pub source: SharedSaveUnitSource,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type)]
+#[derive(Debug, Serialize, Deserialize, Clone, Type, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum SharedSaveUnitSource {
     Concrete {
@@ -235,17 +239,9 @@ impl ConfigurationOwners {
 
     pub fn validate(&self) -> Result<(), OwnershipError> {
         validate_schema("Configuration Owners", self.schema_version)?;
-        validate_schema("Shared Library", self.shared_library.schema_version)?;
+        self.shared_library.validate()?;
         validate_schema("Local State", self.local_state.schema_version)?;
 
-        let mut game_ids = HashSet::new();
-        for game in &self.shared_library.games {
-            if !game_ids.insert(&game.storage_key) {
-                return Err(OwnershipError::DuplicateSharedGame(
-                    game.storage_key.clone(),
-                ));
-            }
-        }
         for (device_id, profile) in &self.device_profiles {
             validate_schema(
                 &format!("Device Profile {device_id}"),
@@ -417,6 +413,35 @@ impl ConfigurationOwners {
             ludusavi_meta: shared.ludusavi_meta.clone(),
             device_bindings,
         }
+    }
+}
+
+impl SharedLibrary {
+    /// Validate remote-portable configuration without requiring Local State or
+    /// a current Device Profile.
+    pub fn validate(&self) -> Result<(), OwnershipError> {
+        validate_schema("Shared Library", self.schema_version)?;
+        let mut game_ids = HashSet::new();
+        for game in &self.games {
+            if game.storage_key.trim().is_empty() {
+                return Err(OwnershipError::EmptySharedGameId);
+            }
+            if !game_ids.insert(&game.storage_key) {
+                return Err(OwnershipError::DuplicateSharedGame(
+                    game.storage_key.clone(),
+                ));
+            }
+            let mut save_unit_ids = HashSet::new();
+            for save_unit in &game.save_units {
+                if !save_unit_ids.insert(save_unit.id) {
+                    return Err(OwnershipError::DuplicateSharedSaveUnit {
+                        game_id: game.storage_key.clone(),
+                        save_unit_id: save_unit.id,
+                    });
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## 概要
- 增加隔离的 V2 namespace 路径与只读、fail-closed 云端根分类
- 增加 Shared Library 独立校验、portable Game 规范化与指纹
- 增加加入现有云端库时的 Same、Local Only、Possible Duplicate 和 Game Definition Conflict 比较模型
- 集中现有 V1 云端路径常量，保持原有同步行为不变、