### PR TITLE
feat: 加入现有 V2 云端资料库

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/cloud_library.rs
+++ b/apps/rgsm-gui/src-tauri/src/cloud_library.rs
@@ -1,8 +1,11 @@
 use std::sync::Arc;
 
 use rgsm_core::cloud_sync::CloudSyncTaskManager;
+use rgsm_core::cloud_sync::v2::{CloudLibraryJoinReview, JoinGameDecision};
 use rgsm_core::config::get_config;
-use rgsm_core::services::{CloudLibraryServiceError, CloudLibraryStatus, ServiceContext};
+use rgsm_core::services::{
+    CloudLibraryJoinOutcome, CloudLibraryServiceError, CloudLibraryStatus, ServiceContext,
+};
 use tauri::{AppHandle, Manager};
 
 use crate::hooks::HookPipelineState;
@@ -21,4 +24,27 @@ pub async fn create(
     let config = get_config()?;
     crate::hooks::rebuild_pipeline(app, &config);
     Ok(status)
+}
+
+pub async fn review(app: &AppHandle) -> Result<CloudLibraryJoinReview, CloudLibraryServiceError> {
+    ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+        .review_cloud_library_join()
+        .await
+}
+
+pub async fn join(
+    app: &AppHandle,
+    decisions: &[JoinGameDecision],
+    confirmed_replacements: bool,
+) -> Result<CloudLibraryJoinOutcome, CloudLibraryServiceError> {
+    app.state::<Arc<CloudSyncTaskManager>>()
+        .cancel_all_and_wait()
+        .await;
+    let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+        .join_cloud_library(decisions, confirmed_replacements)
+        .await?;
+    if matches!(outcome, CloudLibraryJoinOutcome::Active { .. }) {
+        crate::hooks::rebuild_pipeline(app, &get_config()?);
+    }
+    Ok(outcome)
 }

--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -2,6 +2,7 @@ use crate::{quick_actions, sound};
 use rgsm_core::backup::{
     CreatedBy, ExtraBackupItem, Game, GameDeviceBinding, GameDraft, GameSnapshots, SaveUnit,
 };
+use rgsm_core::cloud_sync::v2::{CloudLibraryJoinReview, JoinGameDecision};
 use rgsm_core::cloud_sync::{
     self, BatchSyncItemStatus, BatchSyncReport, CancelCloudSyncResult, CloudBackendCheckReport,
     CloudSyncSessionConfig, CloudSyncTaskManager, ConflictResolution, ConflictResolutionOutcome,
@@ -18,7 +19,7 @@ use rgsm_core::path_pattern::{PathPlaceholder, PathPlaceholderDescriptor};
 use rgsm_core::path_resolution::ResolutionReport;
 use rgsm_core::path_resolver;
 use rgsm_core::preclude::*;
-use rgsm_core::services::{CloudLibraryStatus, ServiceContext};
+use rgsm_core::services::{CloudLibraryJoinOutcome, CloudLibraryStatus, ServiceContext};
 use rgsm_core::steam;
 use rgsm_core::vn_scanner;
 use rgsm_core::{backup, config, system_fonts};
@@ -623,6 +624,30 @@ pub async fn create_cloud_library(
             error!(target:"rgsm::ipc", "Failed to create Cloud Library: {error:?}");
             error.to_string()
         })
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn review_cloud_library_join(
+    app_handle: AppHandle,
+) -> Result<CloudLibraryJoinReview, String> {
+    info!(target:"rgsm::ipc", "Reviewing an existing Cloud Library");
+    crate::cloud_library::review(&app_handle)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn join_cloud_library(
+    decisions: Vec<JoinGameDecision>,
+    confirmed_replacements: bool,
+    app_handle: AppHandle,
+) -> Result<CloudLibraryJoinOutcome, String> {
+    info!(target:"rgsm::ipc", "Joining an existing Cloud Library");
+    crate::cloud_library::join(&app_handle, &decisions, confirmed_replacements)
+        .await
+        .map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -119,6 +119,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::check_cloud_backend,
             ipc_handler::inspect_cloud_library,
             ipc_handler::create_cloud_library,
+            ipc_handler::review_cloud_library_join,
+            ipc_handler::join_cloud_library,
             ipc_handler::cloud_upload_all,
             ipc_handler::cloud_download_all,
             ipc_handler::cancel_cloud_sync,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -212,6 +212,22 @@ async createCloudLibrary(confirmed: boolean) : Promise<Result<CloudLibraryStatus
     else return { status: "error", error: e  as any };
 }
 },
+async reviewCloudLibraryJoin() : Promise<Result<CloudLibraryJoinReview, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("review_cloud_library_join") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async joinCloudLibrary(decisions: JoinGameDecision[], confirmedReplacements: boolean) : Promise<Result<CloudLibraryJoinOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("join_cloud_library", { decisions, confirmedReplacements }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async cloudUploadAll(session: CloudSyncSessionConfig) : Promise<Result<BatchSyncReport, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("cloud_upload_all", { session }) };
@@ -651,6 +667,9 @@ export type CloudBackendCheckItemStatus = "passed" | "warning" | "failed"
 export type CloudBackendCheckOutcome = "available" | "degraded" | "unavailable"
 export type CloudBackendCheckReport = { outcome: CloudBackendCheckOutcome; items: CloudBackendCheckItem[] }
 export type CloudBackendCheckStep = "prepare_backend" | "list_files" | "write_file" | "read_file" | "verify_content" | "delete_file"
+export type CloudLibraryJoinItem = { local_game_id: string; local_name: string; local_fingerprint: string; cloud_names: string[]; cloud_fingerprint: string | null; classification: GameJoinClassification; difference: GameDefinitionDifference }
+export type CloudLibraryJoinOutcome = { kind: "active"; game_count: number } | { kind: "review_changed"; game_name: string }
+export type CloudLibraryJoinReview = { cloud_game_count: number; items: CloudLibraryJoinItem[] }
 export type CloudLibraryStatus = { kind: "empty" } | { kind: "join_required"; game_count: number } | { kind: "cutover_required"; game_count: number } | { kind: "active"; game_count: number }
 export type CloudSettings = {
 /**
@@ -814,6 +833,7 @@ ludusavi_meta?: LudusaviMeta | null;
 device_bindings: Partial<{ [key in string]: GameDeviceBinding }> }
 export type GameAutomationSettings = { storage_key?: string; game_name: string; process_name?: string; on_process_start?: boolean; on_process_exit?: boolean; in_process_interval_secs?: number | null }
 export type GameAutomationSettingsDraft = { process_name?: string; on_process_start?: boolean; on_process_exit?: boolean; in_process_interval_secs?: number | null }
+export type GameDefinitionDifference = { name_changed: boolean; local_save_unit_count: number; cloud_save_unit_count: number; save_units_changed: boolean; local_recognition: boolean; cloud_recognition: boolean; recognition_changed: boolean }
 export type GameDeviceBinding = { rootIds?: number[] | null; accountIds?: number[] | null; installationIds?: number[] | null; restoreMappings: RestoreMappingRule[] }
 /**
  * Frontend/IPC input shape for creating/updating a game.
@@ -824,6 +844,7 @@ export type GameDraft = { name: string; save_paths: SaveUnitDraft[]; game_paths?
  * Metadata from Ludusavi manifest import (optional for manually added games).
  */
 ludusavi_meta?: LudusaviMeta | null; device_bindings: Partial<{ [key in string]: GameDeviceBinding }> }
+export type GameJoinClassification = "same" | "local_only" | "possible_duplicate" | "game_definition_conflict"
 /**
  * A backup list info is a json file in a backup folder for a game.
  * It contains the name of the game,
@@ -873,6 +894,8 @@ isManaged: boolean;
  */
 savePathsCount: number }
 export type IpcNotification = { level: NotificationLevel; title: string; msg: string }
+export type JoinGameAction = "keep_cloud" | "add_local" | "replace_cloud"
+export type JoinGameDecision = { local_game_id: string; local_fingerprint: string; cloud_fingerprint: string | null; action: JoinGameAction }
 export type LudusaviManifestStatus = {
 /**
  * Current manifest source: `local`, `bundled`, or `none`.

--- a/apps/rgsm-gui/src/components/CloudLibraryJoinDialog.vue
+++ b/apps/rgsm-gui/src/components/CloudLibraryJoinDialog.vue
@@ -1,0 +1,400 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import {
+  commands,
+  type CloudLibraryJoinItem,
+  type CloudLibraryJoinReview,
+  type JoinGameAction,
+  type JoinGameDecision,
+} from '~/bindings';
+import { $t } from '~/i18n';
+import { LAYER } from '~/ui/layers';
+
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: boolean): void;
+  (event: 'joined', gameCount: number): void;
+}>();
+
+const feedback = useFeedback();
+const review = ref<CloudLibraryJoinReview | null>(null);
+const actions = ref<Record<string, JoinGameAction>>({});
+const selectedId = ref('');
+const loading = ref(false);
+const joining = ref(false);
+const tagTypes = {
+  same: 'success',
+  local_only: 'info',
+  possible_duplicate: 'warning',
+  game_definition_conflict: 'danger',
+} as const;
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+const selected = computed(
+  () => review.value?.items.find((item) => item.local_game_id === selectedId.value) ?? null
+);
+const replacementCount = computed(
+  () => Object.values(actions.value).filter((action) => action === 'replace_cloud').length
+);
+const changedCount = computed(
+  () => review.value?.items.filter((item) => item.classification !== 'same').length ?? 0
+);
+
+function classificationLabel(item: CloudLibraryJoinItem) {
+  return $t(`sync_settings.library.join.classification.${item.classification}`);
+}
+
+function classificationType(item: CloudLibraryJoinItem) {
+  return tagTypes[item.classification];
+}
+
+function cloudName(item: CloudLibraryJoinItem) {
+  return item.cloud_names.length
+    ? item.cloud_names.join(', ')
+    : $t('sync_settings.library.join.not_in_cloud');
+}
+
+function recognitionLabel(value: boolean) {
+  return value
+    ? $t('sync_settings.library.join.recognition_available')
+    : $t('sync_settings.library.join.recognition_unavailable');
+}
+
+async function loadReview() {
+  loading.value = true;
+  try {
+    const result = await commands.reviewCloudLibraryJoin();
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.library.join.review_failed')}: ${result.error}`);
+      visible.value = false;
+      return;
+    }
+    review.value = result.data;
+    actions.value = Object.fromEntries(
+      result.data.items.map((item) => [item.local_game_id, 'keep_cloud'])
+    );
+    selectedId.value =
+      result.data.items.find((item) => item.classification !== 'same')?.local_game_id ??
+      result.data.items[0]?.local_game_id ??
+      '';
+  } catch (reason) {
+    notifyError(`${$t('sync_settings.library.join.review_failed')}: ${String(reason)}`);
+    visible.value = false;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function decisions(): JoinGameDecision[] {
+  return (review.value?.items ?? [])
+    .filter((item) => item.classification !== 'same')
+    .map((item) => ({
+      local_game_id: item.local_game_id,
+      local_fingerprint: item.local_fingerprint,
+      cloud_fingerprint: item.cloud_fingerprint,
+      action: actions.value[item.local_game_id] ?? 'keep_cloud',
+    }));
+}
+
+async function submit() {
+  if (!review.value || joining.value) return;
+  if (replacementCount.value > 0) {
+    try {
+      await feedback.confirm(
+        $t('sync_settings.library.join.replace_warning', { count: replacementCount.value }),
+        $t('sync_settings.library.join.replace_title'),
+        {
+          confirmButtonText: $t('sync_settings.library.join.replace_confirm'),
+          cancelButtonText: $t('sync_settings.cancel'),
+          type: 'warning',
+        }
+      );
+    } catch {
+      return;
+    }
+  }
+
+  joining.value = true;
+  try {
+    const result = await commands.joinCloudLibrary(decisions(), replacementCount.value > 0);
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.library.join.join_failed')}: ${result.error}`);
+      return;
+    }
+    if (result.data.kind === 'review_changed') {
+      notifyWarning(
+        $t('sync_settings.library.join.review_changed', { game: result.data.game_name })
+      );
+      await loadReview();
+      return;
+    }
+    notifySuccess($t('sync_settings.library.join.join_success'));
+    emit('joined', result.data.game_count);
+    visible.value = false;
+  } catch (reason) {
+    notifyError(`${$t('sync_settings.library.join.join_failed')}: ${String(reason)}`);
+  } finally {
+    joining.value = false;
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) void loadReview();
+  }
+);
+</script>
+
+<template>
+  <ElDialog
+    v-model="visible"
+    :title="$t('sync_settings.library.join.title')"
+    width="min(920px, 94vw)"
+    destroy-on-close
+    class="join-dialog"
+    :z-index="LAYER.dialog"
+  >
+    <div v-loading="loading" class="join-body">
+      <ElAlert
+        type="warning"
+        :title="$t('sync_settings.library.join.risk_title')"
+        :description="$t('sync_settings.library.join.risk_description')"
+        :closable="false"
+        show-icon
+      />
+
+      <template v-if="review">
+        <p class="join-summary">
+          {{
+            $t('sync_settings.library.join.summary', {
+              cloud: review.cloud_game_count,
+              review: changedCount,
+            })
+          }}
+        </p>
+
+        <div v-if="review.items.length" class="join-grid">
+          <nav class="game-list" :aria-label="$t('sync_settings.library.join.games_label')">
+            <ElButton
+              v-for="item in review.items"
+              :key="item.local_game_id"
+              :type="selectedId === item.local_game_id ? 'primary' : 'default'"
+              plain
+              class="game-item"
+              @click="selectedId = item.local_game_id"
+            >
+              <span class="game-name">{{ item.local_name }}</span>
+              <ElTag :type="classificationType(item)" size="small">
+                {{ classificationLabel(item) }}
+              </ElTag>
+            </ElButton>
+          </nav>
+
+          <section v-if="selected" class="game-review">
+            <div class="game-review-heading">
+              <h4>{{ selected.local_name }}</h4>
+              <ElTag :type="classificationType(selected)">
+                {{ classificationLabel(selected) }}
+              </ElTag>
+            </div>
+
+            <div class="difference-table">
+              <div class="difference-head">
+                <span></span>
+                <strong>{{ $t('sync_settings.library.join.local') }}</strong>
+                <strong>{{ $t('sync_settings.library.join.cloud') }}</strong>
+              </div>
+              <div v-if="selected.difference.name_changed || !selected.cloud_names.length">
+                <span>{{ $t('sync_settings.library.join.game_name') }}</span>
+                <span>{{ selected.local_name }}</span>
+                <span>{{ cloudName(selected) }}</span>
+              </div>
+              <div v-if="selected.difference.save_units_changed">
+                <span>{{ $t('sync_settings.library.join.save_units') }}</span>
+                <span>
+                  {{
+                    $t('sync_settings.library.join.item_count', {
+                      count: selected.difference.local_save_unit_count,
+                    })
+                  }}
+                </span>
+                <span>
+                  {{
+                    $t('sync_settings.library.join.item_count', {
+                      count: selected.difference.cloud_save_unit_count,
+                    })
+                  }}
+                </span>
+              </div>
+              <div v-if="selected.difference.recognition_changed">
+                <span>{{ $t('sync_settings.library.join.recognition') }}</span>
+                <span>{{ recognitionLabel(selected.difference.local_recognition) }}</span>
+                <span>{{ recognitionLabel(selected.difference.cloud_recognition) }}</span>
+              </div>
+              <p
+                v-if="
+                  !selected.difference.name_changed &&
+                  !selected.difference.save_units_changed &&
+                  !selected.difference.recognition_changed
+                "
+                class="no-difference"
+              >
+                {{ $t('sync_settings.library.join.no_difference') }}
+              </p>
+            </div>
+
+            <ElRadioGroup
+              v-if="selected.classification !== 'same'"
+              v-model="actions[selected.local_game_id]"
+              class="decision-group"
+            >
+              <ElRadio value="keep_cloud">
+                {{ $t('sync_settings.library.join.keep_cloud') }}
+              </ElRadio>
+              <ElRadio
+                v-if="
+                  selected.classification === 'local_only' ||
+                  selected.classification === 'possible_duplicate'
+                "
+                value="add_local"
+              >
+                {{ $t('sync_settings.library.join.add_local') }}
+              </ElRadio>
+              <ElRadio
+                v-if="selected.classification === 'game_definition_conflict'"
+                value="replace_cloud"
+              >
+                {{ $t('sync_settings.library.join.replace_cloud') }}
+              </ElRadio>
+            </ElRadioGroup>
+          </section>
+        </div>
+        <ElEmpty v-else :description="$t('sync_settings.library.join.no_local_games')" />
+      </template>
+    </div>
+
+    <template #footer>
+      <ElButton @click="visible = false">{{ $t('sync_settings.cancel') }}</ElButton>
+      <ElButton type="primary" :loading="joining" :disabled="loading || !review" @click="submit">
+        {{ $t('sync_settings.library.join.join_action') }}
+      </ElButton>
+    </template>
+  </ElDialog>
+</template>
+
+<style scoped>
+:global(.join-dialog) {
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 32px);
+  margin: 16px auto !important;
+}
+
+:global(.join-dialog .el-dialog__body) {
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.join-body {
+  min-height: 260px;
+}
+
+.join-summary {
+  margin: 16px 0;
+  color: var(--el-text-color-secondary);
+}
+
+.join-grid {
+  display: grid;
+  grid-template-columns: minmax(210px, 0.75fr) minmax(0, 1.7fr);
+  gap: 16px;
+}
+
+.game-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  max-height: 430px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.game-item {
+  justify-content: space-between;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  white-space: normal;
+}
+
+.game-name {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.game-review {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: var(--el-border-radius-base);
+}
+
+.game-review-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.game-review-heading h4 {
+  margin: 0;
+}
+
+.difference-table {
+  margin-top: 16px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+
+.difference-table > div {
+  display: grid;
+  grid-template-columns: minmax(90px, 0.7fr) repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--el-border-color-lighter);
+}
+
+.difference-table > div > span {
+  overflow-wrap: anywhere;
+}
+
+.difference-table > div > span:first-child,
+.no-difference {
+  color: var(--el-text-color-secondary);
+}
+
+.decision-group {
+  display: flex;
+  align-items: flex-start;
+  margin-top: 16px;
+}
+
+@media (max-width: 720px) {
+  :global(.join-dialog .el-dialog__footer) {
+    padding-right: calc(var(--el-dialog-padding-primary) + var(--el-component-size-large));
+  }
+
+  .join-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .game-list {
+    max-height: 180px;
+  }
+}
+</style>

--- a/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
+++ b/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
@@ -17,6 +17,7 @@ const feedback = useFeedback();
 const status = ref<CloudLibraryStatus | null>(null);
 const inspecting = ref(false);
 const creating = ref(false);
+const joining = ref(false);
 
 const alertType = computed(() => {
   switch (status.value?.kind) {
@@ -51,6 +52,10 @@ const statusText = computed(() => {
 function updateStatus(value: CloudLibraryStatus | null) {
   status.value = value;
   emit('status', value);
+}
+
+function joined(gameCount: number) {
+  updateStatus({ kind: 'active', game_count: gameCount });
 }
 
 async function inspect() {
@@ -140,7 +145,11 @@ watch(
       <ElButton v-if="status?.kind === 'empty'" type="primary" :loading="creating" @click="create">
         {{ $t('sync_settings.library.create') }}
       </ElButton>
+      <ElButton v-if="status?.kind === 'join_required'" type="primary" @click="joining = true">
+        {{ $t('sync_settings.library.join.join_action') }}
+      </ElButton>
     </div>
+    <CloudLibraryJoinDialog v-model="joining" @joined="joined" />
   </section>
 </template>
 

--- a/crates/rgsm-core/src/cloud_sync/v2/join.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join.rs
@@ -1,0 +1,531 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use super::{
+    CloudLibraryTransport, CloudNamespaceClassification, CloudNamespaceClassifier,
+    CloudNamespaceError, GameJoinClassification, OpenDalNamespaceTransport, SHARED_LIBRARY_PATH,
+    compare_join_libraries, device_profile_path,
+};
+use crate::config::{DeviceProfile, OwnershipError, SharedGame, SharedLibrary};
+
+static JOIN_WRITER_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CloudLibraryJoinReview {
+    pub cloud_game_count: usize,
+    pub items: Vec<CloudLibraryJoinItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CloudLibraryJoinItem {
+    pub local_game_id: String,
+    pub local_name: String,
+    pub local_fingerprint: String,
+    pub cloud_names: Vec<String>,
+    pub cloud_fingerprint: Option<String>,
+    pub classification: GameJoinClassification,
+    pub difference: GameDefinitionDifference,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct GameDefinitionDifference {
+    pub name_changed: bool,
+    pub local_save_unit_count: usize,
+    pub cloud_save_unit_count: usize,
+    pub save_units_changed: bool,
+    pub local_recognition: bool,
+    pub cloud_recognition: bool,
+    pub recognition_changed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum JoinGameAction {
+    KeepCloud,
+    AddLocal,
+    ReplaceCloud,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct JoinGameDecision {
+    pub local_game_id: String,
+    pub local_fingerprint: String,
+    pub cloud_fingerprint: Option<String>,
+    pub action: JoinGameAction,
+}
+
+pub struct CloudLibraryJoin<T: CloudLibraryTransport> {
+    transport: Arc<T>,
+    max_attempts: usize,
+}
+
+impl CloudLibraryJoin<OpenDalNamespaceTransport> {
+    pub fn new(operator: opendal::Operator, max_attempts: usize) -> Self {
+        Self::with_transport(OpenDalNamespaceTransport::new(operator), max_attempts)
+    }
+}
+
+impl<T: CloudLibraryTransport> CloudLibraryJoin<T> {
+    pub fn with_transport(transport: T, max_attempts: usize) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn review(
+        &self,
+        local: &SharedLibrary,
+    ) -> Result<CloudLibraryJoinReview, CloudLibraryJoinError> {
+        let cloud = self.load_supported().await?;
+        build_review(local, &cloud)
+    }
+
+    pub async fn join(
+        &self,
+        local: &SharedLibrary,
+        local_profile: &DeviceProfile,
+        decisions: &[JoinGameDecision],
+        confirmed_replacements: bool,
+    ) -> Result<(SharedLibrary, DeviceProfile), CloudLibraryJoinError> {
+        let _guard = JOIN_WRITER_LOCK.lock().await;
+        validate_decisions(local, decisions, confirmed_replacements)?;
+
+        for _ in 0..self.max_attempts {
+            let latest = self.load_supported().await?;
+            let accepted = apply_decisions(local, latest, decisions)?;
+            let expected = serde_json::to_vec_pretty(&accepted)?;
+            if decisions
+                .iter()
+                .any(|decision| decision.action != JoinGameAction::KeepCloud)
+            {
+                self.transport.write(SHARED_LIBRARY_PATH, &expected).await?;
+                if self.transport.read(SHARED_LIBRARY_PATH).await?.as_deref()
+                    != Some(expected.as_slice())
+                {
+                    continue;
+                }
+            }
+
+            let profile = local_profile.for_shared_library(&accepted);
+            let profile_path = device_profile_path(&profile.device.id);
+            let profile_bytes = serde_json::to_vec_pretty(&profile)?;
+            self.write_verified(&profile_path, &profile_bytes).await?;
+            return Ok((accepted, profile));
+        }
+        Err(CloudLibraryJoinError::WriteVerificationFailed {
+            path: SHARED_LIBRARY_PATH.to_string(),
+            attempts: self.max_attempts,
+        })
+    }
+
+    async fn load_supported(&self) -> Result<SharedLibrary, CloudLibraryJoinError> {
+        match CloudNamespaceClassifier::with_transport(self.transport.clone())
+            .classify()
+            .await?
+        {
+            CloudNamespaceClassification::SupportedV2 { shared_library, .. } => Ok(shared_library),
+            CloudNamespaceClassification::V1Only { .. } => {
+                Err(CloudLibraryJoinError::JoinUnavailable("legacy_v1"))
+            }
+            CloudNamespaceClassification::Empty => {
+                Err(CloudLibraryJoinError::JoinUnavailable("empty"))
+            }
+        }
+    }
+
+    async fn write_verified(&self, path: &str, bytes: &[u8]) -> Result<(), CloudLibraryJoinError> {
+        for _ in 0..self.max_attempts {
+            self.transport.write(path, bytes).await?;
+            if self.transport.read(path).await?.as_deref() == Some(bytes) {
+                return Ok(());
+            }
+        }
+        Err(CloudLibraryJoinError::WriteVerificationFailed {
+            path: path.to_string(),
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+fn build_review(
+    local: &SharedLibrary,
+    cloud: &SharedLibrary,
+) -> Result<CloudLibraryJoinReview, CloudLibraryJoinError> {
+    let items = compare_join_libraries(local, cloud)?
+        .into_iter()
+        .map(|candidate| {
+            let cloud = candidate.cloud_candidates.first();
+            Ok(CloudLibraryJoinItem {
+                local_game_id: candidate.local.storage_key.clone(),
+                local_name: candidate.local.name.clone(),
+                local_fingerprint: candidate.local.portable_fingerprint()?,
+                cloud_names: candidate
+                    .cloud_candidates
+                    .iter()
+                    .map(|game| game.name.clone())
+                    .collect(),
+                cloud_fingerprint: cloud.map(|game| game.portable_fingerprint()).transpose()?,
+                classification: candidate.classification,
+                difference: difference(&candidate.local, cloud),
+            })
+        })
+        .collect::<Result<Vec<_>, CloudLibraryJoinError>>()?;
+    Ok(CloudLibraryJoinReview {
+        cloud_game_count: cloud.games.len(),
+        items,
+    })
+}
+
+fn difference(local: &SharedGame, cloud: Option<&SharedGame>) -> GameDefinitionDifference {
+    GameDefinitionDifference {
+        name_changed: cloud.is_some_and(|game| game.name != local.name),
+        local_save_unit_count: local.save_units.len(),
+        cloud_save_unit_count: cloud.map_or(0, |game| game.save_units.len()),
+        save_units_changed: cloud.is_none_or(|game| {
+            game.normalized_portable().save_units != local.normalized_portable().save_units
+        }),
+        local_recognition: local.ludusavi_meta.is_some(),
+        cloud_recognition: cloud.is_some_and(|game| game.ludusavi_meta.is_some()),
+        recognition_changed: cloud.is_none_or(|game| game.ludusavi_meta != local.ludusavi_meta),
+    }
+}
+
+fn validate_decisions(
+    local: &SharedLibrary,
+    decisions: &[JoinGameDecision],
+    confirmed_replacements: bool,
+) -> Result<(), CloudLibraryJoinError> {
+    local.validate()?;
+    let local_ids = local
+        .games
+        .iter()
+        .map(|game| game.storage_key.as_str())
+        .collect::<HashSet<_>>();
+    let mut seen = HashSet::new();
+    for decision in decisions {
+        if !local_ids.contains(decision.local_game_id.as_str())
+            || !seen.insert(decision.local_game_id.as_str())
+        {
+            return Err(CloudLibraryJoinError::InvalidDecision(
+                decision.local_game_id.clone(),
+            ));
+        }
+        if decision.action == JoinGameAction::ReplaceCloud && !confirmed_replacements {
+            return Err(CloudLibraryJoinError::ReplacementConfirmationRequired);
+        }
+    }
+    Ok(())
+}
+
+fn apply_decisions(
+    local: &SharedLibrary,
+    mut latest: SharedLibrary,
+    decisions: &[JoinGameDecision],
+) -> Result<SharedLibrary, CloudLibraryJoinError> {
+    let local_by_id = local
+        .games
+        .iter()
+        .map(|game| (game.storage_key.as_str(), game))
+        .collect::<HashMap<_, _>>();
+    for decision in decisions {
+        let local_game = local_by_id[decision.local_game_id.as_str()];
+        if local_game.portable_fingerprint()? != decision.local_fingerprint {
+            return Err(CloudLibraryJoinError::LocalGameChanged(
+                local_game.name.clone(),
+            ));
+        }
+        let cloud_index = latest
+            .games
+            .iter()
+            .position(|game| game.storage_key == decision.local_game_id);
+        match decision.action {
+            JoinGameAction::KeepCloud => {}
+            JoinGameAction::AddLocal => match cloud_index {
+                None => latest.games.push(local_game.clone()),
+                Some(_) => {
+                    return Err(CloudLibraryJoinError::InvalidDecision(
+                        decision.local_game_id.clone(),
+                    ));
+                }
+            },
+            JoinGameAction::ReplaceCloud => {
+                let Some(index) = cloud_index else {
+                    return Err(CloudLibraryJoinError::TargetChanged(
+                        local_game.name.clone(),
+                    ));
+                };
+                let expected = decision.cloud_fingerprint.as_deref();
+                let actual = latest.games[index].portable_fingerprint()?;
+                if expected.is_none() || Some(actual.as_str()) != expected {
+                    return Err(CloudLibraryJoinError::TargetChanged(
+                        local_game.name.clone(),
+                    ));
+                }
+                latest.games[index] = local_game.clone();
+            }
+        }
+    }
+    latest.games.sort_by(|left, right| {
+        left.storage_key
+            .cmp(&right.storage_key)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    latest.validate()?;
+    Ok(latest)
+}
+
+#[derive(Debug, Error)]
+pub enum CloudLibraryJoinError {
+    #[error(transparent)]
+    Namespace(#[from] CloudNamespaceError),
+    #[error(transparent)]
+    Comparison(#[from] super::GameJoinComparisonError),
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+    #[error("Cloud Library serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Cloud Library transport error: {0}")]
+    Transport(#[from] opendal::Error),
+    #[error("Cloud Library join is unavailable for root state: {0}")]
+    JoinUnavailable(&'static str),
+    #[error("Invalid join decision for Game: {0}")]
+    InvalidDecision(String),
+    #[error("Local Game changed during join review: {0}")]
+    LocalGameChanged(String),
+    #[error("Cloud Game changed during join review: {0}")]
+    TargetChanged(String),
+    #[error("Replacing a shared Game requires explicit confirmation")]
+    ReplacementConfirmationRequired,
+    #[error("Cloud object {path} did not match after {attempts} write attempts")]
+    WriteVerificationFailed { path: String, attempts: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Mutex as StdMutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::cloud_sync::v2::{
+        CLOUD_MANIFEST_PATH, CloudManifest, CloudNamespaceDescriptor, NamespaceTransport,
+        V2_NAMESPACE_DESCRIPTOR_PATH,
+    };
+    use crate::config::{
+        ConfigurationOwners, SharedSaveUnit, SharedSaveUnitSource, V2_CONFIG_SCHEMA_VERSION,
+    };
+
+    #[derive(Default)]
+    struct FakeTransport {
+        objects: StdMutex<BTreeMap<String, Vec<u8>>>,
+        writes: StdMutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl NamespaceTransport for FakeTransport {
+        async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+            Ok(self.objects.lock().unwrap().get(path).cloned())
+        }
+
+        async fn list_sample(
+            &self,
+            prefix: &str,
+            limit: usize,
+        ) -> Result<Vec<String>, opendal::Error> {
+            Ok(self
+                .objects
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+    }
+
+    #[async_trait]
+    impl CloudLibraryTransport for FakeTransport {
+        async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error> {
+            self.writes.lock().unwrap().push(path.to_string());
+            self.objects
+                .lock()
+                .unwrap()
+                .insert(path.to_string(), bytes.to_vec());
+            Ok(())
+        }
+    }
+
+    fn game(id: &str, name: &str, unit_id: u32) -> SharedGame {
+        SharedGame {
+            name: name.into(),
+            storage_key: id.into(),
+            save_units: vec![SharedSaveUnit {
+                id: unit_id,
+                source: SharedSaveUnitSource::Concrete {
+                    unit_type: crate::backup::SaveUnitType::Folder,
+                },
+            }],
+            next_save_unit_id: unit_id + 1,
+            ludusavi_meta: None,
+        }
+    }
+
+    fn library(games: Vec<SharedGame>) -> SharedLibrary {
+        SharedLibrary {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            games,
+        }
+    }
+
+    fn transport(cloud: &SharedLibrary) -> FakeTransport {
+        let transport = FakeTransport::default();
+        let mut objects = transport.objects.lock().unwrap();
+        objects.insert(
+            V2_NAMESPACE_DESCRIPTOR_PATH.into(),
+            serde_json::to_vec(&CloudNamespaceDescriptor::default()).unwrap(),
+        );
+        objects.insert(
+            CLOUD_MANIFEST_PATH.into(),
+            serde_json::to_vec(&CloudManifest::default()).unwrap(),
+        );
+        objects.insert(
+            SHARED_LIBRARY_PATH.into(),
+            serde_json::to_vec(cloud).unwrap(),
+        );
+        drop(objects);
+        transport
+    }
+
+    fn profile(local: &SharedLibrary) -> DeviceProfile {
+        let config = crate::config::Config {
+            games: local
+                .games
+                .iter()
+                .map(|game| crate::backup::Game {
+                    name: game.name.clone(),
+                    storage_key: game.storage_key.clone(),
+                    save_paths: Vec::new(),
+                    game_paths: HashMap::new(),
+                    next_save_unit_id: game.next_save_unit_id,
+                    cloud_sync_enabled: false,
+                    auto_backup: None,
+                    ludusavi_meta: None,
+                    device_bindings: HashMap::new(),
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let owners = ConfigurationOwners::from_legacy(&config, &"device".into());
+        owners.device_profiles["device"].clone()
+    }
+
+    #[tokio::test]
+    async fn review_is_read_only_and_classifies_all_local_games() {
+        let mut conflict = game("conflict", "Conflict", 1);
+        let cloud_conflict = conflict.clone();
+        conflict.name = "Local Conflict".into();
+        let local = library(vec![
+            game("same", "Same", 1),
+            game("local", "Local", 1),
+            game("duplicate", "Duplicate", 1),
+            conflict,
+        ]);
+        let cloud = library(vec![
+            game("same", "Same", 1),
+            game("remote-duplicate", "Duplicate", 1),
+            cloud_conflict,
+        ]);
+        let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+
+        let review = join.review(&local).await.unwrap();
+
+        assert_eq!(review.items.len(), 4);
+        assert_eq!(
+            review
+                .items
+                .iter()
+                .map(|item| item.classification)
+                .collect::<Vec<_>>(),
+            vec![
+                GameJoinClassification::GameDefinitionConflict,
+                GameJoinClassification::PossibleDuplicate,
+                GameJoinClassification::LocalOnly,
+                GameJoinClassification::Same,
+            ]
+        );
+        assert!(join.transport.writes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn join_adds_and_replaces_whole_games_then_publishes_profile() {
+        let local_only = game("local", "Local", 1);
+        let replacement = game("conflict", "Local Conflict", 2);
+        let cloud_conflict = game("conflict", "Cloud Conflict", 1);
+        let local = library(vec![local_only.clone(), replacement.clone()]);
+        let cloud = library(vec![cloud_conflict.clone(), game("remote", "Remote", 1)]);
+        let review = build_review(&local, &cloud).unwrap();
+        let decisions = review
+            .items
+            .iter()
+            .map(|item| JoinGameDecision {
+                local_game_id: item.local_game_id.clone(),
+                local_fingerprint: item.local_fingerprint.clone(),
+                cloud_fingerprint: item.cloud_fingerprint.clone(),
+                action: if item.local_game_id == "local" {
+                    JoinGameAction::AddLocal
+                } else {
+                    JoinGameAction::ReplaceCloud
+                },
+            })
+            .collect::<Vec<_>>();
+        let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+
+        let (accepted, _) = join
+            .join(&local, &profile(&local), &decisions, true)
+            .await
+            .unwrap();
+
+        assert!(accepted.games.contains(&local_only));
+        assert!(accepted.games.contains(&replacement));
+        assert!(
+            accepted
+                .games
+                .iter()
+                .any(|game| game.storage_key == "remote")
+        );
+        assert_eq!(
+            join.transport.writes.lock().unwrap().as_slice(),
+            [SHARED_LIBRARY_PATH, device_profile_path("device").as_str()]
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_replacement_does_not_write() {
+        let local = library(vec![game("game", "Local", 2)]);
+        let reviewed_cloud = library(vec![game("game", "Cloud", 1)]);
+        let review = build_review(&local, &reviewed_cloud).unwrap();
+        let decision = JoinGameDecision {
+            local_game_id: "game".into(),
+            local_fingerprint: review.items[0].local_fingerprint.clone(),
+            cloud_fingerprint: review.items[0].cloud_fingerprint.clone(),
+            action: JoinGameAction::ReplaceCloud,
+        };
+        let changed_cloud = library(vec![game("game", "Changed Again", 3)]);
+        let join = CloudLibraryJoin::with_transport(transport(&changed_cloud), 2);
+
+        assert!(matches!(
+            join.join(&local, &profile(&local), &[decision], true)
+                .await,
+            Err(CloudLibraryJoinError::TargetChanged(name)) if name == "Local"
+        ));
+        assert!(join.transport.writes.lock().unwrap().is_empty());
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -2,6 +2,7 @@ mod bootstrap;
 mod deletion;
 mod game_comparison;
 mod integrity;
+mod join;
 mod manifest;
 mod namespace;
 mod repository;
@@ -15,6 +16,10 @@ pub use game_comparison::{
     GameJoinCandidate, GameJoinClassification, GameJoinComparisonError, compare_join_libraries,
 };
 pub use integrity::{ArchiveIntegrity, ArchiveIntegrityError};
+pub use join::{
+    CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinItem, CloudLibraryJoinReview,
+    GameDefinitionDifference, JoinGameAction, JoinGameDecision,
+};
 pub use manifest::{
     CLOUD_MANIFEST_SCHEMA_VERSION, CloudManifest, DeletionKind, GameManifest, LiveSnapshot,
     ManifestError, PendingTombstone, SnapshotNode, SnapshotState,

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -35,6 +35,8 @@ pub enum OwnerStoreError {
     ProfileFileNameMismatch(DeviceId),
     #[error("Local configuration changed while Cloud Library creation was in progress")]
     ActivationInputsChanged,
+    #[error("Local configuration changed while Cloud Library join was in progress")]
+    JoinInputsChanged,
 }
 
 pub(crate) struct OwnerStore {
@@ -154,6 +156,45 @@ impl OwnerStore {
         {
             return Err(OwnerStoreError::ActivationInputsChanged);
         }
+        owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        self.write(&owners)
+    }
+
+    pub(crate) fn activate_join_v2(
+        &self,
+        expected_local_library: &SharedLibrary,
+        expected_local_profile: &DeviceProfile,
+        accepted_library: &SharedLibrary,
+        accepted_profile: &DeviceProfile,
+    ) -> Result<(), OwnerStoreError> {
+        let mut owners = self.load()?;
+        let current_device_id = owners.local_state.current_device_id.clone();
+        let current_profile = owners
+            .device_profiles
+            .get(&current_device_id)
+            .ok_or_else(|| OwnershipError::MissingDeviceProfile(current_device_id.clone()))?;
+        if owners.local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1
+            || owners.shared_library != *expected_local_library
+            || serde_json::to_vec(current_profile)? != serde_json::to_vec(expected_local_profile)?
+            || accepted_profile.device.id != current_device_id
+        {
+            return Err(OwnerStoreError::JoinInputsChanged);
+        }
+
+        let accepted_ids = accepted_library
+            .games
+            .iter()
+            .map(|game| game.storage_key.as_str())
+            .collect::<std::collections::HashSet<_>>();
+        for profile in owners.device_profiles.values_mut() {
+            profile
+                .games
+                .retain(|id, _| accepted_ids.contains(id.as_str()));
+        }
+        owners.shared_library = accepted_library.clone();
+        owners
+            .device_profiles
+            .insert(current_device_id, accepted_profile.clone());
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
         self.write(&owners)
     }

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -429,6 +429,52 @@ impl ConfigurationOwners {
     }
 }
 
+impl DeviceProfile {
+    /// Retain only current-Device values that still apply to an accepted
+    /// Shared Library, and provide conservative defaults for newly seen Games.
+    pub fn for_shared_library(&self, library: &SharedLibrary) -> Self {
+        let mut profile = self.clone();
+        profile.games = library
+            .games
+            .iter()
+            .map(|game| {
+                let save_unit_ids = game
+                    .save_units
+                    .iter()
+                    .map(|unit| unit.id)
+                    .collect::<HashSet<_>>();
+                let mut settings =
+                    self.games
+                        .get(&game.storage_key)
+                        .cloned()
+                        .unwrap_or(DeviceGameProfile {
+                            visible: true,
+                            sync_mode: SyncMode::Manual,
+                            game_path: None,
+                            binding: None,
+                            auto_backup: None,
+                            save_units: HashMap::new(),
+                        });
+                settings
+                    .save_units
+                    .retain(|id, _| save_unit_ids.contains(id));
+                for id in save_unit_ids {
+                    settings
+                        .save_units
+                        .entry(id)
+                        .or_insert(DeviceSaveUnitSettings {
+                            path: None,
+                            enabled: true,
+                            delete_before_apply: false,
+                        });
+                }
+                (game.storage_key.clone(), settings)
+            })
+            .collect();
+        profile
+    }
+}
+
 impl SharedLibrary {
     /// Validate remote-portable configuration without requiring Local State or
     /// a current Device Profile.

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -94,6 +94,24 @@ pub(crate) fn activate_cloud_namespace_v2(
     Ok(())
 }
 
+pub(crate) fn activate_joined_cloud_library(
+    expected_local_library: &SharedLibrary,
+    expected_local_profile: &DeviceProfile,
+    accepted_library: &SharedLibrary,
+    accepted_profile: &DeviceProfile,
+) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    OwnerStore::runtime().activate_join_v2(
+        expected_local_library,
+        expected_local_profile,
+        accepted_library,
+        accepted_profile,
+    )?;
+    Ok(())
+}
+
 fn get_config_unlocked() -> Result<Config, ConfigError> {
     let owner_store = OwnerStore::runtime();
     if owner_store.has_authoritative_state() {

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::hooks::HookPipeline;
 
-pub use sync::{CloudLibraryServiceError, CloudLibraryStatus};
+pub use sync::{CloudLibraryJoinOutcome, CloudLibraryServiceError, CloudLibraryStatus};
 
 #[derive(Clone)]
 pub struct ServiceContext {

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -5,7 +5,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::backup::Game;
 use crate::cloud_sync::v2::{
-    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudNamespaceClassification,
+    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryJoin, CloudLibraryJoinError,
+    CloudLibraryJoinReview, CloudNamespaceClassification, JoinGameDecision,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -14,8 +15,8 @@ use crate::cloud_sync::{
     sync_game as sync_cloud_game, upload_all_from_session,
 };
 use crate::config::{
-    CloudNamespaceGeneration, Config, activate_cloud_namespace_v2, cloud_bootstrap_inputs,
-    cloud_namespace_generation, get_config,
+    CloudNamespaceGeneration, Config, activate_cloud_namespace_v2, activate_joined_cloud_library,
+    cloud_bootstrap_inputs, cloud_namespace_generation, get_config,
 };
 use crate::hooks::{HookSource, MetadataChangedCtx};
 use crate::preclude::BackendError;
@@ -52,18 +53,29 @@ pub enum CloudLibraryStatus {
     Active { game_count: usize },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CloudLibraryJoinOutcome {
+    Active { game_count: usize },
+    ReviewChanged { game_name: String },
+}
+
 #[derive(Debug, Error)]
 pub enum CloudLibraryServiceError {
     #[error("Cloud Library creation requires explicit confirmation")]
     ConfirmationRequired,
     #[error("The active V2 Cloud Library no longer matches the saved connection")]
     ActiveLibraryUnavailable,
+    #[error("This installation does not need to join a Cloud Library")]
+    JoinNotRequired,
     #[error(transparent)]
     Config(#[from] crate::preclude::ConfigError),
     #[error(transparent)]
     Backend(#[from] BackendError),
     #[error(transparent)]
     Bootstrap(#[from] CloudLibraryBootstrapError),
+    #[error(transparent)]
+    Join(#[from] CloudLibraryJoinError),
 }
 
 impl ServiceContext {
@@ -167,6 +179,56 @@ impl ServiceContext {
         activate_cloud_namespace_v2(&shared_library, &device_profile)?;
         Ok(CloudLibraryStatus::Active {
             game_count: shared_library.games.len(),
+        })
+    }
+
+    pub async fn review_cloud_library_join(
+        &self,
+    ) -> Result<CloudLibraryJoinReview, CloudLibraryServiceError> {
+        let (local_library, _, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1 {
+            return Err(CloudLibraryServiceError::JoinNotRequired);
+        }
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        Ok(CloudLibraryJoin::new(session.get_op()?, 3)
+            .review(&local_library)
+            .await?)
+    }
+
+    pub async fn join_cloud_library(
+        &self,
+        decisions: &[JoinGameDecision],
+        confirmed_replacements: bool,
+    ) -> Result<CloudLibraryJoinOutcome, CloudLibraryServiceError> {
+        let (local_library, local_profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1 {
+            return Err(CloudLibraryServiceError::JoinNotRequired);
+        }
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let joined = CloudLibraryJoin::new(session.get_op()?, 3)
+            .join(
+                &local_library,
+                &local_profile,
+                decisions,
+                confirmed_replacements,
+            )
+            .await;
+        let (accepted_library, accepted_profile) = match joined {
+            Ok(joined) => joined,
+            Err(CloudLibraryJoinError::TargetChanged(game_name))
+            | Err(CloudLibraryJoinError::LocalGameChanged(game_name)) => {
+                return Ok(CloudLibraryJoinOutcome::ReviewChanged { game_name });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        activate_joined_cloud_library(
+            &local_library,
+            &local_profile,
+            &accepted_library,
+            &accepted_profile,
+        )?;
+        Ok(CloudLibraryJoinOutcome::Active {
+            game_count: accepted_library.games.len(),
         })
     }
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -677,7 +677,42 @@
             "create_confirm": "Create and switch",
             "create_failed": "Could not create the Cloud Library",
             "create_success": "Cloud Library created",
-            "legacy_disabled": "This device now uses the new Cloud Library. Legacy synchronization controls are unavailable."
+            "legacy_disabled": "This device now uses the new Cloud Library. Legacy synchronization controls are unavailable.",
+            "join": {
+                "title": "Review Cloud Library",
+                "risk_title": "Review before joining",
+                "risk_description": "Joining switches this device to the shared game list. Games kept only on this device are not added unless you select Add to Cloud.",
+                "summary": "The cloud has {cloud} games. {review} local games need your attention.",
+                "games_label": "Games to review",
+                "classification": {
+                    "same": "Same",
+                    "local_only": "Local only",
+                    "possible_duplicate": "Possible duplicate",
+                    "game_definition_conflict": "Different definition"
+                },
+                "local": "This device",
+                "cloud": "Cloud",
+                "game_name": "Name",
+                "save_units": "Save locations",
+                "recognition": "Game recognition",
+                "item_count": "{count} items",
+                "not_in_cloud": "Not in cloud",
+                "recognition_available": "Available",
+                "recognition_unavailable": "Not available",
+                "no_difference": "The portable game definition is the same.",
+                "keep_cloud": "Keep the cloud version",
+                "add_local": "Add this game to Cloud Library",
+                "replace_cloud": "Replace the shared game definition",
+                "join_action": "Join library",
+                "replace_title": "Replace shared definitions?",
+                "replace_warning": "{count} shared game definitions will be replaced for participating devices. Device-specific paths are not uploaded.",
+                "replace_confirm": "Replace and join",
+                "review_failed": "Could not prepare the join review",
+                "join_failed": "Could not join the Cloud Library",
+                "review_changed": "{game} changed while you were reviewing. The latest version has been loaded.",
+                "join_success": "This device joined the Cloud Library",
+                "no_local_games": "There are no local games to compare."
+            }
         },
         "operations": {
             "tab": "Operations",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -677,7 +677,42 @@
             "create_confirm": "创建并切换",
             "create_failed": "无法创建云端资料库",
             "create_success": "云端资料库已创建",
-            "legacy_disabled": "此设备已切换到新的云端资料库，旧版同步操作已不可用。"
+            "legacy_disabled": "此设备已切换到新的云端资料库，旧版同步操作已不可用。",
+            "join": {
+                "title": "审阅云端资料库",
+                "risk_title": "加入前请先审阅",
+                "risk_description": "加入后，此设备会切换到共享游戏列表。仅存在于本机的游戏不会自动加入，除非你明确选择添加到云端。",
+                "summary": "云端已有 {cloud} 个游戏，另有 {review} 个本机游戏需要你确认。",
+                "games_label": "待审阅游戏",
+                "classification": {
+                    "same": "相同",
+                    "local_only": "仅本机",
+                    "possible_duplicate": "可能重复",
+                    "game_definition_conflict": "定义不同"
+                },
+                "local": "此设备",
+                "cloud": "云端",
+                "game_name": "名称",
+                "save_units": "存档位置",
+                "recognition": "游戏识别信息",
+                "item_count": "{count} 项",
+                "not_in_cloud": "云端没有",
+                "recognition_available": "有",
+                "recognition_unavailable": "无",
+                "no_difference": "可同步的游戏定义完全相同。",
+                "keep_cloud": "保留云端版本",
+                "add_local": "将此游戏加入云端资料库",
+                "replace_cloud": "替换共享游戏定义",
+                "join_action": "加入资料库",
+                "replace_title": "替换共享定义？",
+                "replace_warning": "将替换 {count} 个共享游戏定义，并影响参与同步的设备。设备专属路径不会上传。",
+                "replace_confirm": "替换并加入",
+                "review_failed": "无法准备加入审阅",
+                "join_failed": "无法加入云端资料库",
+                "review_changed": "你审阅期间 {game} 已发生变化，现已重新加载最新版本。",
+                "join_success": "此设备已加入云端资料库",
+                "no_local_games": "没有需要比较的本机游戏。"
+            }
         },
         "operations": {
             "tab": "操作",


### PR DESCRIPTION
## 概要

- 审阅现有 V2 资料库，并区分相同、仅本机、可能重复和定义冲突
- 以云端定义为默认，支持明确添加本机游戏或整游戏替换，并展示本机与云端差异
- 重新读取最新 Shared Library，阻止陈旧目标覆盖，按 Shared Library、当前 Device Profile、本地激活的顺序完成加入
- 保留当前设备设置，为云端新增游戏生成安全默认值
