### PR TITLE
feat: 迁移旧版 V1 云端资料库

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/cloud_library.rs
+++ b/apps/rgsm-gui/src-tauri/src/cloud_library.rs
@@ -1,10 +1,13 @@
 use std::sync::Arc;
 
 use rgsm_core::cloud_sync::CloudSyncTaskManager;
-use rgsm_core::cloud_sync::v2::{CloudLibraryJoinReview, JoinGameDecision};
+use rgsm_core::cloud_sync::v2::{
+    CloudLibraryCutoverReview, CloudLibraryJoinReview, JoinGameDecision,
+};
 use rgsm_core::config::get_config;
 use rgsm_core::services::{
-    CloudLibraryJoinOutcome, CloudLibraryServiceError, CloudLibraryStatus, ServiceContext,
+    CloudLibraryCutoverOutcome, CloudLibraryJoinOutcome, CloudLibraryServiceError,
+    CloudLibraryStatus, ServiceContext,
 };
 use tauri::{AppHandle, Manager};
 
@@ -46,5 +49,27 @@ pub async fn join(
     if matches!(outcome, CloudLibraryJoinOutcome::Active { .. }) {
         crate::hooks::rebuild_pipeline(app, &get_config()?);
     }
+    Ok(outcome)
+}
+
+pub async fn review_cutover(
+    app: &AppHandle,
+) -> Result<CloudLibraryCutoverReview, CloudLibraryServiceError> {
+    ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+        .review_cloud_library_cutover()
+        .await
+}
+
+pub async fn cutover(
+    app: &AppHandle,
+    confirmed: bool,
+) -> Result<CloudLibraryCutoverOutcome, CloudLibraryServiceError> {
+    app.state::<Arc<CloudSyncTaskManager>>()
+        .cancel_all_and_wait()
+        .await;
+    let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+        .cutover_cloud_library(confirmed)
+        .await?;
+    crate::hooks::rebuild_pipeline(app, &get_config()?);
     Ok(outcome)
 }

--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -2,7 +2,9 @@ use crate::{quick_actions, sound};
 use rgsm_core::backup::{
     CreatedBy, ExtraBackupItem, Game, GameDeviceBinding, GameDraft, GameSnapshots, SaveUnit,
 };
-use rgsm_core::cloud_sync::v2::{CloudLibraryJoinReview, JoinGameDecision};
+use rgsm_core::cloud_sync::v2::{
+    CloudLibraryCutoverReview, CloudLibraryJoinReview, JoinGameDecision,
+};
 use rgsm_core::cloud_sync::{
     self, BatchSyncItemStatus, BatchSyncReport, CancelCloudSyncResult, CloudBackendCheckReport,
     CloudSyncSessionConfig, CloudSyncTaskManager, ConflictResolution, ConflictResolutionOutcome,
@@ -19,7 +21,9 @@ use rgsm_core::path_pattern::{PathPlaceholder, PathPlaceholderDescriptor};
 use rgsm_core::path_resolution::ResolutionReport;
 use rgsm_core::path_resolver;
 use rgsm_core::preclude::*;
-use rgsm_core::services::{CloudLibraryJoinOutcome, CloudLibraryStatus, ServiceContext};
+use rgsm_core::services::{
+    CloudLibraryCutoverOutcome, CloudLibraryJoinOutcome, CloudLibraryStatus, ServiceContext,
+};
 use rgsm_core::steam;
 use rgsm_core::vn_scanner;
 use rgsm_core::{backup, config, system_fonts};
@@ -646,6 +650,29 @@ pub async fn join_cloud_library(
 ) -> Result<CloudLibraryJoinOutcome, String> {
     info!(target:"rgsm::ipc", "Joining an existing Cloud Library");
     crate::cloud_library::join(&app_handle, &decisions, confirmed_replacements)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn review_cloud_library_cutover(
+    app_handle: AppHandle,
+) -> Result<CloudLibraryCutoverReview, String> {
+    info!(target:"rgsm::ipc", "Reviewing legacy Cloud Library Cutover");
+    crate::cloud_library::review_cutover(&app_handle)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn cutover_cloud_library(
+    confirmed: bool,
+    app_handle: AppHandle,
+) -> Result<CloudLibraryCutoverOutcome, String> {
+    info!(target:"rgsm::ipc", "Cutting over legacy Cloud Library");
+    crate::cloud_library::cutover(&app_handle, confirmed)
         .await
         .map_err(|error| error.to_string())
 }

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -121,6 +121,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::create_cloud_library,
             ipc_handler::review_cloud_library_join,
             ipc_handler::join_cloud_library,
+            ipc_handler::review_cloud_library_cutover,
+            ipc_handler::cutover_cloud_library,
             ipc_handler::cloud_upload_all,
             ipc_handler::cloud_download_all,
             ipc_handler::cancel_cloud_sync,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -228,6 +228,22 @@ async joinCloudLibrary(decisions: JoinGameDecision[], confirmedReplacements: boo
     else return { status: "error", error: e  as any };
 }
 },
+async reviewCloudLibraryCutover() : Promise<Result<CloudLibraryCutoverReview, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("review_cloud_library_cutover") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async cutoverCloudLibrary(confirmed: boolean) : Promise<Result<CloudLibraryCutoverOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cutover_cloud_library", { confirmed }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async cloudUploadAll(session: CloudSyncSessionConfig) : Promise<Result<BatchSyncReport, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("cloud_upload_all", { session }) };
@@ -667,6 +683,8 @@ export type CloudBackendCheckItemStatus = "passed" | "warning" | "failed"
 export type CloudBackendCheckOutcome = "available" | "degraded" | "unavailable"
 export type CloudBackendCheckReport = { outcome: CloudBackendCheckOutcome; items: CloudBackendCheckItem[] }
 export type CloudBackendCheckStep = "prepare_backend" | "list_files" | "write_file" | "read_file" | "verify_content" | "delete_file"
+export type CloudLibraryCutoverOutcome = { game_count: number; snapshot_count: number; unavailable_archives: number }
+export type CloudLibraryCutoverReview = { game_count: number; snapshot_count: number; declared_bytes: number }
 export type CloudLibraryJoinItem = { local_game_id: string; local_name: string; local_fingerprint: string; cloud_names: string[]; cloud_fingerprint: string | null; classification: GameJoinClassification; difference: GameDefinitionDifference }
 export type CloudLibraryJoinOutcome = { kind: "active"; game_count: number } | { kind: "review_changed"; game_name: string }
 export type CloudLibraryJoinReview = { cloud_game_count: number; items: CloudLibraryJoinItem[] }

--- a/apps/rgsm-gui/src/components/CloudLibraryCutoverDialog.vue
+++ b/apps/rgsm-gui/src/components/CloudLibraryCutoverDialog.vue
@@ -1,0 +1,204 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { commands, type CloudLibraryCutoverReview } from '~/bindings';
+import { $t } from '~/i18n';
+import { LAYER } from '~/ui/layers';
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: boolean): void;
+  (event: 'cutover', gameCount: number): void;
+}>();
+const review = ref<CloudLibraryCutoverReview | null>(null);
+const acknowledged = ref(false);
+const loading = ref(false);
+const running = ref(false);
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value) => emit('update:modelValue', value),
+});
+function formatBytes(bytes: number) {
+  if (bytes <= 0) return $t('sync_settings.library.cutover.size_unknown');
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const index = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** index).toFixed(index === 0 ? 0 : 1)} ${units[index]}`;
+}
+async function loadReview() {
+  loading.value = true;
+  acknowledged.value = false;
+  try {
+    const result = await commands.reviewCloudLibraryCutover();
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.library.cutover.review_failed')}: ${result.error}`);
+      visible.value = false;
+      return;
+    }
+    review.value = result.data;
+  } catch (reason) {
+    notifyError(`${$t('sync_settings.library.cutover.review_failed')}: ${String(reason)}`);
+    visible.value = false;
+  } finally {
+    loading.value = false;
+  }
+}
+async function submit() {
+  if (!review.value || !acknowledged.value || running.value) return;
+  running.value = true;
+  try {
+    const result = await commands.cutoverCloudLibrary(true);
+    if (result.status === 'error') {
+      notifyError(`${$t('sync_settings.library.cutover.failed')}: ${result.error}`);
+      return;
+    }
+    const outcome = result.data;
+    if (outcome.unavailable_archives > 0) {
+      notifyWarning(
+        $t('sync_settings.library.cutover.completed_with_warnings', {
+          count: outcome.unavailable_archives,
+        })
+      );
+    } else {
+      notifySuccess($t('sync_settings.library.cutover.completed'));
+    }
+    emit('cutover', outcome.game_count);
+    visible.value = false;
+  } catch (reason) {
+    notifyError(`${$t('sync_settings.library.cutover.failed')}: ${String(reason)}`);
+  } finally {
+    running.value = false;
+  }
+}
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) void loadReview();
+  }
+);
+</script>
+<template>
+  <ElDialog
+    v-model="visible"
+    :title="$t('sync_settings.library.cutover.title')"
+    width="min(720px, 94vw)"
+    class="cutover-dialog"
+    destroy-on-close
+    :close-on-click-modal="!running"
+    :close-on-press-escape="!running"
+    :show-close="!running"
+    :z-index="LAYER.dialog"
+  >
+    <div v-loading="loading || running" class="cutover-body">
+      <template v-if="review">
+        <div class="cutover-summary">
+          <div>
+            <strong>{{ review.game_count }}</strong>
+            <span>{{ $t('sync_settings.library.cutover.games') }}</span>
+          </div>
+          <div>
+            <strong>{{ review.snapshot_count }}</strong>
+            <span>{{ $t('sync_settings.library.cutover.snapshots') }}</span>
+          </div>
+          <div>
+            <strong>{{ formatBytes(review.declared_bytes) }}</strong>
+            <span>{{ $t('sync_settings.library.cutover.declared_size') }}</span>
+          </div>
+        </div>
+
+        <ElAlert
+          type="warning"
+          :title="$t('sync_settings.library.cutover.compatibility_title')"
+          :description="$t('sync_settings.library.cutover.compatibility_description')"
+          :closable="false"
+          show-icon
+        />
+        <ElAlert
+          type="info"
+          :title="$t('sync_settings.library.cutover.archive_title')"
+          :description="$t('sync_settings.library.cutover.archive_description')"
+          :closable="false"
+          show-icon
+        />
+        <ElCheckbox v-model="acknowledged" :disabled="running" class="acknowledgement">
+          {{ $t('sync_settings.library.cutover.acknowledgement') }}
+        </ElCheckbox>
+        <p v-if="running" class="running-note">
+          {{ $t('sync_settings.library.cutover.running') }}
+        </p>
+      </template>
+    </div>
+
+    <template #footer>
+      <ElButton :disabled="running" @click="visible = false">
+        {{ $t('sync_settings.cancel') }}
+      </ElButton>
+      <ElButton
+        type="primary"
+        :loading="running"
+        :disabled="!review || !acknowledged"
+        @click="submit"
+      >
+        {{ $t('sync_settings.library.cutover.start') }}
+      </ElButton>
+    </template>
+  </ElDialog>
+</template>
+<style>
+.cutover-dialog {
+  max-height: calc(100vh - 32px);
+  margin: 16px auto;
+  display: flex;
+  flex-direction: column;
+}
+.cutover-dialog .el-dialog__body {
+  min-height: 0;
+  overflow-y: auto;
+}
+</style>
+<style scoped>
+.cutover-body {
+  min-height: 220px;
+}
+.cutover-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+.cutover-summary div {
+  min-width: 0;
+  padding: 14px;
+  border-radius: var(--el-border-radius-base);
+  background: var(--el-fill-color-light);
+}
+.cutover-summary strong,
+.cutover-summary span {
+  display: block;
+  overflow-wrap: anywhere;
+}
+.cutover-summary strong {
+  font-size: 20px;
+  color: var(--el-text-color-primary);
+}
+.cutover-summary span,
+.running-note {
+  margin-top: 4px;
+  color: var(--el-text-color-secondary);
+}
+.cutover-body .el-alert + .el-alert {
+  margin-top: 12px;
+}
+.acknowledgement {
+  height: auto;
+  margin-top: 18px;
+  white-space: normal;
+}
+
+@media (max-width: 560px) {
+  .cutover-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .cutover-dialog :deep(.el-dialog__footer) {
+    padding-right: calc(var(--el-dialog-padding-primary) + var(--el-component-size-large) + 12px);
+  }
+}
+</style>

--- a/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
+++ b/apps/rgsm-gui/src/components/CloudLibrarySetup.vue
@@ -18,6 +18,7 @@ const status = ref<CloudLibraryStatus | null>(null);
 const inspecting = ref(false);
 const creating = ref(false);
 const joining = ref(false);
+const cuttingOver = ref(false);
 
 const alertType = computed(() => {
   switch (status.value?.kind) {
@@ -148,8 +149,16 @@ watch(
       <ElButton v-if="status?.kind === 'join_required'" type="primary" @click="joining = true">
         {{ $t('sync_settings.library.join.join_action') }}
       </ElButton>
+      <ElButton
+        v-if="status?.kind === 'cutover_required'"
+        type="primary"
+        @click="cuttingOver = true"
+      >
+        {{ $t('sync_settings.library.cutover.action') }}
+      </ElButton>
     </div>
     <CloudLibraryJoinDialog v-model="joining" @joined="joined" />
+    <CloudLibraryCutoverDialog v-model="cuttingOver" @cutover="joined" />
   </section>
 </template>
 

--- a/crates/rgsm-core/src/backup/game_snapshots.rs
+++ b/crates/rgsm-core/src/backup/game_snapshots.rs
@@ -51,6 +51,15 @@ impl GameSnapshots {
     }
 
     pub fn normalize_heads(&mut self) {
+        self.normalize_heads_for_device(get_current_device_id());
+    }
+
+    /// Normalize legacy single-head metadata with an explicit fallback Device.
+    ///
+    /// Cutover uses this form so graph migration never consults process-global
+    /// Device state. The legacy Snapshot `device_id` is consumed only while
+    /// deriving a Head and is not part of the V2 Snapshot identity.
+    pub fn normalize_heads_for_device(&mut self, fallback_device_id: &DeviceId) {
         if self.device_heads.is_empty()
             && let Some(legacy_head) = self.legacy_head.take()
         {
@@ -63,7 +72,7 @@ impl GameSnapshots {
                         .find(|snapshot| snapshot.date == legacy_head)
                         .and_then(|snapshot| snapshot.device_id.clone())
                 })
-                .unwrap_or_else(|| get_current_device_id().clone());
+                .unwrap_or_else(|| fallback_device_id.clone());
             self.device_heads.insert(owner, legacy_head);
         }
 

--- a/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
@@ -1,0 +1,686 @@
+use super::{
+    ArchiveIntegrity, ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudManifest,
+    CloudNamespaceClassification, CloudNamespaceClassifier, CloudNamespaceDescriptor,
+    CloudNamespaceError, GameManifest, ManifestError, SHARED_LIBRARY_PATH, SnapshotNode,
+    SnapshotState, V2_NAMESPACE_DESCRIPTOR_PATH, cloud_archive_path, device_profile_path,
+};
+use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::cloud_sync::transfer::CloudTransfer;
+use crate::cloud_sync::utils::{
+    SyncOperationError, game_cloud_archive_path, load_remote_game_snapshots,
+};
+use crate::config::{
+    ConfigurationOwners, DeviceProfile, OwnershipError, SharedLibrary, V2_CONFIG_SCHEMA_VERSION,
+};
+use crate::device::{DeviceId, encode_device_id};
+use crate::preclude::BackendError;
+use opendal::{ErrorKind, Operator};
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+const CUTOVER_PROGRESS_SCHEMA_VERSION: u32 = 1;
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CloudLibraryCutoverReview {
+    pub game_count: usize,
+    pub snapshot_count: usize,
+    pub declared_bytes: u64,
+}
+#[derive(Debug)]
+pub struct CloudLibraryCutoverResult {
+    pub shared_library: SharedLibrary,
+    pub device_profiles: HashMap<DeviceId, DeviceProfile>,
+    pub snapshot_count: usize,
+    pub unavailable_archives: usize,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct CutoverPlan {
+    schema_version: u32,
+    shared_library: SharedLibrary,
+    device_profiles: HashMap<DeviceId, DeviceProfile>,
+    games: Vec<FrozenGame>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+struct FrozenGame {
+    game_id: String,
+    snapshots: GameSnapshots,
+    results: BTreeMap<String, CutoverArchiveResult>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum CutoverArchiveResult {
+    Verified {
+        integrity: ArchiveIntegrity,
+        local_present: bool,
+    },
+    Unavailable,
+}
+pub struct CloudLibraryCutover {
+    operator: Operator,
+    local_archive_root: PathBuf,
+    progress_path: PathBuf,
+    current_device_id: DeviceId,
+    max_attempts: usize,
+}
+impl CloudLibraryCutover {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        progress_path: PathBuf,
+        current_device_id: DeviceId,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            operator,
+            local_archive_root,
+            progress_path,
+            current_device_id,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+    pub async fn review(&self) -> Result<CloudLibraryCutoverReview, CloudLibraryCutoverError> {
+        let plan = match self.load_progress().await? {
+            Some(plan) => plan,
+            None => self.freeze_plan().await?,
+        };
+        Ok(Self::summarize(&plan))
+    }
+    pub async fn execute(&self) -> Result<CloudLibraryCutoverResult, CloudLibraryCutoverError> {
+        let mut plan = match self.load_progress().await? {
+            Some(plan) => plan,
+            None => {
+                let plan = self.freeze_plan().await?;
+                self.store_progress(&plan).await?;
+                plan
+            }
+        };
+        if self.descriptor_exists().await? {
+            if !Self::is_complete(&plan) {
+                return Err(CloudLibraryCutoverError::UnexpectedPublishedNamespace);
+            }
+            let manifest = self.build_manifest(&plan)?;
+            self.verify_published(&plan.shared_library, &manifest)
+                .await?;
+            return Ok(Self::result(plan));
+        }
+        for game_index in 0..plan.games.len() {
+            let game_id = plan.games[game_index].game_id.clone();
+            let snapshots = plan.games[game_index].snapshots.backups.clone();
+            for snapshot in snapshots {
+                if plan.games[game_index].results.contains_key(&snapshot.date) {
+                    continue;
+                }
+                let result = self.migrate_archive(&game_id, &snapshot).await?;
+                plan.games[game_index]
+                    .results
+                    .insert(snapshot.date.clone(), result);
+                self.store_progress(&plan).await?;
+            }
+        }
+        let manifest = self.build_manifest(&plan)?;
+        self.publish(&plan, &manifest).await?;
+        self.verify_published(&plan.shared_library, &manifest)
+            .await?;
+        Ok(Self::result(plan))
+    }
+    pub async fn finish(&self) -> Result<(), CloudLibraryCutoverError> {
+        remove_path_if_exists(&self.progress_path).await?;
+        remove_dir_if_exists(&self.staging_root()).await?;
+        Ok(())
+    }
+    async fn freeze_plan(&self) -> Result<CutoverPlan, CloudLibraryCutoverError> {
+        let config = match CloudNamespaceClassifier::new(self.operator.clone())
+            .classify()
+            .await?
+        {
+            CloudNamespaceClassification::V1Only { config } => *config,
+            _ => return Err(CloudLibraryCutoverError::CutoverUnavailable),
+        };
+        let owners = ConfigurationOwners::from_legacy(&config, &self.current_device_id);
+        owners.validate()?;
+        let mut games = Vec::with_capacity(config.games.len());
+        for game in &config.games {
+            let mut snapshots = load_remote_game_snapshots(&self.operator, &game.storage_key, None)
+                .await?
+                .unwrap_or_else(|| GameSnapshots::new(&game.storage_key));
+            snapshots.normalize_heads_for_device(&self.current_device_id);
+            let mut identities = std::collections::HashSet::new();
+            for snapshot in &snapshots.backups {
+                if !identities.insert(snapshot.date.clone()) {
+                    return Err(CloudLibraryCutoverError::DuplicateSnapshot(
+                        snapshot.date.clone(),
+                    ));
+                }
+            }
+            games.push(FrozenGame {
+                game_id: game.storage_key.clone(),
+                snapshots,
+                results: BTreeMap::new(),
+            });
+        }
+        Ok(CutoverPlan {
+            schema_version: CUTOVER_PROGRESS_SCHEMA_VERSION,
+            shared_library: owners.shared_library,
+            device_profiles: owners.device_profiles,
+            games,
+        })
+    }
+    fn summarize(plan: &CutoverPlan) -> CloudLibraryCutoverReview {
+        let snapshot_count = plan
+            .games
+            .iter()
+            .map(|game| game.snapshots.backups.len())
+            .sum();
+        let declared_bytes = plan
+            .games
+            .iter()
+            .flat_map(|game| &game.snapshots.backups)
+            .fold(0_u64, |total, snapshot| total.saturating_add(snapshot.size));
+        CloudLibraryCutoverReview {
+            game_count: plan.shared_library.games.len(),
+            snapshot_count,
+            declared_bytes,
+        }
+    }
+    fn result(plan: CutoverPlan) -> CloudLibraryCutoverResult {
+        let summary = Self::summarize(&plan);
+        let unavailable_archives = plan
+            .games
+            .iter()
+            .flat_map(|game| game.results.values())
+            .filter(|result| matches!(result, CutoverArchiveResult::Unavailable))
+            .count();
+        CloudLibraryCutoverResult {
+            shared_library: plan.shared_library,
+            device_profiles: plan.device_profiles,
+            snapshot_count: summary.snapshot_count,
+            unavailable_archives,
+        }
+    }
+    fn is_complete(plan: &CutoverPlan) -> bool {
+        plan.games.iter().all(|game| {
+            game.results.len() == game.snapshots.backups.len()
+                && game
+                    .snapshots
+                    .backups
+                    .iter()
+                    .all(|snapshot| game.results.contains_key(&snapshot.date))
+        })
+    }
+    async fn migrate_archive(
+        &self,
+        game_id: &str,
+        snapshot: &Snapshot,
+    ) -> Result<CutoverArchiveResult, CloudLibraryCutoverError> {
+        let staging_root = self.staging_root();
+        tokio::fs::create_dir_all(&staging_root).await?;
+        let stem = format!(
+            "{}-{}",
+            encode_device_id(game_id),
+            encode_device_id(&snapshot.date)
+        );
+        let source_staging = staging_root.join(format!("{stem}.source"));
+        let verify_staging = staging_root.join(format!("{stem}.verify"));
+        remove_path_if_exists(&source_staging).await?;
+        remove_path_if_exists(&verify_staging).await?;
+        let local_path = archive_path(
+            &self.local_archive_root.join(game_id),
+            &snapshot.date,
+            snapshot.archive_format,
+        );
+        let (source, integrity, local_present) =
+            if let Some(integrity) = accepted_legacy_archive(&local_path, snapshot) {
+                (local_path, integrity, true)
+            } else {
+                let legacy_path = game_cloud_archive_path(game_id, snapshot)?;
+                match CloudTransfer::new(&self.operator)
+                    .download_file_streaming(&legacy_path, &source_staging)
+                    .await
+                {
+                    Ok(()) => match accepted_legacy_archive(&source_staging, snapshot) {
+                        Some(integrity) => (source_staging.clone(), integrity, false),
+                        None => {
+                            remove_path_if_exists(&source_staging).await?;
+                            return Ok(CutoverArchiveResult::Unavailable);
+                        }
+                    },
+                    Err(error) if is_backend_not_found(&error) => {
+                        return Ok(CutoverArchiveResult::Unavailable);
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            };
+        let v2_path = cloud_archive_path(game_id, &snapshot.date, snapshot.archive_format)?;
+        let transfer = CloudTransfer::new(&self.operator);
+        let mut verified = false;
+        for _ in 0..self.max_attempts {
+            transfer.upload_file_streaming(&source, &v2_path).await?;
+            transfer
+                .download_file_streaming(&v2_path, &verify_staging)
+                .await?;
+            if integrity.verify_file(&verify_staging).is_ok() {
+                verified = true;
+                break;
+            }
+        }
+        remove_path_if_exists(&source_staging).await?;
+        remove_path_if_exists(&verify_staging).await?;
+        if !verified {
+            return Err(CloudLibraryCutoverError::ArchiveVerificationFailed {
+                game_id: game_id.to_string(),
+                snapshot_id: snapshot.date.clone(),
+                attempts: self.max_attempts,
+            });
+        }
+        Ok(CutoverArchiveResult::Verified {
+            integrity,
+            local_present,
+        })
+    }
+    fn build_manifest(
+        &self,
+        plan: &CutoverPlan,
+    ) -> Result<CloudManifest, CloudLibraryCutoverError> {
+        let mut manifest = CloudManifest::default();
+        for frozen in &plan.games {
+            let mut game = GameManifest::new(&frozen.game_id);
+            for snapshot in &frozen.snapshots.backups {
+                let result = frozen.results.get(&snapshot.date).ok_or_else(|| {
+                    CloudLibraryCutoverError::MissingProgressResult(snapshot.date.clone())
+                })?;
+                let mut node = match result {
+                    CutoverArchiveResult::Verified { integrity, .. } => SnapshotNode::live(
+                        &snapshot.date,
+                        snapshot.parent.clone(),
+                        integrity.clone(),
+                        snapshot.created_by.clone(),
+                    ),
+                    CutoverArchiveResult::Unavailable => SnapshotNode::unavailable(
+                        &snapshot.date,
+                        snapshot.parent.clone(),
+                        snapshot.created_by.clone(),
+                    ),
+                };
+                node.description = snapshot.describe.clone();
+                node.archive_format = snapshot.archive_format;
+                if let SnapshotState::Live(live) = &mut node.state {
+                    live.cloud_archive_verified =
+                        matches!(result, CutoverArchiveResult::Verified { .. });
+                }
+                game.upsert_live(node)?;
+                if matches!(
+                    result,
+                    CutoverArchiveResult::Verified {
+                        local_present: true,
+                        ..
+                    }
+                ) {
+                    game.report_local_archive(
+                        self.current_device_id.clone(),
+                        snapshot.date.clone(),
+                        true,
+                    );
+                }
+            }
+            for (device_id, head) in frozen.snapshots.head_entries() {
+                game.set_head(device_id.clone(), head.clone());
+            }
+            manifest.games.insert(frozen.game_id.clone(), game);
+        }
+        manifest.validate()?;
+        Ok(manifest)
+    }
+    async fn publish(
+        &self,
+        plan: &CutoverPlan,
+        manifest: &CloudManifest,
+    ) -> Result<(), CloudLibraryCutoverError> {
+        self.write_verified(
+            SHARED_LIBRARY_PATH,
+            &serde_json::to_vec_pretty(&plan.shared_library)?,
+        )
+        .await?;
+        self.write_verified(CLOUD_MANIFEST_PATH, &serde_json::to_vec_pretty(manifest)?)
+            .await?;
+        let mut profiles = plan.device_profiles.iter().collect::<Vec<_>>();
+        profiles.sort_by_key(|(device_id, _)| *device_id);
+        for (device_id, profile) in profiles {
+            self.write_verified(
+                &device_profile_path(device_id),
+                &serde_json::to_vec_pretty(profile)?,
+            )
+            .await?;
+        }
+        self.write_verified(
+            V2_NAMESPACE_DESCRIPTOR_PATH,
+            &serde_json::to_vec_pretty(&CloudNamespaceDescriptor::default())?,
+        )
+        .await
+    }
+    async fn write_verified(
+        &self,
+        path: &str,
+        bytes: &[u8],
+    ) -> Result<(), CloudLibraryCutoverError> {
+        for _ in 0..self.max_attempts {
+            self.operator.write(path, bytes.to_vec()).await?;
+            match self.operator.read(path).await {
+                Ok(stored) if stored.to_vec().as_slice() == bytes => return Ok(()),
+                Ok(_) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(CloudLibraryCutoverError::WriteVerificationFailed {
+            path: path.to_string(),
+            attempts: self.max_attempts,
+        })
+    }
+    async fn verify_published(
+        &self,
+        library: &SharedLibrary,
+        manifest: &CloudManifest,
+    ) -> Result<(), CloudLibraryCutoverError> {
+        match CloudNamespaceClassifier::new(self.operator.clone())
+            .classify()
+            .await?
+        {
+            CloudNamespaceClassification::SupportedV2 {
+                shared_library,
+                manifest: stored_manifest,
+                ..
+            } if shared_library == *library && stored_manifest == *manifest => Ok(()),
+            _ => Err(CloudLibraryCutoverError::FinalVerificationMismatch),
+        }
+    }
+    async fn descriptor_exists(&self) -> Result<bool, opendal::Error> {
+        match self.operator.read(V2_NAMESPACE_DESCRIPTOR_PATH).await {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+    async fn load_progress(&self) -> Result<Option<CutoverPlan>, CloudLibraryCutoverError> {
+        let bytes = match tokio::fs::read(&self.progress_path).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let plan: CutoverPlan = serde_json::from_slice(&bytes)?;
+        if plan.schema_version != CUTOVER_PROGRESS_SCHEMA_VERSION {
+            return Err(CloudLibraryCutoverError::UnsupportedProgressSchema(
+                plan.schema_version,
+            ));
+        }
+        plan.shared_library.validate()?;
+        for (device_id, profile) in &plan.device_profiles {
+            if profile.schema_version != V2_CONFIG_SCHEMA_VERSION {
+                return Err(OwnershipError::UnsupportedSchema {
+                    owner: format!("Device Profile {device_id}"),
+                    found: profile.schema_version,
+                }
+                .into());
+            }
+            if device_id != &profile.device.id {
+                return Err(OwnershipError::ProfileIdentityMismatch {
+                    key: device_id.clone(),
+                    embedded: profile.device.id.clone(),
+                }
+                .into());
+            }
+        }
+        Ok(Some(plan))
+    }
+    async fn store_progress(&self, plan: &CutoverPlan) -> Result<(), CloudLibraryCutoverError> {
+        if let Some(parent) = self.progress_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        CloudTransfer::new(&self.operator)
+            .write_local_bytes_atomically(&self.progress_path, &serde_json::to_vec_pretty(plan)?)
+            .await?;
+        Ok(())
+    }
+    fn staging_root(&self) -> PathBuf {
+        self.progress_path.with_extension("staging")
+    }
+}
+fn accepted_legacy_archive(path: &Path, snapshot: &Snapshot) -> Option<ArchiveIntegrity> {
+    let integrity = ArchiveIntegrity::from_file(path).ok()?;
+    if snapshot.size > 0 && snapshot.size != integrity.size {
+        return None;
+    }
+    if snapshot
+        .archive_hash
+        .as_ref()
+        .is_some_and(|expected| !expected.eq_ignore_ascii_case(&integrity.xxh3_64))
+    {
+        return None;
+    }
+    Some(integrity)
+}
+fn is_backend_not_found(error: &BackendError) -> bool {
+    matches!(error, BackendError::Cloud(source) if source.kind() == ErrorKind::NotFound)
+}
+async fn remove_path_if_exists(path: &Path) -> Result<(), std::io::Error> {
+    match tokio::fs::remove_file(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+async fn remove_dir_if_exists(path: &Path) -> Result<(), std::io::Error> {
+    match tokio::fs::remove_dir_all(path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+#[derive(Debug, Error)]
+pub enum CloudLibraryCutoverError {
+    #[error("Cloud Cutover is available only for a legacy V1 Cloud Library")]
+    CutoverUnavailable,
+    #[error("Cloud Cutover progress uses unsupported schema {0}")]
+    UnsupportedProgressSchema(u32),
+    #[error("Legacy Catalog contains duplicate Snapshot identity: {0}")]
+    DuplicateSnapshot(String),
+    #[error("Cloud Cutover progress is missing Snapshot result: {0}")]
+    MissingProgressResult(String),
+    #[error("A namespace descriptor exists before the frozen Cutover is complete")]
+    UnexpectedPublishedNamespace,
+    #[error("V2 Archive verification failed for {game_id}/{snapshot_id} after {attempts} attempts")]
+    ArchiveVerificationFailed {
+        game_id: String,
+        snapshot_id: String,
+        attempts: usize,
+    },
+    #[error("Cloud object {path} did not match after {attempts} write attempts")]
+    WriteVerificationFailed { path: String, attempts: usize },
+    #[error("Published V2 Cloud Library does not match the frozen Cutover")]
+    FinalVerificationMismatch,
+    #[error(transparent)]
+    Namespace(#[from] CloudNamespaceError),
+    #[error(transparent)]
+    Sync(#[from] SyncOperationError),
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    #[error(transparent)]
+    Integrity(#[from] ArchiveIntegrityError),
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error("Cloud Cutover serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Cloud Cutover I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cloud Cutover transport error: {0}")]
+    Transport(#[from] opendal::Error),
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy, Game};
+    use crate::cloud_sync::V1_CONFIG_PATH;
+    use crate::cloud_sync::utils::game_cloud_metadata_path;
+    use crate::config::Config;
+    use opendal::services;
+    use std::collections::HashMap;
+    fn operator() -> Operator {
+        Operator::new(services::Memory::default()).unwrap().finish()
+    }
+    fn game() -> Game {
+        Game {
+            name: "Test Game".into(),
+            storage_key: "test-game".into(),
+            save_paths: Vec::new(),
+            game_paths: HashMap::new(),
+            next_save_unit_id: 0,
+            cloud_sync_enabled: true,
+            auto_backup: None,
+            ludusavi_meta: None,
+            device_bindings: HashMap::new(),
+        }
+    }
+    fn snapshot(id: &str, parent: Option<&str>, payload: &[u8]) -> Snapshot {
+        Snapshot {
+            date: id.into(),
+            describe: format!("Snapshot {id}"),
+            path: format!("ignored/{id}.zip"),
+            archive_format: ArchiveFormat::Zip,
+            size: payload.len() as u64,
+            parent: parent.map(str::to_string),
+            archive_hash: Some(format!("{:016x}", xxhash_rust::xxh3::xxh3_64(payload))),
+            device_id: Some("creator-device".into()),
+            created_by: CreatedBy::Manual,
+        }
+    }
+    async fn seed(
+        op: &Operator,
+        snapshots: GameSnapshots,
+        archives: &[(&Snapshot, &[u8])],
+    ) -> Vec<u8> {
+        let config = Config {
+            games: vec![game()],
+            ..Config::default()
+        };
+        let config_bytes = serde_json::to_vec_pretty(&config).unwrap();
+        op.write(V1_CONFIG_PATH, config_bytes.clone())
+            .await
+            .unwrap();
+        op.write(
+            &game_cloud_metadata_path("test-game").unwrap(),
+            serde_json::to_vec_pretty(&snapshots).unwrap(),
+        )
+        .await
+        .unwrap();
+        for (snapshot, bytes) in archives {
+            op.write(
+                &game_cloud_archive_path("test-game", snapshot).unwrap(),
+                bytes.to_vec(),
+            )
+            .await
+            .unwrap();
+        }
+        config_bytes
+    }
+    fn cutover(op: Operator, root: &Path) -> CloudLibraryCutover {
+        CloudLibraryCutover::new(
+            op,
+            root.join("local"),
+            root.join("progress.json"),
+            "current-device".into(),
+            2,
+        )
+    }
+    #[tokio::test]
+    async fn migrates_local_and_marks_missing_without_touching_v1() {
+        let op = operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let local_bytes = b"local archive";
+        let local = snapshot("local", None, local_bytes);
+        let missing = snapshot("missing", Some("local"), b"missing bytes");
+        let mut catalog = GameSnapshots::new("test-game");
+        catalog.backups = vec![local.clone(), missing];
+        catalog.device_heads.insert("deck".into(), "missing".into());
+        let v1_config = seed(&op, catalog, &[]).await;
+        let local_path = archive_path(
+            &root.path().join("local/test-game"),
+            &local.date,
+            local.archive_format,
+        );
+        std::fs::create_dir_all(local_path.parent().unwrap()).unwrap();
+        std::fs::write(&local_path, local_bytes).unwrap();
+        let runner = cutover(op.clone(), root.path());
+        let result = runner.execute().await.unwrap();
+        assert_eq!(result.snapshot_count, 2);
+        assert_eq!(result.unavailable_archives, 1);
+        assert_eq!(op.read(V1_CONFIG_PATH).await.unwrap().to_vec(), v1_config);
+        let manifest: CloudManifest =
+            serde_json::from_slice(&op.read(CLOUD_MANIFEST_PATH).await.unwrap().to_vec()).unwrap();
+        let game = &manifest.games["test-game"];
+        assert!(matches!(
+            &game.snapshots["local"].state,
+            SnapshotState::Live(live)
+                if live.cloud_archive_verified && live.integrity.is_some()
+        ));
+        assert!(matches!(
+            &game.snapshots["missing"].state,
+            SnapshotState::Live(live)
+                if !live.cloud_archive_verified && live.integrity.is_none()
+        ));
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(!json.contains("creator-device"));
+        assert_eq!(game.device_heads["deck"], "missing");
+    }
+    #[tokio::test]
+    async fn cloud_only_archive_uses_bounded_staging_and_cleans_it() {
+        let op = operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let bytes = b"cloud archive";
+        let cloud = snapshot("cloud", None, bytes);
+        let mut catalog = GameSnapshots::new("test-game");
+        catalog.backups.push(cloud.clone());
+        seed(&op, catalog, &[(&cloud, bytes)]).await;
+        let runner = cutover(op.clone(), root.path());
+        let result = runner.execute().await.unwrap();
+        assert_eq!(result.unavailable_archives, 0);
+        assert_eq!(std::fs::read_dir(runner.staging_root()).unwrap().count(), 0);
+        let v2_path = cloud_archive_path("test-game", "cloud", ArchiveFormat::Zip).unwrap();
+        assert_eq!(op.read(&v2_path).await.unwrap().to_vec(), bytes);
+    }
+    #[tokio::test]
+    async fn resume_uses_frozen_terminal_results_after_v1_changes() {
+        let op = operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let bytes = b"already migrated";
+        let snapshot = snapshot("done", None, bytes);
+        let mut catalog = GameSnapshots::new("test-game");
+        catalog.backups.push(snapshot.clone());
+        seed(&op, catalog, &[(&snapshot, bytes)]).await;
+        let runner = cutover(op.clone(), root.path());
+        let mut plan = runner.freeze_plan().await.unwrap();
+        let integrity = ArchiveIntegrity {
+            size: bytes.len() as u64,
+            xxh3_64: snapshot.archive_hash.clone().unwrap(),
+        };
+        plan.games[0].results.insert(
+            snapshot.date.clone(),
+            CutoverArchiveResult::Verified {
+                integrity,
+                local_present: false,
+            },
+        );
+        runner.store_progress(&plan).await.unwrap();
+        let v2_path = cloud_archive_path("test-game", "done", ArchiveFormat::Zip).unwrap();
+        op.write(&v2_path, bytes.to_vec()).await.unwrap();
+        op.delete(V1_CONFIG_PATH).await.unwrap();
+        op.delete(&game_cloud_archive_path("test-game", &snapshot).unwrap())
+            .await
+            .unwrap();
+        let result = runner.execute().await.unwrap();
+        assert_eq!(result.snapshot_count, 1);
+        assert_eq!(op.read(&v2_path).await.unwrap().to_vec(), bytes);
+        assert!(op.read(V2_NAMESPACE_DESCRIPTOR_PATH).await.is_ok());
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::ArchiveIntegrity;
-use crate::backup::CreatedBy;
+use crate::backup::{ArchiveFormat, CreatedBy};
 use crate::device::DeviceId;
 
 pub const CLOUD_MANIFEST_SCHEMA_VERSION: u32 = 2;
@@ -272,15 +272,19 @@ impl GameManifest {
                     parent: parent.clone(),
                 });
             }
-            if let SnapshotState::Live(live) = &node.state
-                && (live.integrity.xxh3_64.len() != 16
-                    || !live
-                        .integrity
-                        .xxh3_64
-                        .bytes()
-                        .all(|byte| byte.is_ascii_hexdigit()))
-            {
-                return Err(ManifestError::InvalidIntegrity(snapshot_id.clone()));
+            if let SnapshotState::Live(live) = &node.state {
+                if live.cloud_archive_verified && live.integrity.is_none() {
+                    return Err(ManifestError::InvalidIntegrity(snapshot_id.clone()));
+                }
+                if let Some(integrity) = &live.integrity
+                    && (integrity.xxh3_64.len() != 16
+                        || !integrity
+                            .xxh3_64
+                            .bytes()
+                            .all(|byte| byte.is_ascii_hexdigit()))
+                {
+                    return Err(ManifestError::InvalidIntegrity(snapshot_id.clone()));
+                }
             }
         }
         for snapshot_id in self.snapshots.keys() {
@@ -309,6 +313,10 @@ impl GameManifest {
 pub struct SnapshotNode {
     pub snapshot_id: String,
     pub parent: Option<String>,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub archive_format: ArchiveFormat,
     pub state: SnapshotState,
 }
 
@@ -322,8 +330,29 @@ impl SnapshotNode {
         Self {
             snapshot_id: snapshot_id.into(),
             parent,
+            description: String::new(),
+            archive_format: ArchiveFormat::default(),
             state: SnapshotState::Live(LiveSnapshot {
-                integrity,
+                integrity: Some(integrity),
+                cloud_archive_verified: false,
+                created_by,
+                retention_protected: false,
+            }),
+        }
+    }
+
+    pub fn unavailable(
+        snapshot_id: impl Into<String>,
+        parent: Option<String>,
+        created_by: CreatedBy,
+    ) -> Self {
+        Self {
+            snapshot_id: snapshot_id.into(),
+            parent,
+            description: String::new(),
+            archive_format: ArchiveFormat::default(),
+            state: SnapshotState::Live(LiveSnapshot {
+                integrity: None,
                 cloud_archive_verified: false,
                 created_by,
                 retention_protected: false,
@@ -348,7 +377,8 @@ impl SnapshotState {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiveSnapshot {
-    pub integrity: ArchiveIntegrity,
+    #[serde(default)]
+    pub integrity: Option<ArchiveIntegrity>,
     pub cloud_archive_verified: bool,
     pub created_by: CreatedBy,
     pub retention_protected: bool,

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,4 +1,5 @@
 mod bootstrap;
+mod cutover;
 mod deletion;
 mod game_comparison;
 mod integrity;
@@ -8,6 +9,10 @@ mod namespace;
 mod repository;
 
 pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
+pub use cutover::{
+    CloudLibraryCutover, CloudLibraryCutoverError, CloudLibraryCutoverResult,
+    CloudLibraryCutoverReview,
+};
 pub use deletion::{
     ArchiveDeletionBackend, ArchiveDeletionError, GlobalSnapshotDeletion,
     GlobalSnapshotDeletionError, OpenDalArchiveDeletionBackend, SnapshotDeletionRequest,
@@ -29,7 +34,7 @@ pub use namespace::{
     CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError, NamespaceTransport,
     OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_DEVICE_PROFILES_PREFIX,
     V2_NAMESPACE_DESCRIPTOR_PATH, V2_NAMESPACE_PREFIX, V2_NAMESPACE_SCHEMA_VERSION,
-    device_profile_path,
+    cloud_archive_path, device_profile_path,
 };
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -12,6 +12,7 @@ use super::super::V1_SAVE_DATA_PREFIX;
 use super::{CloudManifest, ManifestError};
 use crate::config::{Config, OwnershipError, SharedLibrary};
 use crate::device::encode_device_id;
+use crate::{backup::ArchiveFormat, cloud_sync::transfer::path_to_remote_key};
 
 pub const V2_NAMESPACE_SCHEMA_VERSION: u32 = 2;
 pub const V2_NAMESPACE_PREFIX: &str = "v2/";
@@ -26,6 +27,18 @@ pub fn device_profile_path(device_id: &str) -> String {
     format!(
         "{V2_DEVICE_PROFILES_PREFIX}{}.json",
         encode_device_id(device_id)
+    )
+}
+
+pub fn cloud_archive_path(
+    game_id: &str,
+    snapshot_id: &str,
+    format: ArchiveFormat,
+) -> Result<String, crate::preclude::BackendError> {
+    path_to_remote_key(
+        &std::path::PathBuf::from(CLOUD_ARCHIVES_PREFIX)
+            .join(game_id)
+            .join(format!("{snapshot_id}.{}", format.extension())),
     )
 }
 

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -37,6 +37,8 @@ pub enum OwnerStoreError {
     ActivationInputsChanged,
     #[error("Local configuration changed while Cloud Library join was in progress")]
     JoinInputsChanged,
+    #[error("Local configuration changed while Cloud Cutover was in progress")]
+    CutoverInputsChanged,
 }
 
 pub(crate) struct OwnerStore {
@@ -195,6 +197,33 @@ impl OwnerStore {
         owners
             .device_profiles
             .insert(current_device_id, accepted_profile.clone());
+        owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        self.write(&owners)
+    }
+
+    pub(crate) fn activate_cutover_v2(
+        &self,
+        expected_local_library: &SharedLibrary,
+        expected_local_profile: &DeviceProfile,
+        accepted_library: &SharedLibrary,
+        accepted_profiles: &HashMap<DeviceId, DeviceProfile>,
+    ) -> Result<(), OwnerStoreError> {
+        let mut owners = self.load()?;
+        let current_device_id = owners.local_state.current_device_id.clone();
+        let current_profile = owners
+            .device_profiles
+            .get(&current_device_id)
+            .ok_or_else(|| OwnershipError::MissingDeviceProfile(current_device_id.clone()))?;
+        if owners.local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1
+            || owners.shared_library != *expected_local_library
+            || serde_json::to_vec(current_profile)? != serde_json::to_vec(expected_local_profile)?
+            || !accepted_profiles.contains_key(&current_device_id)
+        {
+            return Err(OwnerStoreError::CutoverInputsChanged);
+        }
+
+        owners.shared_library = accepted_library.clone();
+        owners.device_profiles = accepted_profiles.clone();
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
         self.write(&owners)
     }
@@ -429,6 +458,55 @@ mod tests {
         assert_eq!(
             store.load().unwrap().local_state.cloud_namespace_generation,
             CloudNamespaceGeneration::V2
+        );
+    }
+
+    #[test]
+    fn cutover_activation_compare_checks_inputs_and_preserves_local_state() {
+        let (_root, store) = store();
+        let input = config(get_current_device_id(), "before");
+        store.initialize_from_legacy(&input).unwrap();
+        let before = store.load().unwrap();
+        let expected_profile = before.device_profiles[get_current_device_id()].clone();
+        let mut stale_profile = expected_profile.clone();
+        stale_profile.device.name = "stale".into();
+
+        assert!(matches!(
+            store.activate_cutover_v2(
+                &before.shared_library,
+                &stale_profile,
+                &before.shared_library,
+                &before.device_profiles,
+            ),
+            Err(OwnerStoreError::CutoverInputsChanged)
+        ));
+
+        let mut accepted_profiles = before.device_profiles.clone();
+        accepted_profiles
+            .get_mut(get_current_device_id())
+            .unwrap()
+            .device
+            .name = "Migrated Device".into();
+        store
+            .activate_cutover_v2(
+                &before.shared_library,
+                &expected_profile,
+                &before.shared_library,
+                &accepted_profiles,
+            )
+            .unwrap();
+        let active = store.load().unwrap();
+        assert_eq!(
+            active.local_state.interface.locale,
+            before.local_state.interface.locale
+        );
+        assert_eq!(
+            active.local_state.cloud_namespace_generation,
+            CloudNamespaceGeneration::V2
+        );
+        assert_eq!(
+            active.device_profiles[get_current_device_id()].device.name,
+            "Migrated Device"
         );
     }
 

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -112,6 +112,24 @@ pub(crate) fn activate_joined_cloud_library(
     Ok(())
 }
 
+pub(crate) fn activate_cutover_cloud_library(
+    expected_local_library: &SharedLibrary,
+    expected_local_profile: &DeviceProfile,
+    accepted_library: &SharedLibrary,
+    accepted_profiles: &std::collections::HashMap<crate::device::DeviceId, DeviceProfile>,
+) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    OwnerStore::runtime().activate_cutover_v2(
+        expected_local_library,
+        expected_local_profile,
+        accepted_library,
+        accepted_profiles,
+    )?;
+    Ok(())
+}
+
 fn get_config_unlocked() -> Result<Config, ConfigError> {
     let owner_store = OwnerStore::runtime();
     if owner_store.has_authoritative_state() {

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -8,7 +8,10 @@ use std::sync::Arc;
 
 use crate::hooks::HookPipeline;
 
-pub use sync::{CloudLibraryJoinOutcome, CloudLibraryServiceError, CloudLibraryStatus};
+pub use sync::{
+    CloudLibraryCutoverOutcome, CloudLibraryJoinOutcome, CloudLibraryServiceError,
+    CloudLibraryStatus,
+};
 
 #[derive(Clone)]
 pub struct ServiceContext {

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -5,7 +5,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::backup::Game;
 use crate::cloud_sync::v2::{
-    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryJoin, CloudLibraryJoinError,
+    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryCutover,
+    CloudLibraryCutoverError, CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError,
     CloudLibraryJoinReview, CloudNamespaceClassification, JoinGameDecision,
 };
 use crate::cloud_sync::{
@@ -15,8 +16,9 @@ use crate::cloud_sync::{
     sync_game as sync_cloud_game, upload_all_from_session,
 };
 use crate::config::{
-    CloudNamespaceGeneration, Config, activate_cloud_namespace_v2, activate_joined_cloud_library,
-    cloud_bootstrap_inputs, cloud_namespace_generation, get_config,
+    CloudNamespaceGeneration, Config, activate_cloud_namespace_v2, activate_cutover_cloud_library,
+    activate_joined_cloud_library, cloud_bootstrap_inputs, cloud_namespace_generation, get_config,
+    resolve_backup_path,
 };
 use crate::hooks::{HookSource, MetadataChangedCtx};
 use crate::preclude::BackendError;
@@ -60,6 +62,13 @@ pub enum CloudLibraryJoinOutcome {
     ReviewChanged { game_name: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CloudLibraryCutoverOutcome {
+    pub game_count: usize,
+    pub snapshot_count: usize,
+    pub unavailable_archives: usize,
+}
+
 #[derive(Debug, Error)]
 pub enum CloudLibraryServiceError {
     #[error("Cloud Library creation requires explicit confirmation")]
@@ -68,6 +77,8 @@ pub enum CloudLibraryServiceError {
     ActiveLibraryUnavailable,
     #[error("This installation does not need to join a Cloud Library")]
     JoinNotRequired,
+    #[error("This installation does not need Cloud Cutover")]
+    CutoverNotRequired,
     #[error(transparent)]
     Config(#[from] crate::preclude::ConfigError),
     #[error(transparent)]
@@ -76,6 +87,10 @@ pub enum CloudLibraryServiceError {
     Bootstrap(#[from] CloudLibraryBootstrapError),
     #[error(transparent)]
     Join(#[from] CloudLibraryJoinError),
+    #[error(transparent)]
+    Cutover(#[from] CloudLibraryCutoverError),
+    #[error("Cloud Cutover progress identity could not be created: {0}")]
+    CutoverProgressIdentity(#[from] serde_json::Error),
 }
 
 impl ServiceContext {
@@ -230,6 +245,73 @@ impl ServiceContext {
         Ok(CloudLibraryJoinOutcome::Active {
             game_count: accepted_library.games.len(),
         })
+    }
+
+    pub async fn review_cloud_library_cutover(
+        &self,
+    ) -> Result<CloudLibraryCutoverReview, CloudLibraryServiceError> {
+        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1 {
+            return Err(CloudLibraryServiceError::CutoverNotRequired);
+        }
+        self.cutover(&profile, &local_state)?
+            .review()
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn cutover_cloud_library(
+        &self,
+        confirmed: bool,
+    ) -> Result<CloudLibraryCutoverOutcome, CloudLibraryServiceError> {
+        if !confirmed {
+            return Err(CloudLibraryServiceError::ConfirmationRequired);
+        }
+        let (local_library, local_profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::LegacyV1 {
+            return Err(CloudLibraryServiceError::CutoverNotRequired);
+        }
+        let cutover = self.cutover(&local_profile, &local_state)?;
+        let result = cutover.execute().await?;
+        activate_cutover_cloud_library(
+            &local_library,
+            &local_profile,
+            &result.shared_library,
+            &result.device_profiles,
+        )?;
+        if let Err(error) = cutover.finish().await {
+            log::warn!(
+                target: "rgsm::cloud::cutover",
+                "V2 activation succeeded but local Cutover cleanup failed: {error}"
+            );
+        }
+        Ok(CloudLibraryCutoverOutcome {
+            game_count: result.shared_library.games.len(),
+            snapshot_count: result.snapshot_count,
+            unavailable_archives: result.unavailable_archives,
+        })
+    }
+
+    fn cutover(
+        &self,
+        profile: &crate::config::DeviceProfile,
+        local_state: &crate::config::LocalState,
+    ) -> Result<CloudLibraryCutover, CloudLibraryServiceError> {
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let identity =
+            xxhash_rust::xxh3::xxh3_64(&serde_json::to_vec(&local_state.cloud_settings)?);
+        let progress_path = crate::app_dirs::get_app_data_dir().join(format!(
+            "GameSaveManager.cloud-cutover.{identity:016x}.json"
+        ));
+        let archive_root =
+            resolve_backup_path(profile.local_archive_root.as_deref().unwrap_or("save_data"));
+        Ok(CloudLibraryCutover::new(
+            session.get_op()?,
+            archive_root,
+            progress_path,
+            local_state.current_device_id.clone(),
+            3,
+        ))
     }
 }
 

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -712,6 +712,25 @@
                 "review_changed": "{game} changed while you were reviewing. The latest version has been loaded.",
                 "join_success": "This device joined the Cloud Library",
                 "no_local_games": "There are no local games to compare."
+            },
+            "cutover": {
+                "action": "Migrate legacy library",
+                "title": "Migrate Legacy Cloud Library",
+                "games": "Games",
+                "snapshots": "Snapshots",
+                "declared_size": "Estimated archive size",
+                "size_unknown": "Unknown",
+                "compatibility_title": "Upgrade every participating device",
+                "compatibility_description": "After migration, this device uses the new Cloud Library. Older or downgraded versions keep seeing the unchanged legacy data and cannot see later V2 progress.",
+                "archive_title": "Existing archive damage is preserved safely",
+                "archive_description": "Migration verifies every available archive. A Snapshot whose archive is missing or corrupt remains listed but cannot be downloaded or restored. You can resume the same migration after an interruption.",
+                "acknowledgement": "I understand that participating devices must use a compatible version and downgrading will not show new progress.",
+                "start": "Migrate and switch",
+                "running": "Keep the app open. Archives are verified individually, and an interruption can resume without restarting completed items.",
+                "review_failed": "Could not prepare the migration review",
+                "failed": "Could not migrate the legacy Cloud Library",
+                "completed": "Legacy Cloud Library migrated",
+                "completed_with_warnings": "Migration completed, but {count} archives were already missing or corrupt."
             }
         },
         "operations": {

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -712,6 +712,25 @@
                 "review_changed": "你审阅期间 {game} 已发生变化，现已重新加载最新版本。",
                 "join_success": "此设备已加入云端资料库",
                 "no_local_games": "没有需要比较的本机游戏。"
+            },
+            "cutover": {
+                "action": "迁移旧版资料库",
+                "title": "迁移旧版云端资料库",
+                "games": "游戏",
+                "snapshots": "快照",
+                "declared_size": "预计归档大小",
+                "size_unknown": "未知",
+                "compatibility_title": "所有参与设备都需要升级",
+                "compatibility_description": "迁移后，此设备将使用新的云端资料库。旧版或降级后的程序仍只能看到保持不变的旧版数据，无法看到之后的 V2 进度。",
+                "archive_title": "已有的归档损坏会被安全保留",
+                "archive_description": "迁移会逐一验证可用归档。若某个快照的归档已缺失或损坏，该快照仍会保留在列表中，但无法下载或恢复。迁移中断后可以继续同一进度。",
+                "acknowledgement": "我明白参与同步的设备必须使用兼容版本，降级后也无法看到新的进度。",
+                "start": "迁移并切换",
+                "running": "请保持应用运行。归档会逐一验证；即使中断，之后也会跳过已完成的项目并继续。",
+                "review_failed": "无法准备迁移审阅",
+                "failed": "无法迁移旧版云端资料库",
+                "completed": "旧版云端资料库已迁移",
+                "completed_with_warnings": "迁移已完成，但有 {count} 个归档原本就已缺失或损坏。"
             }
         },
         "operations": {


### PR DESCRIPTION
## 概要

- 冻结一次旧版 V1 快照目录，并将共享游戏定义、设备配置和快照关系迁移到隔离的 V2 命名空间
- 优先使用已验证的本地归档，否则通过有界暂存迁移云端归档；缺失或损坏的历史归档保留为明确不可用
- 按归档验证、Shared Library、Cloud Manifest、Device Profiles、namespace descriptor 的顺序发布，支持中断后继续
- 提供迁移影响审阅、强制兼容性确认和迁移结果提示