### PR TITLE
feat(cloud-sync): automate V2 snapshot sync

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
@@ -14,6 +14,7 @@ pub use rgsm_core::hooks::*;
 
 use std::sync::{Arc, RwLock};
 
+use log::warn;
 use tauri::{AppHandle, Manager};
 
 use rgsm_core::cloud_sync::{Backend, CloudSyncTaskManager};
@@ -79,16 +80,30 @@ pub fn build_builtin_pipeline(
     hooks.push(Box::new(quick_action_sync_hook::QuickActionSyncHook::new(
         quick_action_sync,
     )));
-    if !matches!(config.settings.cloud_settings.backend, Backend::Disabled)
-        && matches!(
-            cloud_namespace_generation(),
-            Ok(CloudNamespaceGeneration::LegacyV1)
-        )
-    {
-        let sync_queue: Arc<dyn SyncJobQueue> = task_manager;
-        hooks.push(Box::new(
-            rgsm_core::hooks::cloud_sync_hook::CloudSyncEnqueueHook::new(sync_queue),
-        ));
+    if !matches!(config.settings.cloud_settings.backend, Backend::Disabled) {
+        match cloud_namespace_generation() {
+            Ok(CloudNamespaceGeneration::LegacyV1) => {
+                let sync_queue: Arc<dyn SyncJobQueue> = task_manager;
+                hooks.push(Box::new(
+                    rgsm_core::hooks::cloud_sync_hook::CloudSyncEnqueueHook::new(sync_queue),
+                ));
+            }
+            Ok(CloudNamespaceGeneration::V2) => {
+                let state = app.state::<crate::snapshot_sync::SnapshotSyncRuntimeState>();
+                match rgsm_core::services::build_v2_snapshot_sync_hook(state.operation_lock()) {
+                    Ok(Some(hook)) => hooks.push(Box::new(hook)),
+                    Ok(None) => {}
+                    Err(error) => warn!(
+                        target: "rgsm::hooks::v2_snapshot_sync",
+                        "Failed to build V2 Snapshot Sync hook: {error}"
+                    ),
+                }
+            }
+            Err(error) => warn!(
+                target: "rgsm::hooks::v2_snapshot_sync",
+                "Failed to determine Cloud Library generation: {error}"
+            ),
+        }
     }
     hooks.push(Box::new(notification_hook::NotificationHook::new(
         app.clone(),

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod hooks;
 mod ipc_handler;
 mod process_util;
 mod quick_actions;
+mod snapshot_sync;
 mod sound;
 
 /// Tauri adapter for SyncEventEmitter — bridges core events to Tauri's event system.
@@ -220,6 +221,8 @@ pub fn run() -> anyhow::Result<()> {
                 cloud_sync_worker.run().await;
             });
             let config = get_config().expect("Failed to load config while building hooks");
+            let snapshot_sync_runtime = snapshot_sync::SnapshotSyncRuntimeState::default();
+            app.manage(snapshot_sync_runtime.clone());
             let pipeline =
                 hooks::build_builtin_pipeline(app.handle(), cloud_sync_manager.clone(), &config);
             app.manage(hooks::HookPipelineState::new(pipeline));
@@ -240,6 +243,7 @@ pub fn run() -> anyhow::Result<()> {
                         .await;
                 });
             }
+            snapshot_sync::setup(snapshot_sync_runtime);
 
             sound::setup(app).expect("Cannot setup sound manager");
             // 处理快捷备份，包括托盘、定时、快捷键

--- a/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
+++ b/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
@@ -1,0 +1,89 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use log::{info, warn};
+use tokio::sync::Mutex;
+use tokio::time::{Instant, MissedTickBehavior};
+use tokio_util::sync::CancellationToken;
+
+const CONTROL_POLL_INTERVAL: Duration = Duration::from_secs(15);
+
+#[derive(Clone, Default)]
+pub struct SnapshotSyncRuntimeState {
+    operation_lock: Arc<Mutex<()>>,
+}
+
+impl SnapshotSyncRuntimeState {
+    pub fn operation_lock(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.operation_lock)
+    }
+}
+
+pub fn setup(state: SnapshotSyncRuntimeState) {
+    tauri::async_runtime::spawn(run(state));
+}
+
+async fn run(state: SnapshotSyncRuntimeState) {
+    let cancellation = CancellationToken::new();
+    {
+        let _guard = state.operation_lock.lock().await;
+        match rgsm_core::services::resume_v2_snapshot_sync(&cancellation).await {
+            Ok(downloaded) if downloaded > 0 => info!(
+                target: "rgsm::cloud::v2_snapshot_sync",
+                "Resumed {downloaded} pending Snapshot downloads at startup"
+            ),
+            Ok(_) => {}
+            Err(error) => warn!(
+                target: "rgsm::cloud::v2_snapshot_sync",
+                "V2 Snapshot download recovery failed: {error}"
+            ),
+        }
+        run_reconciliation(&cancellation).await;
+    }
+
+    let mut last_run = Instant::now();
+    let mut control_tick = tokio::time::interval(CONTROL_POLL_INTERVAL);
+    control_tick.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    control_tick.tick().await;
+    loop {
+        control_tick.tick().await;
+        let poll_minutes = match rgsm_core::services::v2_snapshot_sync_poll_minutes() {
+            Ok(Some(minutes)) => minutes,
+            Ok(None) => {
+                last_run = Instant::now();
+                continue;
+            }
+            Err(error) => {
+                warn!(
+                    target: "rgsm::cloud::v2_snapshot_sync",
+                    "Failed to read V2 Snapshot Sync polling policy: {error}"
+                );
+                continue;
+            }
+        };
+        let poll_interval = Duration::from_secs(poll_minutes.saturating_mul(60));
+        if last_run.elapsed() < poll_interval {
+            continue;
+        }
+        let _guard = state.operation_lock.lock().await;
+        run_reconciliation(&cancellation).await;
+        last_run = Instant::now();
+    }
+}
+
+async fn run_reconciliation(cancellation: &CancellationToken) {
+    match rgsm_core::services::run_v2_snapshot_sync_once(cancellation).await {
+        Ok(outcome) if outcome != Default::default() => info!(
+            target: "rgsm::cloud::v2_snapshot_sync",
+            "V2 Snapshot Sync completed: {} published, {} uploaded, {} downloaded",
+            outcome.published,
+            outcome.uploaded,
+            outcome.downloaded
+        ),
+        Ok(_) => {}
+        Err(error) => warn!(
+            target: "rgsm::cloud::v2_snapshot_sync",
+            "V2 Snapshot Sync reconciliation failed: {error}"
+        ),
+    }
+}

--- a/apps/rgsm-gui/src/pages/SyncSettings.vue
+++ b/apps/rgsm-gui/src/pages/SyncSettings.vue
@@ -131,6 +131,12 @@ const savedBackendEnabled = computed(
   () => config.value?.settings.cloud_settings?.backend?.type !== 'Disabled'
 );
 const v2LibraryActive = computed(() => cloudLibraryStatus.value?.kind === 'active');
+const snapshotSyncInterval = computed({
+  get: () => cloud_settings.value.auto_sync_interval || 5,
+  set: (minutes: number) => {
+    cloud_settings.value.auto_sync_interval = minutes;
+  },
+});
 const savedConnectionKey = computed(() =>
   JSON.stringify(config.value?.settings.cloud_settings ?? null)
 );
@@ -842,6 +848,15 @@ onMounted(async () => {
                 :max="32"
               />
               <span class="field-hint">{{ $t('sync_settings.max_concurrency_hint') }}</span>
+            </ElFormItem>
+            <ElFormItem v-if="v2LibraryActive" :label="$t('sync_settings.auto_sync_interval')">
+              <ElInputNumber
+                v-model="snapshotSyncInterval"
+                :step="1"
+                :step-strictly="true"
+                :min="1"
+                :max="1440"
+              />
             </ElFormItem>
 
             <ElFormItem>

--- a/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
@@ -426,6 +426,8 @@ pub enum ManifestError {
     ExpectedLive(String),
     #[error("Snapshot has invalid XXH3-64 integrity: {0}")]
     InvalidIntegrity(String),
+    #[error("Snapshot identity already describes different content: {0}")]
+    SnapshotContentConflict(String),
     #[error("Tombstoned Snapshot cannot be resurrected: {0}")]
     TombstoneResurrection(String),
     #[error("Snapshot deletion conflicts with existing Tombstone state: {0}")]

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
@@ -64,6 +64,8 @@ struct MaterializationPlan {
     manifest_revision: u64,
     scope: Option<String>,
     max_catalog_revision: Option<u64>,
+    #[serde(default)]
+    min_catalog_revision_exclusive: Option<u64>,
     remaining: Vec<MaterializationItem>,
 }
 
@@ -166,7 +168,7 @@ impl CloudArchiveMaterializer {
     ) -> Result<MaterializationPreview, MaterializationError> {
         let plan = match self.load_plan().await? {
             Some(plan) => plan,
-            None => self.load_or_plan(None, None, false).await?,
+            None => self.load_or_plan(None, None, None, false).await?,
         };
         Ok(MaterializationPreview {
             snapshot_count: plan.remaining.len(),
@@ -256,10 +258,15 @@ impl CloudArchiveMaterializer {
     ) -> Result<MaterializationOutcome, MaterializationError> {
         match self.load_plan().await? {
             Some(plan) => {
-                self.materialize_scope(plan.scope, plan.max_catalog_revision, cancellation)
-                    .await
+                self.materialize_scope(
+                    plan.scope,
+                    plan.max_catalog_revision,
+                    plan.min_catalog_revision_exclusive,
+                    cancellation,
+                )
+                .await
             }
-            None => self.materialize_scope(None, None, cancellation).await,
+            None => self.materialize_scope(None, None, None, cancellation).await,
         }
     }
 
@@ -269,7 +276,12 @@ impl CloudArchiveMaterializer {
         max_catalog_revision: u64,
     ) -> Result<MaterializationPreview, MaterializationError> {
         let plan = self
-            .load_or_plan(Some(game_id.to_string()), Some(max_catalog_revision), false)
+            .load_or_plan(
+                Some(game_id.to_string()),
+                Some(max_catalog_revision),
+                None,
+                false,
+            )
             .await?;
         Ok(MaterializationPreview {
             snapshot_count: plan.remaining.len(),
@@ -286,18 +298,60 @@ impl CloudArchiveMaterializer {
         self.materialize_scope(
             Some(game_id.to_string()),
             Some(max_catalog_revision),
+            None,
             cancellation,
         )
         .await
+    }
+
+    pub async fn materialize_game_since(
+        &self,
+        game_id: &str,
+        min_catalog_revision_exclusive: u64,
+        cancellation: &CancellationToken,
+    ) -> Result<MaterializationOutcome, MaterializationError> {
+        self.materialize_scope(
+            Some(game_id.to_string()),
+            None,
+            Some(min_catalog_revision_exclusive),
+            cancellation,
+        )
+        .await
+    }
+
+    pub async fn resume_pending(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<Option<MaterializationOutcome>, MaterializationError> {
+        let Some(plan) = self.load_plan().await? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.materialize_scope(
+                plan.scope,
+                plan.max_catalog_revision,
+                plan.min_catalog_revision_exclusive,
+                cancellation,
+            )
+            .await?,
+        ))
     }
 
     async fn materialize_scope(
         &self,
         scope: Option<String>,
         max_catalog_revision: Option<u64>,
+        min_catalog_revision_exclusive: Option<u64>,
         cancellation: &CancellationToken,
     ) -> Result<MaterializationOutcome, MaterializationError> {
-        let mut plan = self.load_or_plan(scope, max_catalog_revision, true).await?;
+        let mut plan = self
+            .load_or_plan(
+                scope,
+                max_catalog_revision,
+                min_catalog_revision_exclusive,
+                true,
+            )
+            .await?;
         let initial = plan.remaining.len();
         while let Some(item) = plan.remaining.first().cloned() {
             if cancellation.is_cancelled() {
@@ -356,10 +410,14 @@ impl CloudArchiveMaterializer {
         &self,
         scope: Option<String>,
         max_catalog_revision: Option<u64>,
+        min_catalog_revision_exclusive: Option<u64>,
         persist_new: bool,
     ) -> Result<MaterializationPlan, MaterializationError> {
         if let Some(plan) = self.load_plan().await? {
-            if plan.scope != scope || plan.max_catalog_revision != max_catalog_revision {
+            if plan.scope != scope
+                || plan.max_catalog_revision != max_catalog_revision
+                || plan.min_catalog_revision_exclusive != min_catalog_revision_exclusive
+            {
                 return Err(MaterializationError::AnotherMaterializationPending);
             }
             return Ok(plan);
@@ -379,6 +437,8 @@ impl CloudArchiveMaterializer {
                 };
                 if !live.cloud_archive_verified
                     || max_catalog_revision.is_some_and(|maximum| node.catalog_revision > maximum)
+                    || min_catalog_revision_exclusive
+                        .is_some_and(|minimum| node.catalog_revision <= minimum)
                     || (self.is_locally_reported(game, &node.snapshot_id)
                         && local_size_matches(
                             &self.local_path(game_id, &node.snapshot_id, node.archive_format),
@@ -400,6 +460,7 @@ impl CloudArchiveMaterializer {
             manifest_revision: manifest.revision,
             scope,
             max_catalog_revision,
+            min_catalog_revision_exclusive,
             remaining,
         };
         if persist_new {

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
@@ -247,7 +247,7 @@ async fn game_materialization_respects_scope_and_activation_revision() {
     }
     write_manifest(&operator, &manifest).await;
 
-    let outcome = materializer(operator, root.path(), "deck")
+    let outcome = materializer(operator.clone(), root.path(), "deck")
         .materialize_game("selected", 3, &CancellationToken::new())
         .await
         .unwrap();
@@ -276,6 +276,28 @@ async fn game_materialization_respects_scope_and_activation_revision() {
             ArchiveFormat::Zip
         )
         .exists()
+    );
+
+    let post_activation = materializer(operator, root.path(), "laptop")
+        .materialize_game_since("selected", 3, &CancellationToken::new())
+        .await
+        .unwrap();
+    assert_eq!(post_activation.downloaded, 1);
+    assert!(
+        !archive_path(
+            &root.path().join("laptop").join("selected"),
+            "before",
+            ArchiveFormat::Zip
+        )
+        .exists()
+    );
+    assert!(
+        archive_path(
+            &root.path().join("laptop").join("selected"),
+            "after",
+            ArchiveFormat::Zip
+        )
+        .is_file()
     );
 }
 

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -11,6 +11,7 @@ mod materialization_tests;
 mod namespace;
 mod profile_repository;
 mod repository;
+mod snapshot_sync;
 
 pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
 pub use cutover::{
@@ -47,4 +48,7 @@ pub use namespace::{
 pub use profile_repository::{DeviceProfileRepository, DeviceProfileRepositoryError};
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,
+};
+pub use snapshot_sync::{
+    SnapshotReconciliationOutcome, SnapshotSyncCoordinator, SnapshotSyncError,
 };

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
@@ -1,0 +1,543 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::PathBuf;
+
+use opendal::Operator;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    ArchiveIntegrity, ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudArchiveMaterializer,
+    CloudManifest, CloudManifestRepository, ManifestError, ManifestRepositoryError, SnapshotNode,
+    SnapshotState,
+};
+use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::device::DeviceId;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SnapshotReconciliationOutcome {
+    pub published: usize,
+    pub uploaded: usize,
+    pub downloaded: usize,
+}
+
+pub struct SnapshotSyncCoordinator {
+    operator: Operator,
+    materializer: CloudArchiveMaterializer,
+    local_archive_root: PathBuf,
+    current_device_id: DeviceId,
+    max_attempts: usize,
+}
+
+impl SnapshotSyncCoordinator {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        current_device_id: DeviceId,
+        progress_path: PathBuf,
+        max_attempts: usize,
+    ) -> Self {
+        let max_attempts = max_attempts.max(1);
+        Self {
+            materializer: CloudArchiveMaterializer::new(
+                operator.clone(),
+                local_archive_root.clone(),
+                current_device_id.clone(),
+                progress_path,
+                max_attempts,
+            ),
+            operator,
+            local_archive_root,
+            current_device_id,
+            max_attempts,
+        }
+    }
+
+    pub async fn reconcile_game(
+        &self,
+        game_id: &str,
+        local: &GameSnapshots,
+        activation_revision: u64,
+        local_baseline: &BTreeSet<String>,
+        cancellation: &CancellationToken,
+    ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncError> {
+        let mut manifest = self.repository().load().await?;
+        let order = publication_order(&manifest, game_id, local, local_baseline)?;
+        let mut outcome = SnapshotReconciliationOutcome::default();
+
+        for snapshot in order {
+            if cancellation.is_cancelled() {
+                return Err(SnapshotSyncError::Cancelled);
+            }
+            let inherited_ancestor = local_baseline.contains(&snapshot.date);
+            self.publish_local_node(
+                game_id,
+                &snapshot,
+                inherited_ancestor.then_some(activation_revision),
+            )
+            .await?;
+            outcome.published += 1;
+        }
+
+        manifest = self.repository().load().await?;
+        let locally_reported = manifest
+            .games
+            .get(game_id)
+            .and_then(|game| game.local_archives.get(&self.current_device_id))
+            .cloned()
+            .unwrap_or_default();
+        for snapshot in &local.backups {
+            if local_baseline.contains(&snapshot.date)
+                || locally_reported.contains(&snapshot.date)
+                || !self.local_path(game_id, snapshot).is_file()
+            {
+                continue;
+            }
+            self.publish_local_node(game_id, snapshot, None).await?;
+            outcome.published += 1;
+        }
+
+        self.publish_current_head(game_id, local).await?;
+        manifest = self.repository().load().await?;
+        let upload_ids = manifest
+            .games
+            .get(game_id)
+            .map(|game| {
+                game.snapshots
+                    .values()
+                    .filter(|node| {
+                        node.catalog_revision > activation_revision
+                            && !local_baseline.contains(&node.snapshot_id)
+                            && game
+                                .local_archives
+                                .get(&self.current_device_id)
+                                .is_some_and(|items| items.contains(&node.snapshot_id))
+                            && matches!(
+                                &node.state,
+                                SnapshotState::Live(live) if !live.cloud_archive_verified
+                            )
+                    })
+                    .map(|node| node.snapshot_id.clone())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for snapshot_id in upload_ids {
+            if cancellation.is_cancelled() {
+                return Err(SnapshotSyncError::Cancelled);
+            }
+            self.materializer.upload(game_id, &snapshot_id).await?;
+            outcome.uploaded += 1;
+        }
+
+        outcome.downloaded = self
+            .materializer
+            .materialize_game_since(game_id, activation_revision, cancellation)
+            .await?
+            .downloaded;
+        Ok(outcome)
+    }
+
+    pub async fn resume_pending(
+        &self,
+        cancellation: &CancellationToken,
+    ) -> Result<usize, SnapshotSyncError> {
+        Ok(self
+            .materializer
+            .resume_pending(cancellation)
+            .await?
+            .map_or(0, |outcome| outcome.downloaded))
+    }
+
+    async fn publish_local_node(
+        &self,
+        game_id: &str,
+        snapshot: &Snapshot,
+        inherited_revision: Option<u64>,
+    ) -> Result<(), SnapshotSyncError> {
+        let local_path = self.local_path(game_id, snapshot);
+        let integrity = if local_path.is_file() {
+            let path = local_path.clone();
+            Some(
+                tokio::task::spawn_blocking(move || ArchiveIntegrity::from_file(&path))
+                    .await
+                    .map_err(|error| SnapshotSyncError::HashTask(error.to_string()))??,
+            )
+        } else {
+            None
+        };
+        let game_id = game_id.to_string();
+        let snapshot = snapshot.clone();
+        let current_device_id = self.current_device_id.clone();
+        self.repository()
+            .mutate(move |manifest| {
+                let catalog_revision =
+                    inherited_revision.unwrap_or(manifest.revision.checked_add(1).ok_or_else(
+                        || ManifestError::SnapshotContentConflict(snapshot.date.clone()),
+                    )?);
+                let game = manifest.game_mut(&game_id);
+                if let Some(existing) = game.snapshots.get_mut(&snapshot.date) {
+                    merge_local_snapshot(existing, &snapshot, integrity.clone())?;
+                } else {
+                    let mut node = match integrity.clone() {
+                        Some(integrity) => SnapshotNode::live(
+                            &snapshot.date,
+                            snapshot.parent.clone(),
+                            integrity,
+                            snapshot.created_by.clone(),
+                        ),
+                        None => SnapshotNode::unavailable(
+                            &snapshot.date,
+                            snapshot.parent.clone(),
+                            snapshot.created_by.clone(),
+                        ),
+                    };
+                    node.catalog_revision = catalog_revision;
+                    node.description = snapshot.describe.clone();
+                    node.archive_format = snapshot.archive_format;
+                    game.upsert_live(node)?;
+                }
+                game.report_local_archive(
+                    current_device_id.clone(),
+                    snapshot.date.clone(),
+                    integrity.is_some(),
+                );
+                Ok(())
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn publish_current_head(
+        &self,
+        game_id: &str,
+        local: &GameSnapshots,
+    ) -> Result<(), SnapshotSyncError> {
+        let Some(head) = local.head_for_device(&self.current_device_id).cloned() else {
+            return Ok(());
+        };
+        let manifest = self.repository().load().await?;
+        let Some(game) = manifest.games.get(game_id) else {
+            return Ok(());
+        };
+        if !game.snapshots.contains_key(&head)
+            || game.device_heads.get(&self.current_device_id) == Some(&head)
+        {
+            return Ok(());
+        }
+        let game_id = game_id.to_string();
+        let current_device_id = self.current_device_id.clone();
+        self.repository()
+            .mutate(move |manifest| {
+                let game = manifest
+                    .games
+                    .get_mut(&game_id)
+                    .ok_or_else(|| ManifestError::MissingGame(game_id.clone()))?;
+                if !game.snapshots.contains_key(&head) {
+                    return Err(ManifestError::MissingSnapshot(head.clone()));
+                }
+                game.set_head(current_device_id.clone(), head.clone());
+                Ok(())
+            })
+            .await?;
+        Ok(())
+    }
+
+    fn repository(&self) -> CloudManifestRepository<super::OpenDalManifestTransport> {
+        CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        )
+    }
+
+    fn local_path(&self, game_id: &str, snapshot: &Snapshot) -> PathBuf {
+        archive_path(
+            &self.local_archive_root.join(game_id),
+            &snapshot.date,
+            snapshot.archive_format,
+        )
+    }
+}
+
+fn merge_local_snapshot(
+    existing: &mut SnapshotNode,
+    local: &Snapshot,
+    integrity: Option<ArchiveIntegrity>,
+) -> Result<(), ManifestError> {
+    let SnapshotState::Live(live) = &mut existing.state else {
+        return Err(ManifestError::TombstoneResurrection(local.date.clone()));
+    };
+    if existing.parent != local.parent
+        || existing.archive_format != local.archive_format
+        || live.created_by != local.created_by
+        || matches!(
+            (&live.integrity, &integrity),
+            (Some(expected), Some(actual)) if expected != actual
+        )
+    {
+        return Err(ManifestError::SnapshotContentConflict(local.date.clone()));
+    }
+    if live.integrity.is_none() {
+        live.integrity = integrity;
+    }
+    existing.description = local.describe.clone();
+    Ok(())
+}
+
+/// Return missing local nodes in parent-before-child order.
+///
+/// The traversal starts only from post-activation nodes (those absent from the
+/// captured baseline), but walks through baseline ancestors when the remote
+/// graph does not know them yet. This preserves graph validity without
+/// automatically uploading those inherited Archive bytes.
+fn publication_order(
+    manifest: &CloudManifest,
+    game_id: &str,
+    local: &GameSnapshots,
+    local_baseline: &BTreeSet<String>,
+) -> Result<Vec<Snapshot>, SnapshotSyncError> {
+    let remote = manifest.games.get(game_id);
+    let known: BTreeSet<String> = remote
+        .map(|game| game.snapshots.keys().cloned().collect())
+        .unwrap_or_default();
+    let snapshots = local
+        .backups
+        .iter()
+        .map(|snapshot| (snapshot.date.clone(), snapshot))
+        .collect::<BTreeMap<_, _>>();
+    let mut visiting = HashSet::new();
+    let mut emitted = known.clone();
+    let mut order = Vec::new();
+    for snapshot in &local.backups {
+        if local_baseline.contains(&snapshot.date) || known.contains(&snapshot.date) {
+            continue;
+        }
+        visit_snapshot(
+            &snapshot.date,
+            &snapshots,
+            &mut visiting,
+            &mut emitted,
+            &mut order,
+        )?;
+    }
+    Ok(order)
+}
+
+fn visit_snapshot(
+    snapshot_id: &str,
+    snapshots: &BTreeMap<String, &Snapshot>,
+    visiting: &mut HashSet<String>,
+    emitted: &mut BTreeSet<String>,
+    order: &mut Vec<Snapshot>,
+) -> Result<(), SnapshotSyncError> {
+    if emitted.contains(snapshot_id) {
+        return Ok(());
+    }
+    if !visiting.insert(snapshot_id.to_string()) {
+        return Err(SnapshotSyncError::LocalParentCycle(snapshot_id.to_string()));
+    }
+    let snapshot = snapshots
+        .get(snapshot_id)
+        .ok_or_else(|| SnapshotSyncError::MissingLocalAncestor(snapshot_id.to_string()))?;
+    if let Some(parent) = &snapshot.parent {
+        visit_snapshot(parent, snapshots, visiting, emitted, order)?;
+    }
+    visiting.remove(snapshot_id);
+    emitted.insert(snapshot_id.to_string());
+    order.push((*snapshot).clone());
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum SnapshotSyncError {
+    #[error("Local Snapshot graph is missing ancestor {0}")]
+    MissingLocalAncestor(String),
+    #[error("Local Snapshot parent cycle contains {0}")]
+    LocalParentCycle(String),
+    #[error("Snapshot Sync was cancelled")]
+    Cancelled,
+    #[error("Snapshot hash task failed: {0}")]
+    HashTask(String),
+    #[error(transparent)]
+    Integrity(#[from] ArchiveIntegrityError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestRepositoryError),
+    #[error(transparent)]
+    Materialization(#[from] super::MaterializationError),
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy};
+    use crate::cloud_sync::v2::{GameManifest, SnapshotState, cloud_archive_path};
+
+    fn memory_operator() -> Operator {
+        Operator::new(services::Memory::default()).unwrap().finish()
+    }
+
+    fn snapshot(id: &str, parent: Option<&str>) -> Snapshot {
+        Snapshot {
+            date: id.into(),
+            describe: id.into(),
+            path: String::new(),
+            archive_format: ArchiveFormat::Zip,
+            size: 0,
+            parent: parent.map(str::to_string),
+            archive_hash: None,
+            device_id: Some("deck".into()),
+            created_by: CreatedBy::Manual,
+        }
+    }
+
+    async fn write_manifest(operator: &Operator, manifest: &CloudManifest) {
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec_pretty(manifest).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn baseline_ancestors_are_catalogued_but_only_new_snapshots_upload() {
+        let operator = memory_operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let archive_root = root.path().join("deck");
+        let game_root = archive_root.join("game");
+        std::fs::create_dir_all(&game_root).unwrap();
+        std::fs::write(
+            archive_path(&game_root, "baseline", ArchiveFormat::Zip),
+            b"baseline",
+        )
+        .unwrap();
+        std::fs::write(archive_path(&game_root, "new", ArchiveFormat::Zip), b"new").unwrap();
+        let mut manifest = CloudManifest {
+            revision: 5,
+            ..Default::default()
+        };
+        manifest
+            .games
+            .insert("game".into(), GameManifest::new("game"));
+        write_manifest(&operator, &manifest).await;
+        let mut local = GameSnapshots::new("Game");
+        local.backups = vec![
+            snapshot("baseline", None),
+            snapshot("new", Some("baseline")),
+        ];
+        local.set_head_for_device("deck".into(), Some("new".into()));
+        let coordinator = SnapshotSyncCoordinator::new(
+            operator.clone(),
+            archive_root,
+            "deck".into(),
+            root.path().join("progress.json"),
+            2,
+        );
+
+        let outcome = coordinator
+            .reconcile_game(
+                "game",
+                &local,
+                5,
+                &BTreeSet::from(["baseline".into()]),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            SnapshotReconciliationOutcome {
+                published: 2,
+                uploaded: 1,
+                downloaded: 0,
+            }
+        );
+        let stored = coordinator.repository().load().await.unwrap();
+        let game = &stored.games["game"];
+        assert_eq!(game.snapshots["baseline"].catalog_revision, 5);
+        assert!(!matches!(
+            &game.snapshots["baseline"].state,
+            SnapshotState::Live(live) if live.cloud_archive_verified
+        ));
+        assert!(matches!(
+            &game.snapshots["new"].state,
+            SnapshotState::Live(live) if live.cloud_archive_verified
+        ));
+        assert_eq!(game.device_heads["deck"], "new");
+        assert!(
+            operator
+                .read(&cloud_archive_path("game", "baseline", ArchiveFormat::Zip).unwrap())
+                .await
+                .is_err()
+        );
+        assert!(
+            operator
+                .read(&cloud_archive_path("game", "new", ArchiveFormat::Zip).unwrap())
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn reconciliation_downloads_only_post_activation_cloud_archives() {
+        let operator = memory_operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let archive_root = root.path().join("deck");
+        let mut manifest = CloudManifest {
+            revision: 6,
+            ..Default::default()
+        };
+        let mut game = GameManifest::new("game");
+        for (id, revision, bytes) in [("old", 5, b"old".as_slice()), ("new", 6, b"new".as_slice())]
+        {
+            let fixture = root.path().join(format!("{id}.zip"));
+            std::fs::write(&fixture, bytes).unwrap();
+            let mut node = SnapshotNode::live(
+                id,
+                None,
+                ArchiveIntegrity::from_file(&fixture).unwrap(),
+                CreatedBy::Manual,
+            );
+            node.catalog_revision = revision;
+            let SnapshotState::Live(live) = &mut node.state else {
+                unreachable!()
+            };
+            live.cloud_archive_verified = true;
+            game.upsert_live(node).unwrap();
+            operator
+                .write(
+                    &cloud_archive_path("game", id, ArchiveFormat::Zip).unwrap(),
+                    bytes.to_vec(),
+                )
+                .await
+                .unwrap();
+        }
+        manifest.games.insert("game".into(), game);
+        write_manifest(&operator, &manifest).await;
+        let coordinator = SnapshotSyncCoordinator::new(
+            operator,
+            archive_root.clone(),
+            "deck".into(),
+            root.path().join("progress.json"),
+            2,
+        );
+
+        let outcome = coordinator
+            .reconcile_game(
+                "game",
+                &GameSnapshots::new("Game"),
+                5,
+                &BTreeSet::new(),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.downloaded, 1);
+        assert!(!archive_path(&archive_root.join("game"), "old", ArchiveFormat::Zip).exists());
+        assert!(archive_path(&archive_root.join("game"), "new", ArchiveFormat::Zip).is_file());
+    }
+}

--- a/crates/rgsm-core/src/hooks/mod.rs
+++ b/crates/rgsm-core/src/hooks/mod.rs
@@ -14,6 +14,7 @@ pub mod traits;
 pub mod checksum_hook;
 pub mod cloud_sync_hook;
 pub mod pre_restore_backup_hook;
+mod v2_snapshot_sync_hook;
 
 pub use checksum_hook::{ArchiveHashHook, ArchiveVerifyHook};
 pub use cloud_sync_hook::CloudSyncEnqueueHook;
@@ -21,3 +22,4 @@ pub use contexts::*;
 pub use pipeline::*;
 pub use pre_restore_backup_hook::PreRestoreBackupHook;
 pub use traits::{HookResult, LifecycleHook, SnapshotHook, SyncJobQueue};
+pub use v2_snapshot_sync_hook::{SnapshotSyncTarget, V2SnapshotSyncHook};

--- a/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
+++ b/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
@@ -1,0 +1,78 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use log::info;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use super::{HookSource, LifecycleHook, SnapshotCreatedCtx};
+use crate::cloud_sync::v2::SnapshotSyncCoordinator;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotSyncTarget {
+    pub activation_revision: u64,
+    pub local_baseline: BTreeSet<String>,
+}
+
+pub struct V2SnapshotSyncHook {
+    coordinator: SnapshotSyncCoordinator,
+    targets: BTreeMap<String, SnapshotSyncTarget>,
+    operation_lock: Arc<Mutex<()>>,
+}
+
+impl V2SnapshotSyncHook {
+    pub fn new(
+        coordinator: SnapshotSyncCoordinator,
+        targets: BTreeMap<String, SnapshotSyncTarget>,
+        operation_lock: Arc<Mutex<()>>,
+    ) -> Self {
+        Self {
+            coordinator,
+            targets,
+            operation_lock,
+        }
+    }
+}
+
+#[async_trait]
+impl LifecycleHook for V2SnapshotSyncHook {
+    fn name(&self) -> &str {
+        "V2SnapshotSyncHook"
+    }
+
+    fn priority(&self) -> u32 {
+        50
+    }
+
+    async fn on_snapshot_created(&self, ctx: &mut SnapshotCreatedCtx) -> Result<()> {
+        if ctx.source == HookSource::CloudSync {
+            return Ok(());
+        }
+        let game_id = ctx.game.backup_dir_name();
+        let Some(target) = self.targets.get(game_id.as_ref()) else {
+            return Ok(());
+        };
+        let _guard = self.operation_lock.lock().await;
+        let outcome = self
+            .coordinator
+            .reconcile_game(
+                game_id.as_ref(),
+                &ctx.snapshots,
+                target.activation_revision,
+                &target.local_baseline,
+                &CancellationToken::new(),
+            )
+            .await?;
+        info!(
+            target: "rgsm::hooks::v2_snapshot_sync",
+            "Reconciled {} after Snapshot creation: {} published, {} uploaded, {} downloaded",
+            game_id,
+            outcome.published,
+            outcome.uploaded,
+            outcome.downloaded
+        );
+        Ok(())
+    }
+}

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -2,12 +2,17 @@ mod config;
 mod game;
 mod path_resolution;
 mod snapshot;
+mod snapshot_sync;
 mod sync;
 
 use std::sync::Arc;
 
 use crate::hooks::HookPipeline;
 
+pub use snapshot_sync::{
+    DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES, SnapshotSyncServiceError, build_v2_snapshot_sync_hook,
+    resume_v2_snapshot_sync, run_v2_snapshot_sync_once, v2_snapshot_sync_poll_minutes,
+};
 pub use sync::{
     CloudLibraryCutoverOutcome, CloudLibraryJoinOutcome, CloudLibraryServiceError,
     CloudLibraryStatus, GameSyncModeOutcome,

--- a/crates/rgsm-core/src/services/snapshot_sync.rs
+++ b/crates/rgsm-core/src/services/snapshot_sync.rs
@@ -1,0 +1,238 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use thiserror::Error;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::app_dirs::resolve_app_path;
+use crate::backup::GameSnapshots;
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{
+    SnapshotReconciliationOutcome, SnapshotSyncCoordinator, SnapshotSyncError,
+};
+use crate::config::{
+    CloudNamespaceGeneration, Config, DeviceProfile, SyncMode, cloud_bootstrap_inputs, get_config,
+};
+use crate::hooks::{SnapshotSyncTarget, V2SnapshotSyncHook};
+use crate::preclude::{BackendError, BackupError, ConfigError};
+
+pub const DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES: u64 = 5;
+
+struct SnapshotSyncRuntime {
+    coordinator: SnapshotSyncCoordinator,
+    targets: BTreeMap<String, SnapshotSyncTarget>,
+    game_names: BTreeMap<String, String>,
+    config: Config,
+}
+
+pub fn build_v2_snapshot_sync_hook(
+    operation_lock: Arc<Mutex<()>>,
+) -> Result<Option<V2SnapshotSyncHook>, SnapshotSyncServiceError> {
+    Ok(load_runtime()?.map(|runtime| {
+        V2SnapshotSyncHook::new(runtime.coordinator, runtime.targets, operation_lock)
+    }))
+}
+
+pub async fn run_v2_snapshot_sync_once(
+    cancellation: &CancellationToken,
+) -> Result<SnapshotReconciliationOutcome, SnapshotSyncServiceError> {
+    let Some(runtime) = load_runtime()? else {
+        return Ok(SnapshotReconciliationOutcome::default());
+    };
+    let mut total = SnapshotReconciliationOutcome::default();
+    for (game_id, target) in &runtime.targets {
+        if cancellation.is_cancelled() {
+            return Err(SnapshotSyncServiceError::Cancelled);
+        }
+        let snapshots = match runtime
+            .config
+            .games
+            .iter()
+            .find(|game| game.storage_key == *game_id)
+        {
+            Some(game) => game.get_game_snapshots_info()?,
+            None => GameSnapshots::new(
+                runtime
+                    .game_names
+                    .get(game_id)
+                    .cloned()
+                    .unwrap_or_else(|| game_id.clone()),
+            ),
+        };
+        let outcome = runtime
+            .coordinator
+            .reconcile_game(
+                game_id,
+                &snapshots,
+                target.activation_revision,
+                &target.local_baseline,
+                cancellation,
+            )
+            .await?;
+        total.published += outcome.published;
+        total.uploaded += outcome.uploaded;
+        total.downloaded += outcome.downloaded;
+    }
+    Ok(total)
+}
+
+pub async fn resume_v2_snapshot_sync(
+    cancellation: &CancellationToken,
+) -> Result<usize, SnapshotSyncServiceError> {
+    let Some(runtime) = load_runtime()? else {
+        return Ok(0);
+    };
+    Ok(runtime.coordinator.resume_pending(cancellation).await?)
+}
+
+pub fn v2_snapshot_sync_poll_minutes() -> Result<Option<u64>, SnapshotSyncServiceError> {
+    let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+    if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2
+        || !profile
+            .games
+            .values()
+            .any(|game| game.sync_mode == SyncMode::SnapshotSync)
+    {
+        return Ok(None);
+    }
+    let configured = local_state.cloud_settings.auto_sync_interval;
+    Ok(Some(if configured == 0 {
+        DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES
+    } else {
+        configured
+    }))
+}
+
+fn load_runtime() -> Result<Option<SnapshotSyncRuntime>, SnapshotSyncServiceError> {
+    let (library, profile, local_state) = cloud_bootstrap_inputs()?;
+    if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+        return Ok(None);
+    }
+    let targets = sync_targets(&profile);
+    if targets.is_empty() {
+        return Ok(None);
+    }
+    let archive_root = profile
+        .local_archive_root
+        .as_deref()
+        .map(resolve_app_path)
+        .ok_or(SnapshotSyncServiceError::StorageLocationRequired)?;
+    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+    Ok(Some(SnapshotSyncRuntime {
+        coordinator: SnapshotSyncCoordinator::new(
+            session.get_op()?,
+            archive_root,
+            local_state.current_device_id,
+            resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
+            3,
+        ),
+        targets,
+        game_names: library
+            .games
+            .into_iter()
+            .map(|game| (game.storage_key, game.name))
+            .collect(),
+        config: get_config()?,
+    }))
+}
+
+fn sync_targets(profile: &DeviceProfile) -> BTreeMap<String, SnapshotSyncTarget> {
+    profile
+        .games
+        .iter()
+        .filter_map(|(game_id, settings)| {
+            (settings.sync_mode == SyncMode::SnapshotSync).then(|| {
+                settings.snapshot_sync_activation_revision.map(|revision| {
+                    (
+                        game_id.clone(),
+                        SnapshotSyncTarget {
+                            activation_revision: revision,
+                            local_baseline: settings.snapshot_sync_local_baseline.clone(),
+                        },
+                    )
+                })
+            })?
+        })
+        .collect()
+}
+
+#[derive(Debug, Error)]
+pub enum SnapshotSyncServiceError {
+    #[error("Choose a local archive folder before using Snapshot Sync")]
+    StorageLocationRequired,
+    #[error("Snapshot Sync was cancelled")]
+    Cancelled,
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    #[error(transparent)]
+    Backup(#[from] BackupError),
+    #[error(transparent)]
+    SnapshotSync(#[from] SnapshotSyncError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DeviceGameProfile, InitialCatchUpPolicy};
+
+    #[test]
+    fn only_snapshot_sync_profiles_with_boundaries_become_targets() {
+        let mut profile = DeviceProfile {
+            schema_version: crate::config::V2_CONFIG_SCHEMA_VERSION,
+            device: crate::device::Device {
+                id: "deck".into(),
+                name: "Deck".into(),
+                resources: Vec::new(),
+                next_resource_id: 0,
+            },
+            local_archive_root: None,
+            games: Default::default(),
+            private_favorites: Vec::new(),
+            quick_action: Default::default(),
+            behavior: serde_json::from_value(serde_json::json!({
+                "prompt_when_not_described": false,
+                "extra_backup_when_apply": false,
+                "confirm_before_apply_latest": true,
+                "confirm_before_apply_snapshot": true,
+                "prompt_when_auto_backup": false,
+                "default_delete_before_apply": false,
+                "add_new_to_favorites": false,
+                "vn_scan_dirs": [],
+                "max_auto_backup_count": 0,
+                "max_extra_backup_count": 0,
+                "compression_preset": "Fast",
+                "compute_archive_hash": false,
+                "verify_archive_before_apply": false
+            }))
+            .unwrap(),
+        };
+        let game = |mode, revision| DeviceGameProfile {
+            visible: true,
+            sync_mode: mode,
+            snapshot_sync_activation_revision: revision,
+            snapshot_sync_local_baseline: Default::default(),
+            initial_catch_up: InitialCatchUpPolicy::KeepRemote,
+            game_path: None,
+            binding: None,
+            auto_backup: None,
+            save_units: Default::default(),
+        };
+        profile
+            .games
+            .insert("manual".into(), game(SyncMode::Manual, None));
+        profile
+            .games
+            .insert("ready".into(), game(SyncMode::SnapshotSync, Some(4)));
+        profile
+            .games
+            .insert("incomplete".into(), game(SyncMode::SnapshotSync, None));
+
+        let targets = sync_targets(&profile);
+
+        assert_eq!(targets.keys().cloned().collect::<Vec<_>>(), vec!["ready"]);
+        assert_eq!(targets["ready"].activation_revision, 4);
+    }
+}


### PR DESCRIPTION
## 概要

- 新快照创建后直接发布 V2 目录节点并校验上传
- 以启用版本和本地基线区分自动同步范围，旧父节点只补目录关系
- 启动时恢复本地下载计划，并在应用运行期间按设备间隔轮询对账
- 自动路径只传输快照文件，不恢复存档、不移动应用状态，也不写跨设备请求