### PR TITLE
feat: 创建 V2 云端资料库

### DIFF
--- a/apps/rgsm-gui/.prettierignore
+++ b/apps/rgsm-gui/.prettierignore
@@ -35,4 +35,5 @@ Cargo.lock
 
 # Test related
 src-tauri/GameSaveManager.config.json
+src-tauri/GameSaveManager.config.v2/
 src-tauri/save_data/*

--- a/apps/rgsm-gui/src-tauri/.gitignore
+++ b/apps/rgsm-gui/src-tauri/.gitignore
@@ -4,6 +4,7 @@
 /gen/schemas
 
 GameSaveManager.config.json
+GameSaveManager.config.v2/
 *.bak
 save_data/
 

--- a/apps/rgsm-gui/src-tauri/src/cloud_library.rs
+++ b/apps/rgsm-gui/src-tauri/src/cloud_library.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use rgsm_core::cloud_sync::CloudSyncTaskManager;
+use rgsm_core::config::get_config;
+use rgsm_core::services::{CloudLibraryServiceError, CloudLibraryStatus, ServiceContext};
+use tauri::{AppHandle, Manager};
+
+use crate::hooks::HookPipelineState;
+
+pub async fn create(
+    app: &AppHandle,
+    confirmed: bool,
+) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+    app.state::<Arc<CloudSyncTaskManager>>()
+        .cancel_all_and_wait()
+        .await;
+    let pipeline = app.state::<HookPipelineState>().snapshot();
+    let status = ServiceContext::new(pipeline)
+        .create_cloud_library(confirmed)
+        .await?;
+    let config = get_config()?;
+    crate::hooks::rebuild_pipeline(app, &config);
+    Ok(status)
+}

--- a/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, RwLock};
 use tauri::{AppHandle, Manager};
 
 use rgsm_core::cloud_sync::{Backend, CloudSyncTaskManager};
-use rgsm_core::config::Config;
+use rgsm_core::config::{CloudNamespaceGeneration, Config, cloud_namespace_generation};
 
 pub struct HookPipelineState {
     inner: RwLock<Arc<HookPipeline>>,
@@ -79,7 +79,12 @@ pub fn build_builtin_pipeline(
     hooks.push(Box::new(quick_action_sync_hook::QuickActionSyncHook::new(
         quick_action_sync,
     )));
-    if !matches!(config.settings.cloud_settings.backend, Backend::Disabled) {
+    if !matches!(config.settings.cloud_settings.backend, Backend::Disabled)
+        && matches!(
+            cloud_namespace_generation(),
+            Ok(CloudNamespaceGeneration::LegacyV1)
+        )
+    {
         let sync_queue: Arc<dyn SyncJobQueue> = task_manager;
         hooks.push(Box::new(
             rgsm_core::hooks::cloud_sync_hook::CloudSyncEnqueueHook::new(sync_queue),

--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -18,7 +18,7 @@ use rgsm_core::path_pattern::{PathPlaceholder, PathPlaceholderDescriptor};
 use rgsm_core::path_resolution::ResolutionReport;
 use rgsm_core::path_resolver;
 use rgsm_core::preclude::*;
-use rgsm_core::services::ServiceContext;
+use rgsm_core::services::{CloudLibraryStatus, ServiceContext};
 use rgsm_core::steam;
 use rgsm_core::vn_scanner;
 use rgsm_core::{backup, config, system_fonts};
@@ -595,6 +595,34 @@ pub async fn check_cloud_backend(
             Err(e.to_string())
         }
     }
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn inspect_cloud_library(app_handle: AppHandle) -> Result<CloudLibraryStatus, String> {
+    info!(target:"rgsm::ipc", "Inspecting the saved Cloud Library");
+    svc(&app_handle)
+        .inspect_cloud_library()
+        .await
+        .map_err(|error| {
+            error!(target:"rgsm::ipc", "Failed to inspect Cloud Library: {error:?}");
+            error.to_string()
+        })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn create_cloud_library(
+    confirmed: bool,
+    app_handle: AppHandle,
+) -> Result<CloudLibraryStatus, String> {
+    info!(target:"rgsm::ipc", "Creating a new Cloud Library");
+    crate::cloud_library::create(&app_handle, confirmed)
+        .await
+        .map_err(|error| {
+            error!(target:"rgsm::ipc", "Failed to create Cloud Library: {error:?}");
+            error.to_string()
+        })
 }
 
 #[tauri::command]

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use rust_i18n::{i18n, t};
 i18n!("../../../locales", fallback = ["en_US", "zh_SIMPLIFIED"]);
 
 use rgsm_core::cloud_sync::SyncEventEmitter;
-use rgsm_core::config::get_config;
+use rgsm_core::config::{cloud_namespace_generation, get_config};
 use tauri::Manager;
 
 use log::{error, info, warn};
@@ -18,6 +18,7 @@ use rgsm_core::config::config_check;
 // GUI-specific modules
 #[cfg(debug_assertions)]
 mod bindings_format;
+mod cloud_library;
 mod hooks;
 mod ipc_handler;
 mod process_util;
@@ -116,6 +117,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::restore_extra_backup,
             ipc_handler::open_extra_backup_folder,
             ipc_handler::check_cloud_backend,
+            ipc_handler::inspect_cloud_library,
+            ipc_handler::create_cloud_library,
             ipc_handler::cloud_upload_all,
             ipc_handler::cloud_download_all,
             ipc_handler::cancel_cloud_sync,
@@ -215,9 +218,15 @@ pub fn run() -> anyhow::Result<()> {
             app.manage(cloud_sync_manager);
             if config_status.config_migrated {
                 let migrated_config = config.clone();
+                let generation =
+                    cloud_namespace_generation().expect("Failed to load Cloud Library generation");
                 tauri::async_runtime::spawn(async move {
                     startup_cloud_sync_manager
-                        .enqueue_config_upload_if_enabled(&migrated_config, "config_migration")
+                        .enqueue_config_upload_if_enabled(
+                            &migrated_config,
+                            generation,
+                            "config_migration",
+                        )
                         .await;
                 });
             }

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -196,6 +196,22 @@ async checkCloudBackend(session: CloudSyncSessionConfig) : Promise<Result<CloudB
     else return { status: "error", error: e  as any };
 }
 },
+async inspectCloudLibrary() : Promise<Result<CloudLibraryStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("inspect_cloud_library") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async createCloudLibrary(confirmed: boolean) : Promise<Result<CloudLibraryStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("create_cloud_library", { confirmed }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async cloudUploadAll(session: CloudSyncSessionConfig) : Promise<Result<BatchSyncReport, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("cloud_upload_all", { session }) };
@@ -635,6 +651,7 @@ export type CloudBackendCheckItemStatus = "passed" | "warning" | "failed"
 export type CloudBackendCheckOutcome = "available" | "degraded" | "unavailable"
 export type CloudBackendCheckReport = { outcome: CloudBackendCheckOutcome; items: CloudBackendCheckItem[] }
 export type CloudBackendCheckStep = "prepare_backend" | "list_files" | "write_file" | "read_file" | "verify_content" | "delete_file"
+export type CloudLibraryStatus = { kind: "empty" } | { kind: "join_required"; game_count: number } | { kind: "cutover_required"; game_count: number } | { kind: "active"; game_count: number }
 export type CloudSettings = {
 /**
  * 同步间隔，单位分钟，为0则不自动同步

--- a/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
+++ b/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
@@ -1,0 +1,181 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Connection } from '@element-plus/icons-vue';
+import { commands, type CloudLibraryStatus } from '~/bindings';
+import { $t } from '~/i18n';
+
+const props = defineProps<{
+  enabled: boolean;
+  connectionKey: string;
+}>();
+
+const emit = defineEmits<{
+  (event: 'status', value: CloudLibraryStatus | null): void;
+}>();
+
+const feedback = useFeedback();
+const status = ref<CloudLibraryStatus | null>(null);
+const inspecting = ref(false);
+const creating = ref(false);
+
+const alertType = computed(() => {
+  switch (status.value?.kind) {
+    case 'active':
+      return 'success';
+    case 'empty':
+      return 'info';
+    case 'join_required':
+    case 'cutover_required':
+      return 'warning';
+    default:
+      return 'info';
+  }
+});
+
+const statusText = computed(() => {
+  const current = status.value;
+  if (!current) return $t('sync_settings.library.not_checked');
+  switch (current.kind) {
+    case 'empty':
+      return $t('sync_settings.library.empty');
+    case 'join_required':
+      return $t('sync_settings.library.join_required', { count: current.game_count });
+    case 'cutover_required':
+      return $t('sync_settings.library.cutover_required', { count: current.game_count });
+    case 'active':
+      return $t('sync_settings.library.active', { count: current.game_count });
+  }
+  return $t('sync_settings.library.not_checked');
+});
+
+function updateStatus(value: CloudLibraryStatus | null) {
+  status.value = value;
+  emit('status', value);
+}
+
+async function inspect() {
+  if (!props.enabled || inspecting.value) return;
+  inspecting.value = true;
+  try {
+    const result = await commands.inspectCloudLibrary();
+    if (result.status === 'error') {
+      updateStatus(null);
+      notifyError(`${$t('sync_settings.library.inspect_failed')}: ${result.error}`);
+      return;
+    }
+    updateStatus(result.data);
+  } catch (reason) {
+    updateStatus(null);
+    notifyError(`${$t('sync_settings.library.inspect_failed')}: ${String(reason)}`);
+  } finally {
+    inspecting.value = false;
+  }
+}
+
+async function create() {
+  try {
+    await feedback.confirm(
+      $t('sync_settings.library.create_warning'),
+      $t('sync_settings.library.create_title'),
+      {
+        confirmButtonText: $t('sync_settings.library.create_confirm'),
+        cancelButtonText: $t('sync_settings.cancel'),
+        type: 'warning',
+      }
+    );
+  } catch {
+    return;
+  }
+
+  creating.value = true;
+  try {
+    const result = await commands.createCloudLibrary(true);
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.library.create_failed')}: ${result.error}`);
+      await inspect();
+      return;
+    }
+    updateStatus(result.data);
+    notifySuccess($t('sync_settings.library.create_success'));
+  } catch (reason) {
+    notifyError(`${$t('sync_settings.library.create_failed')}: ${String(reason)}`);
+  } finally {
+    creating.value = false;
+  }
+}
+
+watch(
+  () => [props.enabled, props.connectionKey] as const,
+  ([enabled]) => {
+    updateStatus(null);
+    if (enabled) void inspect();
+  },
+  { immediate: true }
+);
+</script>
+
+<template>
+  <section class="library-card">
+    <div class="library-heading">
+      <div>
+        <h3>{{ $t('sync_settings.library.title') }}</h3>
+        <p>{{ $t('sync_settings.library.description') }}</p>
+      </div>
+      <ElIcon :size="24"><Connection /></ElIcon>
+    </div>
+
+    <ElAlert v-if="enabled" :type="alertType" :title="statusText" :closable="false" show-icon />
+    <ElAlert
+      v-else
+      type="info"
+      :title="$t('sync_settings.library.backend_disabled')"
+      :closable="false"
+      show-icon
+    />
+
+    <div class="library-actions">
+      <ElButton :disabled="!enabled" :loading="inspecting" @click="inspect">
+        {{ $t('sync_settings.library.inspect') }}
+      </ElButton>
+      <ElButton v-if="status?.kind === 'empty'" type="primary" :loading="creating" @click="create">
+        {{ $t('sync_settings.library.create') }}
+      </ElButton>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.library-card {
+  padding: 20px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: var(--el-border-radius-base);
+  background: var(--el-fill-color-blank);
+}
+
+.library-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  color: var(--el-text-color-primary);
+}
+
+.library-heading h3 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.library-heading p {
+  margin: 0;
+  color: var(--el-text-color-secondary);
+  line-height: 1.5;
+}
+
+.library-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+</style>

--- a/apps/rgsm-gui/src/pages/SyncSettings.vue
+++ b/apps/rgsm-gui/src/pages/SyncSettings.vue
@@ -5,6 +5,7 @@ import {
   commands,
   type Backend,
   type CloudBackendCheckReport,
+  type CloudLibraryStatus,
   type ConflictResolution,
   type GameSyncState,
   type SyncState,
@@ -68,6 +69,7 @@ const conflictDialogVisible = ref(false);
 const selectedConflictGameName = ref<string | null>(null);
 const checkingBackend = ref(false);
 const backendCheckReport = ref<CloudBackendCheckReport | null>(null);
+const cloudLibraryStatus = ref<CloudLibraryStatus | null>(null);
 const cloud_settings = ref<EditableCloudSettings>(
   toEditableCloudSettings(config.value!.settings.cloud_settings)
 );
@@ -127,6 +129,14 @@ function loadDraftFromConfig() {
 const savedBackendEnabled = computed(
   () => config.value?.settings.cloud_settings?.backend?.type !== 'Disabled'
 );
+const v2LibraryActive = computed(() => cloudLibraryStatus.value?.kind === 'active');
+const savedConnectionKey = computed(() =>
+  JSON.stringify(config.value?.settings.cloud_settings ?? null)
+);
+
+function updateCloudLibraryStatus(status: CloudLibraryStatus | null) {
+  cloudLibraryStatus.value = status;
+}
 
 const hasEnabledGames = computed(() =>
   (config.value?.games ?? []).some((game) => game.cloud_sync_enabled !== false)
@@ -633,11 +643,19 @@ onMounted(async () => {
     <ElTabs v-model="activeTab" class="sync-tabs">
       <!-- Tab 1: Overview -->
       <ElTabPane :label="$t('sync_settings.overview.tab')" name="overview">
+        <ElAlert
+          v-if="v2LibraryActive"
+          type="success"
+          :title="$t('sync_settings.library.legacy_disabled')"
+          :closable="false"
+          show-icon
+          class="section-alert"
+        />
         <div class="overview-toolbar">
           <ElButton
             type="primary"
             :icon="Refresh"
-            :disabled="!savedBackendEnabled || !hasEnabledGames"
+            :disabled="v2LibraryActive || !savedBackendEnabled || !hasEnabledGames"
             @click="syncAllGames"
           >
             {{ $t('sync_settings.overview.sync_all') }}
@@ -680,6 +698,7 @@ onMounted(async () => {
                 v-if="!row.isConfig"
                 v-model="row.cloudSyncEnabled"
                 size="small"
+                :disabled="v2LibraryActive"
                 @change="toggleGameSync(tableRowToGameRow(row))"
               />
               <span v-else class="config-lock-icon">
@@ -708,7 +727,9 @@ onMounted(async () => {
           <ElTableColumn :label="$t('sync_settings.overview.actions')" width="150" align="center">
             <template #default="{ row }">
               <ElButton
-                v-if="row.isConfig && row.status === 'failed' && savedBackendEnabled"
+                v-if="
+                  row.isConfig && row.status === 'failed' && savedBackendEnabled && !v2LibraryActive
+                "
                 :icon="Refresh"
                 size="small"
                 text
@@ -718,7 +739,7 @@ onMounted(async () => {
                 {{ $t('sync_settings.config_retry') }}
               </ElButton>
               <ElButton
-                v-else-if="!row.isConfig && row.status === 'conflict'"
+                v-else-if="!v2LibraryActive && !row.isConfig && row.status === 'conflict'"
                 :icon="Warning"
                 type="warning"
                 size="small"
@@ -728,7 +749,9 @@ onMounted(async () => {
                 {{ $t('sync_settings.conflict.resolve') }}
               </ElButton>
               <ElButton
-                v-else-if="!row.isConfig && row.cloudSyncEnabled && savedBackendEnabled"
+                v-else-if="
+                  !v2LibraryActive && !row.isConfig && row.cloudSyncEnabled && savedBackendEnabled
+                "
                 :icon="Refresh"
                 size="small"
                 text
@@ -839,10 +862,24 @@ onMounted(async () => {
 
           <BackendCheckResult :report="backendCheckReport" :checking="checkingBackend" />
         </div>
+        <CloudLibrarySetup
+          class="library-setup"
+          :enabled="savedBackendEnabled"
+          :connection-key="savedConnectionKey"
+          @status="updateCloudLibraryStatus"
+        />
       </ElTabPane>
 
       <!-- Tab 3: Operations -->
       <ElTabPane :label="$t('sync_settings.operations.tab')" name="operations">
+        <ElAlert
+          v-if="v2LibraryActive"
+          type="success"
+          :title="$t('sync_settings.library.legacy_disabled')"
+          :closable="false"
+          show-icon
+          class="section-alert"
+        />
         <ElAlert type="warning" :closable="false" show-icon style="margin-bottom: 20px">
           {{ $t('sync_settings.operations.warning') }}
         </ElAlert>
@@ -855,7 +892,7 @@ onMounted(async () => {
             <ElButton
               type="danger"
               :icon="Upload"
-              :disabled="currentSessionConfig()?.backend.type === 'Disabled'"
+              :disabled="v2LibraryActive || currentSessionConfig()?.backend.type === 'Disabled'"
               @click="upload_all"
             >
               {{ $t('sync_settings.overwrite_upload') }}
@@ -870,7 +907,7 @@ onMounted(async () => {
             <ElButton
               type="danger"
               :icon="Download"
-              :disabled="currentSessionConfig()?.backend.type === 'Disabled'"
+              :disabled="v2LibraryActive || currentSessionConfig()?.backend.type === 'Disabled'"
               @click="download_all"
             >
               {{ $t('sync_settings.overwrite_download') }}
@@ -931,6 +968,11 @@ onMounted(async () => {
   :deep(.el-tabs__nav-wrap::after) {
     height: 1px;
   }
+}
+
+.section-alert,
+.library-setup {
+  margin-bottom: 20px;
 }
 
 /* Overview tab */

--- a/apps/rgsm-tui/src/app.rs
+++ b/apps/rgsm-tui/src/app.rs
@@ -111,8 +111,9 @@ impl App {
         }
 
         let config = rgsm_core::config::get_config()?;
+        let generation = rgsm_core::config::cloud_namespace_generation()?;
         self.cloud_sync_manager
-            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .enqueue_config_upload_if_enabled(&config, generation, "config_migration")
             .await;
         Ok(())
     }

--- a/crates/rgsm-core/src/cloud_sync/task_manager.rs
+++ b/crates/rgsm-core/src/cloud_sync/task_manager.rs
@@ -20,7 +20,7 @@ use super::sync_state::{
 use crate::backup::GameSnapshots;
 use crate::cloud_sync::transfer::CloudTransfer;
 use crate::cloud_sync::{Backend, session_from_backend, upload_config, upload_game_snapshots};
-use crate::config::get_config;
+use crate::config::{CloudNamespaceGeneration, get_config};
 use crate::hooks::SyncJobQueue;
 use crate::preclude::*;
 
@@ -228,8 +228,12 @@ impl CloudSyncTaskManager {
     pub async fn enqueue_config_upload_if_enabled(
         &self,
         config: &crate::config::Config,
+        generation: CloudNamespaceGeneration,
         context: impl Into<String>,
     ) {
+        if generation != CloudNamespaceGeneration::LegacyV1 {
+            return;
+        }
         let backend = match &config.settings.cloud_settings.backend {
             Backend::Disabled => return,
             backend => backend.clone(),
@@ -273,6 +277,17 @@ impl CloudSyncTaskManager {
         }
     }
 
+    pub async fn cancel_all_and_wait(&self) -> CancelCloudSyncResult {
+        let result = self.cancel_all().await;
+        loop {
+            let idle = self.notify.notified();
+            if self.running_count.load(Ordering::Acquire) == 0 {
+                return result;
+            }
+            idle.await;
+        }
+    }
+
     pub async fn begin_manual_job(&self, description: String) -> (u64, CancellationToken) {
         let (id, token) = {
             let mut state = self.state.lock().await;
@@ -301,6 +316,7 @@ impl CloudSyncTaskManager {
         self.running_count.fetch_sub(1, Ordering::Relaxed);
         self.finish_job(id, description, status, error).await;
         self.emit_full_status(None).await;
+        self.notify.notify_waiters();
     }
 
     async fn emit_full_status(&self, current_description: Option<String>) {
@@ -397,16 +413,17 @@ impl CloudSyncTaskManager {
                 let Some(queued_job) = state.queue.pop_front() else {
                     continue;
                 };
+                self.running_count.fetch_add(1, Ordering::Release);
                 (queued_job, state.queue_cancel_token.child_token())
             };
 
             let permit = semaphore.clone().acquire_owned().await;
             if permit.is_err() {
+                self.running_count.fetch_sub(1, Ordering::Release);
+                self.notify.notify_waiters();
                 return;
             }
             let permit = permit.unwrap();
-
-            self.running_count.fetch_add(1, Ordering::Relaxed);
 
             let job_id = queued_job.id;
             let job = queued_job.job;
@@ -463,6 +480,7 @@ impl CloudSyncTaskManager {
                 }
 
                 me.emit_full_status(None).await;
+                me.notify.notify_waiters();
             });
         }
     }
@@ -759,7 +777,11 @@ mod tests {
         let config = crate::config::Config::default();
 
         manager
-            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .enqueue_config_upload_if_enabled(
+                &config,
+                CloudNamespaceGeneration::LegacyV1,
+                "config_migration",
+            )
             .await;
 
         let state = manager.state.lock().await;
@@ -777,7 +799,11 @@ mod tests {
         };
 
         manager
-            .enqueue_config_upload_if_enabled(&config, "config_migration")
+            .enqueue_config_upload_if_enabled(
+                &config,
+                CloudNamespaceGeneration::LegacyV1,
+                "config_migration",
+            )
             .await;
 
         let state = manager.state.lock().await;
@@ -792,5 +818,23 @@ mod tests {
             }
             other => panic!("expected config upload job, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn cancel_and_wait_does_not_return_while_a_manual_job_is_running() {
+        let manager = manager();
+        let (id, _) = manager.begin_manual_job("manual".to_string()).await;
+        let finisher = manager.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            finisher
+                .finish_manual_job(id, "manual", CloudSyncJobStatus::Cancelled, None)
+                .await;
+        });
+
+        let result = manager.cancel_all_and_wait().await;
+
+        assert!(matches!(result, CancelCloudSyncResult::Cancelled));
+        assert_eq!(manager.running_count.load(Ordering::Acquire), 0);
     }
 }

--- a/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
@@ -1,0 +1,268 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use thiserror::Error;
+
+use super::{
+    CLOUD_MANIFEST_PATH, CloudManifest, CloudNamespaceClassification, CloudNamespaceClassifier,
+    CloudNamespaceDescriptor, CloudNamespaceError, ManifestError, NamespaceTransport,
+    OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_NAMESPACE_DESCRIPTOR_PATH,
+    device_profile_path,
+};
+use crate::config::{DeviceProfile, OwnershipError, SharedLibrary};
+
+#[async_trait]
+pub trait CloudLibraryTransport: NamespaceTransport {
+    async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error>;
+}
+
+#[async_trait]
+impl CloudLibraryTransport for OpenDalNamespaceTransport {
+    async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error> {
+        self.operator.write(path, bytes.to_vec()).await?;
+        Ok(())
+    }
+}
+
+pub struct CloudLibraryBootstrap<T: CloudLibraryTransport> {
+    transport: Arc<T>,
+    max_attempts: usize,
+}
+
+impl CloudLibraryBootstrap<OpenDalNamespaceTransport> {
+    pub fn new(operator: opendal::Operator, max_attempts: usize) -> Self {
+        Self::with_transport(OpenDalNamespaceTransport::new(operator), max_attempts)
+    }
+}
+
+impl<T: CloudLibraryTransport> CloudLibraryBootstrap<T> {
+    pub fn with_transport(transport: T, max_attempts: usize) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn inspect(
+        &self,
+    ) -> Result<CloudNamespaceClassification, CloudLibraryBootstrapError> {
+        Ok(
+            CloudNamespaceClassifier::with_transport(self.transport.clone())
+                .classify()
+                .await?,
+        )
+    }
+
+    /// Create the complete namespace only from a freshly reclassified empty root.
+    ///
+    /// The descriptor is intentionally written last. A stopped process therefore
+    /// leaves either no V2 state, a fail-closed partial namespace, or a complete
+    /// namespace; it never advertises an incomplete library as supported.
+    pub async fn create_empty(
+        &self,
+        shared_library: &SharedLibrary,
+        device_profile: &DeviceProfile,
+    ) -> Result<(), CloudLibraryBootstrapError> {
+        match self.inspect().await? {
+            CloudNamespaceClassification::Empty => {}
+            CloudNamespaceClassification::SupportedV2 { .. } => {
+                return Err(CloudLibraryBootstrapError::RootChanged("existing_v2"));
+            }
+            CloudNamespaceClassification::V1Only { .. } => {
+                return Err(CloudLibraryBootstrapError::RootChanged("legacy_v1"));
+            }
+        }
+
+        shared_library.validate()?;
+        let manifest = CloudManifest::default();
+        manifest.validate()?;
+        let profile_path = device_profile_path(&device_profile.device.id);
+        let descriptor = CloudNamespaceDescriptor::default();
+
+        self.write_verified(SHARED_LIBRARY_PATH, &pretty_bytes(shared_library)?)
+            .await?;
+        self.write_verified(CLOUD_MANIFEST_PATH, &pretty_bytes(&manifest)?)
+            .await?;
+        self.write_verified(&profile_path, &pretty_bytes(device_profile)?)
+            .await?;
+        self.write_verified(V2_NAMESPACE_DESCRIPTOR_PATH, &pretty_bytes(&descriptor)?)
+            .await?;
+
+        match self.inspect().await? {
+            CloudNamespaceClassification::SupportedV2 {
+                shared_library: stored,
+                manifest: stored_manifest,
+                ..
+            } if stored == *shared_library && stored_manifest == manifest => Ok(()),
+            _ => Err(CloudLibraryBootstrapError::FinalVerificationMismatch),
+        }
+    }
+
+    async fn write_verified(
+        &self,
+        path: &str,
+        bytes: &[u8],
+    ) -> Result<(), CloudLibraryBootstrapError> {
+        for _ in 0..self.max_attempts {
+            self.transport.write(path, bytes).await?;
+            if self.transport.read(path).await?.as_deref() == Some(bytes) {
+                return Ok(());
+            }
+        }
+        Err(CloudLibraryBootstrapError::WriteVerificationFailed {
+            path: path.to_string(),
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+fn pretty_bytes(value: &impl Serialize) -> Result<Vec<u8>, serde_json::Error> {
+    serde_json::to_vec_pretty(value)
+}
+
+#[derive(Debug, Error)]
+pub enum CloudLibraryBootstrapError {
+    #[error(transparent)]
+    Namespace(#[from] CloudNamespaceError),
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error("Cloud Library serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Cloud Library transport error: {0}")]
+    Transport(#[from] opendal::Error),
+    #[error("Cloud root changed before creation: {0}")]
+    RootChanged(&'static str),
+    #[error("Cloud object {path} did not match after {attempts} write attempts")]
+    WriteVerificationFailed { path: String, attempts: usize },
+    #[error("Created Cloud Library did not match the intended state")]
+    FinalVerificationMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::config::V2_CONFIG_SCHEMA_VERSION;
+
+    #[derive(Default)]
+    struct State {
+        objects: BTreeMap<String, Vec<u8>>,
+        writes: Vec<String>,
+        corrupt_writes: bool,
+    }
+
+    #[derive(Default)]
+    struct FakeTransport {
+        state: Mutex<State>,
+    }
+
+    #[async_trait]
+    impl NamespaceTransport for FakeTransport {
+        async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+            Ok(self.state.lock().unwrap().objects.get(path).cloned())
+        }
+
+        async fn list_sample(
+            &self,
+            prefix: &str,
+            limit: usize,
+        ) -> Result<Vec<String>, opendal::Error> {
+            Ok(self
+                .state
+                .lock()
+                .unwrap()
+                .objects
+                .keys()
+                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+    }
+
+    #[async_trait]
+    impl CloudLibraryTransport for FakeTransport {
+        async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error> {
+            let mut state = self.state.lock().unwrap();
+            state.writes.push(path.to_string());
+            let stored = if state.corrupt_writes {
+                b"corrupt".to_vec()
+            } else {
+                bytes.to_vec()
+            };
+            state.objects.insert(path.to_string(), stored);
+            Ok(())
+        }
+    }
+
+    fn inputs() -> (SharedLibrary, DeviceProfile) {
+        let owners = crate::config::ConfigurationOwners::from_legacy(
+            &crate::config::Config::default(),
+            &"device".to_string(),
+        );
+        (
+            SharedLibrary {
+                schema_version: V2_CONFIG_SCHEMA_VERSION,
+                games: Vec::new(),
+            },
+            owners.device_profiles["device"].clone(),
+        )
+    }
+
+    #[tokio::test]
+    async fn creates_required_objects_with_descriptor_last() {
+        let transport = FakeTransport::default();
+        let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
+        let (shared, profile) = inputs();
+
+        bootstrap.create_empty(&shared, &profile).await.unwrap();
+
+        let state = bootstrap.transport.state.lock().unwrap();
+        assert_eq!(
+            state.writes.last().map(String::as_str),
+            Some(V2_NAMESPACE_DESCRIPTOR_PATH)
+        );
+        assert!(state.objects.contains_key(&device_profile_path("device")));
+    }
+
+    #[tokio::test]
+    async fn refuses_non_empty_and_partial_roots_without_writing() {
+        let transport = FakeTransport::default();
+        transport
+            .state
+            .lock()
+            .unwrap()
+            .objects
+            .insert("unrelated".into(), Vec::new());
+        let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
+        let (shared, profile) = inputs();
+
+        assert!(matches!(
+            bootstrap.create_empty(&shared, &profile).await,
+            Err(CloudLibraryBootstrapError::Namespace(
+                CloudNamespaceError::UnrecognizedRoot(_)
+            ))
+        ));
+        assert!(bootstrap.transport.state.lock().unwrap().writes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn read_back_mismatch_never_publishes_descriptor() {
+        let transport = FakeTransport::default();
+        transport.state.lock().unwrap().corrupt_writes = true;
+        let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
+        let (shared, profile) = inputs();
+
+        assert!(matches!(
+            bootstrap.create_empty(&shared, &profile).await,
+            Err(CloudLibraryBootstrapError::WriteVerificationFailed { attempts: 2, .. })
+        ));
+        let state = bootstrap.transport.state.lock().unwrap();
+        assert!(!state.objects.contains_key(V2_NAMESPACE_DESCRIPTOR_PATH));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,3 +1,4 @@
+mod bootstrap;
 mod deletion;
 mod game_comparison;
 mod integrity;
@@ -5,6 +6,7 @@ mod manifest;
 mod namespace;
 mod repository;
 
+pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
 pub use deletion::{
     ArchiveDeletionBackend, ArchiveDeletionError, GlobalSnapshotDeletion,
     GlobalSnapshotDeletionError, OpenDalArchiveDeletionBackend, SnapshotDeletionRequest,
@@ -22,6 +24,7 @@ pub use namespace::{
     CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError, NamespaceTransport,
     OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_DEVICE_PROFILES_PREFIX,
     V2_NAMESPACE_DESCRIPTOR_PATH, V2_NAMESPACE_PREFIX, V2_NAMESPACE_SCHEMA_VERSION,
+    device_profile_path,
 };
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use opendal::{ErrorKind, Operator};
@@ -9,6 +11,7 @@ use super::super::V1_CONFIG_PATH;
 use super::super::V1_SAVE_DATA_PREFIX;
 use super::{CloudManifest, ManifestError};
 use crate::config::{Config, OwnershipError, SharedLibrary};
+use crate::device::encode_device_id;
 
 pub const V2_NAMESPACE_SCHEMA_VERSION: u32 = 2;
 pub const V2_NAMESPACE_PREFIX: &str = "v2/";
@@ -18,6 +21,13 @@ pub const V2_DEVICE_PROFILES_PREFIX: &str = "v2/device-profiles/";
 pub const CLOUD_MANIFEST_PATH: &str = "v2/cloud-manifest.json";
 pub const CLOUD_ARCHIVES_PREFIX: &str = "v2/archives/";
 const CLASSIFICATION_ENTRY_SAMPLE_LIMIT: usize = 8;
+
+pub fn device_profile_path(device_id: &str) -> String {
+    format!(
+        "{V2_DEVICE_PROFILES_PREFIX}{}.json",
+        encode_device_id(device_id)
+    )
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CloudNamespaceDescriptor {
@@ -51,8 +61,19 @@ pub trait NamespaceTransport: Send + Sync {
     async fn list_sample(&self, prefix: &str, limit: usize) -> Result<Vec<String>, opendal::Error>;
 }
 
+#[async_trait]
+impl<T: NamespaceTransport + ?Sized> NamespaceTransport for Arc<T> {
+    async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+        self.as_ref().read(path).await
+    }
+
+    async fn list_sample(&self, prefix: &str, limit: usize) -> Result<Vec<String>, opendal::Error> {
+        self.as_ref().list_sample(prefix, limit).await
+    }
+}
+
 pub struct OpenDalNamespaceTransport {
-    operator: Operator,
+    pub(super) operator: Operator,
 }
 
 impl OpenDalNamespaceTransport {

--- a/crates/rgsm-core/src/config/mod.rs
+++ b/crates/rgsm-core/src/config/mod.rs
@@ -11,10 +11,10 @@ mod utils;
 pub use app_config::{Config, FavoriteTreeNode};
 pub use owner_store::OwnerStoreError;
 pub use ownership::{
-    ConfigurationOwners, DeviceBehaviorSettings, DeviceGameProfile, DeviceProfile,
-    DeviceSaveUnitSettings, EffectiveConfiguration, LocalInterfaceSettings, LocalState,
-    OwnershipError, SharedGame, SharedLibrary, SharedSaveUnit, SharedSaveUnitSource, SyncMode,
-    V2_CONFIG_SCHEMA_VERSION,
+    CloudNamespaceGeneration, ConfigurationOwners, DeviceBehaviorSettings, DeviceGameProfile,
+    DeviceProfile, DeviceSaveUnitSettings, EffectiveConfiguration, LocalInterfaceSettings,
+    LocalState, OwnershipError, SharedGame, SharedLibrary, SharedSaveUnit, SharedSaveUnitSource,
+    SyncMode, V2_CONFIG_SCHEMA_VERSION,
 };
 pub use quick_actions_settings::{
     GameAutomationSettings, GameAutomationSettingsDraft, QuickActionSoundPreferences,

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -7,11 +7,11 @@ use serde::de::DeserializeOwned;
 use thiserror::Error;
 
 use crate::app_dirs::get_app_data_dir;
-use crate::device::{DeviceId, get_current_device_id};
+use crate::device::{DeviceId, encode_device_id, get_current_device_id};
 
 use super::{
-    Config, ConfigurationOwners, DeviceProfile, LocalState, OwnershipError, SharedLibrary,
-    V2_CONFIG_SCHEMA_VERSION,
+    CloudNamespaceGeneration, Config, ConfigurationOwners, DeviceProfile, LocalState,
+    OwnershipError, SharedLibrary, V2_CONFIG_SCHEMA_VERSION,
 };
 
 pub(crate) const OWNER_DIRECTORY_NAME: &str = "GameSaveManager.config.v2";
@@ -33,6 +33,8 @@ pub enum OwnerStoreError {
     DuplicateDeviceProfile(DeviceId),
     #[error("Device Profile file name does not match embedded Device ID: {0}")]
     ProfileFileNameMismatch(DeviceId),
+    #[error("Local configuration changed while Cloud Library creation was in progress")]
+    ActivationInputsChanged,
 }
 
 pub(crate) struct OwnerStore {
@@ -79,18 +81,26 @@ impl OwnerStore {
     }
 
     pub(crate) fn replace_effective(&self, config: &Config) -> Result<Config, OwnerStoreError> {
-        let current_device_id = if self.has_authoritative_state() {
-            self.load()?.local_state.current_device_id
+        let existing = if self.has_authoritative_state() {
+            Some(self.load()?)
         } else {
-            get_current_device_id().clone()
+            None
         };
-        let owners = ConfigurationOwners::from_legacy(config, &current_device_id);
+        let current_device_id = existing.as_ref().map_or_else(
+            || get_current_device_id().clone(),
+            |owners| owners.local_state.current_device_id.clone(),
+        );
+        let mut owners = ConfigurationOwners::from_legacy(config, &current_device_id);
+        if let Some(existing) = existing {
+            owners.local_state.cloud_namespace_generation =
+                existing.local_state.cloud_namespace_generation;
+        }
         let effective = owners.assemble_effective()?;
         self.write(&owners)?;
         Ok(effective)
     }
 
-    fn load(&self) -> Result<ConfigurationOwners, OwnerStoreError> {
+    pub(crate) fn load(&self) -> Result<ConfigurationOwners, OwnerStoreError> {
         self.recover()?;
         let active = self.active_path();
         let shared_library: SharedLibrary = read_json(&active.join(SHARED_LIBRARY_FILE_NAME))?;
@@ -125,6 +135,27 @@ impl OwnerStore {
         };
         owners.validate()?;
         Ok(owners)
+    }
+
+    pub(crate) fn activate_v2(
+        &self,
+        expected_library: &SharedLibrary,
+        expected_profile: &DeviceProfile,
+    ) -> Result<(), OwnerStoreError> {
+        let mut owners = self.load()?;
+        let current_profile = owners
+            .device_profiles
+            .get(&owners.local_state.current_device_id)
+            .ok_or_else(|| {
+                OwnershipError::MissingDeviceProfile(owners.local_state.current_device_id.clone())
+            })?;
+        if owners.shared_library != *expected_library
+            || serde_json::to_vec(current_profile)? != serde_json::to_vec(expected_profile)?
+        {
+            return Err(OwnerStoreError::ActivationInputsChanged);
+        }
+        owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        self.write(&owners)
     }
 
     fn write(&self, owners: &ConfigurationOwners) -> Result<(), OwnerStoreError> {
@@ -211,17 +242,8 @@ fn remove_dir_if_exists(path: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-/// Encode a Device ID as a path-safe lowercase hexadecimal file stem.
-///
-/// Each UTF-8 byte becomes two characters, so both time and additional space
-/// are O(n) in the Device ID byte length.
 fn profile_file_name(device_id: &str) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut encoded = String::with_capacity(device_id.len() * 2 + 5);
-    for byte in device_id.as_bytes() {
-        encoded.push(HEX[(byte >> 4) as usize] as char);
-        encoded.push(HEX[(byte & 0x0f) as usize] as char);
-    }
+    let mut encoded = encode_device_id(device_id);
     encoded.push_str(".json");
     encoded
 }
@@ -348,6 +370,24 @@ mod tests {
                 .quick_action_game_id
                 .as_deref(),
             Some("deck-only")
+        );
+    }
+
+    #[test]
+    fn effective_saves_preserve_v2_activation() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        let owners = store.load().unwrap();
+        let profile = &owners.device_profiles[get_current_device_id()];
+        store.activate_v2(&owners.shared_library, profile).unwrap();
+
+        store.merge_effective(&input).unwrap();
+        store.replace_effective(&input).unwrap();
+
+        assert_eq!(
+            store.load().unwrap().local_state.cloud_namespace_generation,
+            CloudNamespaceGeneration::V2
         );
     }
 

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -116,6 +116,14 @@ pub enum SyncMode {
     LiveSaveSync,
 }
 
+#[derive(Debug, Default, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudNamespaceGeneration {
+    #[default]
+    LegacyV1,
+    V2,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct DeviceBehaviorSettings {
     pub prompt_when_not_described: bool,
@@ -140,6 +148,8 @@ pub struct LocalState {
     pub current_device_id: DeviceId,
     pub interface: LocalInterfaceSettings,
     pub cloud_settings: CloudSettings,
+    #[serde(default)]
+    pub cloud_namespace_generation: CloudNamespaceGeneration,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
@@ -233,6 +243,7 @@ impl ConfigurationOwners {
                 current_device_id: current_device_id.clone(),
                 interface: LocalInterfaceSettings::from(&config.settings),
                 cloud_settings: config.settings.cloud_settings.clone(),
+                cloud_namespace_generation: CloudNamespaceGeneration::LegacyV1,
             },
         }
     }
@@ -282,6 +293,8 @@ impl ConfigurationOwners {
             .collect::<HashSet<_>>();
 
         self.shared_library = incoming.shared_library;
+        incoming.local_state.cloud_namespace_generation =
+            self.local_state.cloud_namespace_generation;
         self.local_state = incoming.local_state;
         self.device_profiles.retain(|device_id, _| {
             device_id == &current_device_id || incoming_device_ids.contains(device_id)

--- a/crates/rgsm-core/src/config/ownership_tests.rs
+++ b/crates/rgsm-core/src/config/ownership_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
-use super::{Config, ConfigurationOwners, OwnershipError, QuickActionsSettings};
+use super::{
+    CloudNamespaceGeneration, Config, ConfigurationOwners, OwnershipError, QuickActionsSettings,
+};
 use crate::backup::{Game, SaveUnit, SaveUnitType};
 use crate::device::{Device, DeviceId};
 
@@ -105,6 +107,24 @@ fn owners_round_trip_back_to_equivalent_effective_config() {
     assert_eq!(
         serde_json::to_value(effective).unwrap(),
         serde_json::to_value(config).unwrap()
+    );
+}
+
+#[test]
+fn legacy_owner_json_defaults_to_v1_generation() {
+    let (config, windows_id, _) = dual_device_config();
+    let owners = ConfigurationOwners::from_legacy(&config, &windows_id);
+    let mut persisted = serde_json::to_value(&owners).unwrap();
+    persisted["local_state"]
+        .as_object_mut()
+        .unwrap()
+        .remove("cloud_namespace_generation");
+
+    let reloaded: ConfigurationOwners = serde_json::from_value(persisted).unwrap();
+
+    assert_eq!(
+        reloaded.local_state.cloud_namespace_generation,
+        CloudNamespaceGeneration::LegacyV1
     );
 }
 

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -6,7 +6,9 @@ use tokio::sync::{Mutex as TokioMutex, MutexGuard};
 
 use crate::app_dirs::resolve_app_path;
 use crate::config::owner_store::OwnerStore;
-use crate::config::{Config, backup};
+use crate::config::{
+    CloudNamespaceGeneration, Config, DeviceProfile, LocalState, SharedLibrary, backup,
+};
 use crate::preclude::*;
 use crate::updater::update_config;
 use log::info;
@@ -50,6 +52,46 @@ pub fn get_config() -> Result<Config, ConfigError> {
         .lock()
         .map_err(|_| ConfigError::StoreLockPoisoned)?;
     get_config_unlocked()
+}
+
+pub fn cloud_namespace_generation() -> Result<CloudNamespaceGeneration, ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    Ok(OwnerStore::runtime()
+        .load()?
+        .local_state
+        .cloud_namespace_generation)
+}
+
+pub(crate) fn cloud_bootstrap_inputs()
+-> Result<(SharedLibrary, DeviceProfile, LocalState), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    let owners = OwnerStore::runtime().load()?;
+    let profile = owners
+        .device_profiles
+        .get(&owners.local_state.current_device_id)
+        .cloned()
+        .ok_or_else(|| {
+            crate::config::OwnershipError::MissingDeviceProfile(
+                owners.local_state.current_device_id.clone(),
+            )
+        })
+        .map_err(crate::config::OwnerStoreError::from)?;
+    Ok((owners.shared_library, profile, owners.local_state))
+}
+
+pub(crate) fn activate_cloud_namespace_v2(
+    expected_library: &SharedLibrary,
+    expected_profile: &DeviceProfile,
+) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    OwnerStore::runtime().activate_v2(expected_library, expected_profile)?;
+    Ok(())
 }
 
 fn get_config_unlocked() -> Result<Config, ConfigError> {

--- a/crates/rgsm-core/src/device.rs
+++ b/crates/rgsm-core/src/device.rs
@@ -8,6 +8,19 @@ use crate::path_pattern::StoreKind;
 pub type DeviceId = String;
 pub type DeviceResourceId = u32;
 
+/// Encode a Device ID as path-safe lowercase hexadecimal.
+///
+/// Each UTF-8 byte becomes two characters, so time and output space are O(n).
+pub fn encode_device_id(device_id: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(device_id.len() * 2);
+    for byte in device_id.as_bytes() {
+        encoded.push(HEX[(byte >> 4) as usize] as char);
+        encoded.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    encoded
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Type)]
 #[serde(rename_all = "camelCase")]
 pub enum DeviceResourceSource {
@@ -183,6 +196,11 @@ mod tests {
 
         assert_eq!(device.resources[0].id, id);
         assert_eq!(device.next_resource_id, 1);
+    }
+
+    #[test]
+    fn encoded_device_ids_are_path_safe() {
+        assert_eq!(encode_device_id("../Deck"), "2e2e2f4465636b");
     }
 
     #[test]

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -49,6 +49,8 @@ pub enum BackendError {
     InvalidConflictState(String),
     #[error("Unsupported cloud conflict resolution: {0}")]
     UnsupportedConflictResolution(String),
+    #[error("Legacy cloud synchronization is unavailable after V2 Cloud Library activation")]
+    V2CloudLibraryActive,
     #[error("IO error: {0:#?}")]
     Io(#[from] io::Error),
     #[error("Opendal error: {0:#?}")]

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -8,6 +8,8 @@ use std::sync::Arc;
 
 use crate::hooks::HookPipeline;
 
+pub use sync::{CloudLibraryServiceError, CloudLibraryStatus};
+
 #[derive(Clone)]
 pub struct ServiceContext {
     pipeline: Arc<HookPipeline>,

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -1,13 +1,22 @@
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 
 use crate::backup::Game;
+use crate::cloud_sync::v2::{
+    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudNamespaceClassification,
+};
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
     ConflictResolutionOutcome, SyncGameOutcome, download_all_from_session,
     resolve_game_conflict as resolve_cloud_conflict, sync_config as sync_cloud_config,
     sync_game as sync_cloud_game, upload_all_from_session,
 };
-use crate::config::{Config, get_config};
+use crate::config::{
+    CloudNamespaceGeneration, Config, activate_cloud_namespace_v2, cloud_bootstrap_inputs,
+    cloud_namespace_generation, get_config,
+};
 use crate::hooks::{HookSource, MetadataChangedCtx};
 use crate::preclude::BackendError;
 
@@ -26,6 +35,37 @@ fn find_game(config: &Config, game_name: &str) -> Result<Game, BackendError> {
         .ok_or_else(|| BackendError::GameNotFound(game_name.to_string()))
 }
 
+fn ensure_legacy_cloud_sync() -> Result<(), BackendError> {
+    if cloud_namespace_generation()? == CloudNamespaceGeneration::V2 {
+        Err(BackendError::V2CloudLibraryActive)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CloudLibraryStatus {
+    Empty,
+    JoinRequired { game_count: usize },
+    CutoverRequired { game_count: usize },
+    Active { game_count: usize },
+}
+
+#[derive(Debug, Error)]
+pub enum CloudLibraryServiceError {
+    #[error("Cloud Library creation requires explicit confirmation")]
+    ConfirmationRequired,
+    #[error("The active V2 Cloud Library no longer matches the saved connection")]
+    ActiveLibraryUnavailable,
+    #[error(transparent)]
+    Config(#[from] crate::preclude::ConfigError),
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    #[error(transparent)]
+    Bootstrap(#[from] CloudLibraryBootstrapError),
+}
+
 impl ServiceContext {
     pub async fn check_cloud_backend(
         &self,
@@ -39,6 +79,7 @@ impl ServiceContext {
         session: &CloudSyncSessionConfig,
         token: Option<CancellationToken>,
     ) -> Result<BatchSyncReport, BackendError> {
+        ensure_legacy_cloud_sync()?;
         upload_all_from_session(session, token).await
     }
 
@@ -47,10 +88,12 @@ impl ServiceContext {
         session: &CloudSyncSessionConfig,
         token: Option<CancellationToken>,
     ) -> Result<BatchSyncReport, BackendError> {
+        ensure_legacy_cloud_sync()?;
         download_all_from_session(session, token).await
     }
 
     pub async fn sync_game(&self, game_name: &str) -> Result<SyncGameOutcome, BackendError> {
+        ensure_legacy_cloud_sync()?;
         let config = get_config()?;
         let session = cloud_session(&config);
         let op = session.get_op()?;
@@ -63,6 +106,7 @@ impl ServiceContext {
         game_name: &str,
         resolution: ConflictResolution,
     ) -> Result<ConflictResolutionOutcome, BackendError> {
+        ensure_legacy_cloud_sync()?;
         let config = get_config()?;
         let session = cloud_session(&config);
         let op = session.get_op()?;
@@ -85,9 +129,124 @@ impl ServiceContext {
     }
 
     pub async fn sync_config(&self) -> Result<(), BackendError> {
+        ensure_legacy_cloud_sync()?;
         let config = get_config()?;
         let session = cloud_session(&config);
         let op = session.get_op()?;
         sync_cloud_config(&session, &op, &config).await
+    }
+
+    pub async fn inspect_cloud_library(
+        &self,
+    ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+        let (_, _, local_state) = cloud_bootstrap_inputs()?;
+        let generation = local_state.cloud_namespace_generation;
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let bootstrap = CloudLibraryBootstrap::new(session.get_op()?, 3);
+        let classification = bootstrap.inspect().await?;
+        map_library_status(generation, classification)
+    }
+
+    pub async fn create_cloud_library(
+        &self,
+        confirmed: bool,
+    ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+        if !confirmed {
+            return Err(CloudLibraryServiceError::ConfirmationRequired);
+        }
+        let (shared_library, device_profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation == CloudNamespaceGeneration::V2 {
+            return self.inspect_cloud_library().await;
+        }
+
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let bootstrap = CloudLibraryBootstrap::new(session.get_op()?, 3);
+        bootstrap
+            .create_empty(&shared_library, &device_profile)
+            .await?;
+        activate_cloud_namespace_v2(&shared_library, &device_profile)?;
+        Ok(CloudLibraryStatus::Active {
+            game_count: shared_library.games.len(),
+        })
+    }
+}
+
+fn map_library_status(
+    generation: CloudNamespaceGeneration,
+    classification: CloudNamespaceClassification,
+) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+    match (generation, classification) {
+        (
+            CloudNamespaceGeneration::V2,
+            CloudNamespaceClassification::SupportedV2 { shared_library, .. },
+        ) => Ok(CloudLibraryStatus::Active {
+            game_count: shared_library.games.len(),
+        }),
+        (CloudNamespaceGeneration::V2, _) => {
+            Err(CloudLibraryServiceError::ActiveLibraryUnavailable)
+        }
+        (
+            CloudNamespaceGeneration::LegacyV1,
+            CloudNamespaceClassification::SupportedV2 { shared_library, .. },
+        ) => Ok(CloudLibraryStatus::JoinRequired {
+            game_count: shared_library.games.len(),
+        }),
+        (CloudNamespaceGeneration::LegacyV1, CloudNamespaceClassification::V1Only { config }) => {
+            Ok(CloudLibraryStatus::CutoverRequired {
+                game_count: config.games.len(),
+            })
+        }
+        (CloudNamespaceGeneration::LegacyV1, CloudNamespaceClassification::Empty) => {
+            Ok(CloudLibraryStatus::Empty)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_sync::v2::{CloudManifest, CloudNamespaceDescriptor};
+    use crate::config::{SharedLibrary, V2_CONFIG_SCHEMA_VERSION};
+
+    fn supported() -> CloudNamespaceClassification {
+        CloudNamespaceClassification::SupportedV2 {
+            descriptor: CloudNamespaceDescriptor::default(),
+            shared_library: SharedLibrary {
+                schema_version: V2_CONFIG_SCHEMA_VERSION,
+                games: Vec::new(),
+            },
+            manifest: CloudManifest::default(),
+        }
+    }
+
+    #[test]
+    fn remote_state_maps_to_explicit_player_actions() {
+        assert_eq!(
+            map_library_status(CloudNamespaceGeneration::LegacyV1, supported()).unwrap(),
+            CloudLibraryStatus::JoinRequired { game_count: 0 }
+        );
+        assert_eq!(
+            map_library_status(
+                CloudNamespaceGeneration::LegacyV1,
+                CloudNamespaceClassification::Empty
+            )
+            .unwrap(),
+            CloudLibraryStatus::Empty
+        );
+        assert_eq!(
+            map_library_status(CloudNamespaceGeneration::V2, supported()).unwrap(),
+            CloudLibraryStatus::Active { game_count: 0 }
+        );
+    }
+
+    #[test]
+    fn active_device_fails_closed_when_saved_location_is_not_v2() {
+        assert!(matches!(
+            map_library_status(
+                CloudNamespaceGeneration::V2,
+                CloudNamespaceClassification::Empty
+            ),
+            Err(CloudLibraryServiceError::ActiveLibraryUnavailable)
+        ));
     }
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -660,6 +660,25 @@
         "backend_tab": {
             "tab": "Backend"
         },
+        "library": {
+            "title": "Cloud Library",
+            "description": "Save the connection above, then check whether this location can use the new multi-device library.",
+            "backend_disabled": "Enable and save a cloud backend before checking this location.",
+            "not_checked": "This saved location has not been checked yet.",
+            "inspect": "Check library",
+            "inspect_failed": "Could not check the Cloud Library",
+            "empty": "This location is empty and can create a new Cloud Library.",
+            "join_required": "An existing Cloud Library contains {count} games. This device must review and join it.",
+            "cutover_required": "Legacy cloud data for {count} games was found. It must be migrated explicitly.",
+            "active": "This device is using the Cloud Library with {count} games.",
+            "create": "Create library",
+            "create_title": "Create Cloud Library",
+            "create_warning": "Create a new multi-device Cloud Library from this device's game list? This also stops this device from using the legacy cloud format. Other devices must use a compatible version to share future changes.",
+            "create_confirm": "Create and switch",
+            "create_failed": "Could not create the Cloud Library",
+            "create_success": "Cloud Library created",
+            "legacy_disabled": "This device now uses the new Cloud Library. Legacy synchronization controls are unavailable."
+        },
         "operations": {
             "tab": "Operations",
             "warning": "These operations may overwrite data. Use with caution.",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -660,6 +660,25 @@
         "backend_tab": {
             "tab": "后端配置"
         },
+        "library": {
+            "title": "云端资料库",
+            "description": "请先保存上方连接设置，再检查该位置能否使用新的多设备资料库。",
+            "backend_disabled": "请先启用并保存云存档后端。",
+            "not_checked": "尚未检查当前保存的云端位置。",
+            "inspect": "检查资料库",
+            "inspect_failed": "无法检查云端资料库",
+            "empty": "该位置为空，可以创建新的云端资料库。",
+            "join_required": "发现包含 {count} 个游戏的云端资料库，此设备需要审阅后加入。",
+            "cutover_required": "发现 {count} 个游戏的旧版云存档，需要明确执行迁移。",
+            "active": "此设备正在使用包含 {count} 个游戏的云端资料库。",
+            "create": "创建资料库",
+            "create_title": "创建云端资料库",
+            "create_warning": "要根据此设备的游戏列表创建新的多设备云端资料库吗？此设备也会停止使用旧版云存档格式。其他设备必须使用兼容版本才能共享后续变更。",
+            "create_confirm": "创建并切换",
+            "create_failed": "无法创建云端资料库",
+            "create_success": "云端资料库已创建",
+            "legacy_disabled": "此设备已切换到新的云端资料库，旧版同步操作已不可用。"
+        },
         "operations": {
             "tab": "操作",
             "warning": "以下操作可能会覆盖数据，请谨慎使用。",


### PR DESCRIPTION
## 概要

- 识别已保存云端位置，并区分空目录、旧版数据和已有 V2 资料库
- 仅允许显式创建空资料库，按描述文件最后发布的顺序写入并读回确认
- 远端完成后才激活本机 V2；切换前等待旧版同步退出，切换后关闭旧版入口
- 在同步设置中提供简洁的资料库状态与风险确认