### PR TITLE
feat(cloud-sync): compare V2 device progress

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -693,6 +693,18 @@ pub async fn get_cloud_archive_library(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn review_v2_game_progress(
+    game_id: String,
+    app_handle: AppHandle,
+) -> Result<rgsm_core::cloud_sync::v2::V2ConflictReview, String> {
+    svc(&app_handle)
+        .review_v2_game_progress(&game_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn preview_materialize_all(
     app_handle: AppHandle,
 ) -> Result<MaterializationPreview, String> {

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::review_cloud_library_cutover,
             ipc_handler::cutover_cloud_library,
             ipc_handler::get_cloud_archive_library,
+            ipc_handler::review_v2_game_progress,
             ipc_handler::preview_materialize_all,
             ipc_handler::upload_cloud_archive,
             ipc_handler::download_cloud_archive,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -252,6 +252,14 @@ async getCloudArchiveLibrary() : Promise<Result<CloudArchiveLibraryView, string>
     else return { status: "error", error: e  as any };
 }
 },
+async reviewV2GameProgress(gameId: string) : Promise<Result<V2ConflictReview, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("review_v2_game_progress", { gameId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async previewMaterializeAll() : Promise<Result<MaterializationPreview, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("preview_materialize_all") };
@@ -726,7 +734,7 @@ export type BuildInfo = { version: string; git_hash: string }
 export type CancelCloudSyncResult = "cancelled" | "no_active_operations"
 export type CandidateDimensions = { rootId?: string | null; accountId?: string | null; installationId?: string | null; store?: StoreKind | null }
 export type CandidateExpression = { id: string; expression: string; logicalAnchor: string; dimensions: CandidateDimensions; caseSensitive: boolean }
-export type CloudArchiveGameView = { game_id: string; name: string; sync_mode: SyncMode; snapshots: CloudArchiveSnapshotView[]; local_count: number; cloud_count: number }
+export type CloudArchiveGameView = { game_id: string; name: string; sync_mode: SyncMode; advertised_head_count: number; snapshots: CloudArchiveSnapshotView[]; local_count: number; cloud_count: number }
 export type CloudArchiveLibraryView = { games: CloudArchiveGameView[]; pending_materialization: boolean }
 export type CloudArchiveSnapshotView = { snapshot_id: string; description: string; size: number | null; local_verified: boolean; cloud_verified: boolean; reported_on_devices: string[] }
 export type CloudBackendCheckItem = { step: CloudBackendCheckStep; status: CloudBackendCheckItemStatus; critical: boolean; message: string | null }
@@ -804,14 +812,8 @@ devices?: Partial<{ [key in string]: Device }> }
 /**
  * What the user chose to do when a conflict is detected.
  */
-export type ConflictResolution = "keep_local" | "accept_remote" |
-/**
- * Preserve both local and remote branches without merging.
- *
- * TODO: implement branch selection and upload semantics for this git-like fork workflow.
- */
-"fork" | "cancelled"
-export type ConflictResolutionOutcome = "cancelled" | "kept_local" | "accepted_remote"
+export type ConflictResolution = "keep_local" | "accept_remote"
+export type ConflictResolutionOutcome = "kept_local" | "accepted_remote"
 /**
  * Tracks how a snapshot was created.
  *
@@ -967,6 +969,7 @@ export type InitialCatchUpPolicy = "keep_remote" | "download_existing"
 export type IpcNotification = { level: NotificationLevel; title: string; msg: string }
 export type JoinGameAction = "keep_cloud" | "add_local" | "replace_cloud"
 export type JoinGameDecision = { local_game_id: string; local_fingerprint: string; cloud_fingerprint: string | null; action: JoinGameAction }
+export type LocalProgressView = { snapshot_id: string; description: string; local_available: boolean; cloud_available: boolean }
 export type LudusaviManifestStatus = {
 /**
  * Current manifest source: `local`, `bundled`, or `none`.
@@ -1045,6 +1048,7 @@ export type PathPlaceholder = "root" | "game" | "base" | "home" | "storeGameId" 
 export type PathPlaceholderDescriptor = { placeholder: PathPlaceholder; token: string; windowsApplicable: boolean }
 export type PendingAction = "none" | "retry_required" | "user_decision_required"
 export type PlatformKind = "windows" | "linux" | "macOs"
+export type ProgressRelation = "same" | "remote_ahead" | "remote_earlier" | "different_progress" | "no_local_position"
 export type QuickActionCompleted = { operation: QuickActionOperation; status: QuickActionStatus; trigger: QuickActionType; game_name: string | null }
 export type QuickActionHotkeys = { apply: string[]; backup: string[] }
 export type QuickActionOperation = "Backup" | "Apply"
@@ -1055,6 +1059,7 @@ export type QuickActionSoundSource = { kind: "default" } | { kind: "file"; path:
 export type QuickActionStatus = "Success" | "Failure" | "SkippedUnchanged"
 export type QuickActionType = "Timer" | "Tray" | "Hotkey" | "ProcessStart" | "ProcessExit" | "ProcessInterval"
 export type QuickActionsSettings = { quick_action_game_id?: string | null; hotkeys?: QuickActionHotkeys; enable_sound?: boolean; enable_notification?: boolean; notify_when_unchanged?: boolean; sounds?: QuickActionSoundSlots; game_automations?: GameAutomationSettings[] }
+export type RemoteProgressCandidate = { snapshot_id: string; description: string; devices: string[]; relation: ProgressRelation; local_unique_snapshots: number; remote_unique_snapshots: number; common_ancestor: string | null; local_available: boolean; cloud_available: boolean }
 export type ResolutionDiagnostic = { kind: ResolutionDiagnosticKind; message: string }
 export type ResolutionDiagnosticKind = "unknownPlaceholder" | "invalidGlob" | "missingContext" | "unsupportedPlatform" | "noCandidate" | "noMatch" | "multipleCandidates" | "multipleMatches"
 export type ResolutionReport = { rawPattern: string; selectionState: ResolutionSelectionState; candidates: CandidateExpression[]; locations: ResolvedSaveLocation[]; diagnostics: ResolutionDiagnostic[] }
@@ -1168,6 +1173,7 @@ export type SyncGameOutcome = "already_in_sync" | "uploaded" | "downloaded" | "m
 export type SyncMode = "manual" | "snapshot_sync" | "live_save_sync"
 export type SyncResult = "success" | { error: string } | "conflict" | "cancelled"
 export type SyncState = { schema_version: number; backend_fingerprint?: string; current_device_id?: string; config_state?: GameSyncState; games?: Partial<{ [key in string]: GameSyncState }> }
+export type V2ConflictReview = { game_id: string; manifest_revision: number; local: LocalProgressView | null; candidates: RemoteProgressCandidate[]; requires_choice: boolean }
 
 /** tauri-specta globals **/
 

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import { Download, Refresh, Upload } from '@element-plus/icons-vue';
+import { Connection, Download, Refresh, Upload } from '@element-plus/icons-vue';
 
 import {
   commands,
@@ -21,6 +21,7 @@ const changingMode = ref(false);
 const activeTransfer = ref('');
 const openGames = ref<string[]>([]);
 const modeGame = ref<CloudArchiveGameView | null>(null);
+const progressGame = ref<CloudArchiveGameView | null>(null);
 const catchUpPolicy = ref<InitialCatchUpPolicy>('keep_remote');
 
 const totalSnapshots = computed(
@@ -242,16 +243,32 @@ onMounted(load);
                 }}
               </span>
             </div>
-            <ElSelect
-              :model-value="game.sync_mode"
-              class="sync-mode-select"
-              :aria-label="$t('sync_settings.archives.mode')"
-              @click.stop
-              @change="changeMode(game, $event)"
-            >
-              <ElOption value="manual" :label="$t('sync_settings.archives.mode_manual')" />
-              <ElOption value="snapshot_sync" :label="$t('sync_settings.archives.mode_snapshot')" />
-            </ElSelect>
+            <div class="game-actions">
+              <ElButton
+                v-if="game.advertised_head_count > 0"
+                :icon="Connection"
+                type="primary"
+                plain
+                size="small"
+                @click.stop="progressGame = game"
+              >
+                {{ $t('sync_settings.archives.progress.action') }}
+                <ElBadge :value="game.advertised_head_count" />
+              </ElButton>
+              <ElSelect
+                :model-value="game.sync_mode"
+                class="sync-mode-select"
+                :aria-label="$t('sync_settings.archives.mode')"
+                @click.stop
+                @change="changeMode(game, $event)"
+              >
+                <ElOption value="manual" :label="$t('sync_settings.archives.mode_manual')" />
+                <ElOption
+                  value="snapshot_sync"
+                  :label="$t('sync_settings.archives.mode_snapshot')"
+                />
+              </ElSelect>
+            </div>
           </div>
         </template>
         <div v-for="snapshot in game.snapshots" :key="snapshot.snapshot_id" class="snapshot-row">
@@ -284,6 +301,14 @@ onMounted(load);
         </div>
       </ElCollapseItem>
     </ElCollapse>
+
+    <V2ConflictReviewDialog
+      v-if="progressGame"
+      :model-value="progressGame !== null"
+      :game-id="progressGame.game_id"
+      :game-name="progressGame.name"
+      @update:model-value="progressGame = null"
+    />
 
     <ElDialog
       :model-value="modeGame !== null"
@@ -373,6 +398,19 @@ onMounted(load);
   display: flex;
   gap: 8px;
   flex-shrink: 0;
+}
+
+.game-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.game-actions :deep(.el-badge__content) {
+  position: static;
+  margin-left: 5px;
+  transform: none;
 }
 
 .resume-alert {
@@ -481,6 +519,11 @@ onMounted(load);
     gap: 10px;
   }
 
+  .game-actions {
+    align-items: flex-end;
+    flex-direction: column;
+  }
+
   .sync-mode-select {
     width: 132px;
   }
@@ -492,6 +535,11 @@ onMounted(load);
   }
 
   .sync-mode-select {
+    width: 100%;
+  }
+
+  .game-actions {
+    align-items: stretch;
     width: 100%;
   }
 }

--- a/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
+++ b/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
@@ -1,0 +1,331 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { Monitor, MostlyCloudy } from '@element-plus/icons-vue';
+
+import {
+  commands,
+  type ProgressRelation,
+  type RemoteProgressCandidate,
+  type V2ConflictReview,
+} from '../bindings';
+import { notifyError } from '../composables/useActivityCenter';
+import { $t } from '../i18n';
+
+const props = defineProps<{
+  modelValue: boolean;
+  gameId: string;
+  gameName: string;
+}>();
+
+const emit = defineEmits<{
+  (event: 'update:modelValue', value: boolean): void;
+}>();
+
+const review = ref<V2ConflictReview | null>(null);
+const loading = ref(false);
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+});
+
+const relationKeys: Record<ProgressRelation, string> = {
+  same: 'sync_settings.archives.progress.relation_same',
+  remote_ahead: 'sync_settings.archives.progress.relation_ahead',
+  remote_earlier: 'sync_settings.archives.progress.relation_earlier',
+  different_progress: 'sync_settings.archives.progress.relation_different',
+  no_local_position: 'sync_settings.archives.progress.relation_no_local',
+};
+
+function snapshotLabel(description: string, snapshotId: string) {
+  return description || snapshotId;
+}
+
+function relationType(relation: ProgressRelation) {
+  if (relation === 'same') return 'success';
+  if (relation === 'remote_ahead') return 'primary';
+  if (relation === 'remote_earlier') return 'info';
+  return 'warning';
+}
+
+function devices(candidate: RemoteProgressCandidate) {
+  return candidate.devices.join(' · ');
+}
+
+async function load() {
+  loading.value = true;
+  review.value = null;
+  try {
+    const result = await commands.reviewV2GameProgress(props.gameId);
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.progress.load_failed'), result.error);
+      return;
+    }
+    review.value = result.data;
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(
+  () => props.modelValue,
+  (open) => {
+    if (open) void load();
+  }
+);
+</script>
+
+<template>
+  <ElDialog
+    v-model="visible"
+    :title="$t('sync_settings.archives.progress.title', { game: gameName })"
+    width="min(780px, 94vw)"
+    destroy-on-close
+  >
+    <div v-loading="loading" class="progress-review">
+      <ElAlert
+        v-if="review"
+        :type="review.requires_choice ? 'warning' : 'success'"
+        :title="
+          review.requires_choice
+            ? $t('sync_settings.archives.progress.choice_required')
+            : $t('sync_settings.archives.progress.aligned')
+        "
+        :closable="false"
+        show-icon
+      />
+
+      <section v-if="review" class="local-card">
+        <div class="position-heading">
+          <span class="position-icon"
+            ><ElIcon><Monitor /></ElIcon
+          ></span>
+          <div>
+            <small>{{ $t('sync_settings.archives.progress.local_title') }}</small>
+            <strong v-if="review.local">
+              {{ snapshotLabel(review.local.description, review.local.snapshot_id) }}
+            </strong>
+            <strong v-else>{{ $t('sync_settings.archives.progress.no_local') }}</strong>
+          </div>
+        </div>
+        <div v-if="review.local" class="availability">
+          <ElTag :type="review.local.local_available ? 'success' : 'info'" effect="plain" round>
+            {{
+              review.local.local_available
+                ? $t('sync_settings.archives.progress.on_device')
+                : $t('sync_settings.archives.progress.not_on_device')
+            }}
+          </ElTag>
+          <ElTag :type="review.local.cloud_available ? 'primary' : 'info'" effect="plain" round>
+            {{
+              review.local.cloud_available
+                ? $t('sync_settings.archives.progress.in_cloud')
+                : $t('sync_settings.archives.progress.not_in_cloud')
+            }}
+          </ElTag>
+        </div>
+      </section>
+
+      <div v-if="review?.candidates.length" class="candidate-list">
+        <article
+          v-for="candidate in review.candidates"
+          :key="candidate.snapshot_id"
+          class="candidate-card"
+        >
+          <div class="candidate-top">
+            <div class="position-heading">
+              <span class="position-icon cloud"
+                ><ElIcon><MostlyCloudy /></ElIcon
+              ></span>
+              <div>
+                <small>{{ devices(candidate) }}</small>
+                <strong>{{ snapshotLabel(candidate.description, candidate.snapshot_id) }}</strong>
+              </div>
+            </div>
+            <ElTag :type="relationType(candidate.relation)" effect="light" round>
+              {{ $t(relationKeys[candidate.relation]) }}
+            </ElTag>
+          </div>
+
+          <div class="diff-grid">
+            <div>
+              <span>{{ $t('sync_settings.archives.progress.local_unique') }}</span>
+              <strong>{{ candidate.local_unique_snapshots }}</strong>
+            </div>
+            <div>
+              <span>{{ $t('sync_settings.archives.progress.remote_unique') }}</span>
+              <strong>{{ candidate.remote_unique_snapshots }}</strong>
+            </div>
+            <div>
+              <span>{{ $t('sync_settings.archives.progress.shared_point') }}</span>
+              <strong>
+                {{
+                  candidate.common_ancestor || $t('sync_settings.archives.progress.no_shared_point')
+                }}
+              </strong>
+            </div>
+          </div>
+
+          <div class="availability">
+            <ElTag :type="candidate.local_available ? 'success' : 'info'" effect="plain" round>
+              {{
+                candidate.local_available
+                  ? $t('sync_settings.archives.progress.on_device')
+                  : $t('sync_settings.archives.progress.not_on_device')
+              }}
+            </ElTag>
+            <ElTag :type="candidate.cloud_available ? 'primary' : 'warning'" effect="plain" round>
+              {{
+                candidate.cloud_available
+                  ? $t('sync_settings.archives.progress.in_cloud')
+                  : $t('sync_settings.archives.progress.not_in_cloud')
+              }}
+            </ElTag>
+          </div>
+        </article>
+      </div>
+      <ElEmpty
+        v-else-if="review"
+        :description="$t('sync_settings.archives.progress.no_candidates')"
+      />
+    </div>
+
+    <template #footer>
+      <ElButton @click="visible = false">
+        {{ $t('sync_settings.archives.progress.decide_later') }}
+      </ElButton>
+    </template>
+  </ElDialog>
+</template>
+
+<style scoped>
+.progress-review {
+  min-height: 180px;
+}
+
+.local-card,
+.candidate-card {
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 12px;
+  background: var(--el-bg-color);
+}
+
+.local-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 16px 0;
+  padding: 14px 16px;
+}
+
+.candidate-list {
+  display: grid;
+  gap: 12px;
+}
+
+.candidate-card {
+  padding: 16px;
+  box-shadow: var(--el-box-shadow-lighter);
+}
+
+.candidate-top,
+.position-heading,
+.availability {
+  display: flex;
+  align-items: center;
+}
+
+.candidate-top {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.position-heading {
+  min-width: 0;
+  gap: 10px;
+}
+
+.position-heading > div {
+  display: grid;
+  min-width: 0;
+}
+
+.position-heading small,
+.diff-grid span {
+  color: var(--el-text-color-secondary);
+  font-size: 0.78rem;
+}
+
+.position-heading small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.position-heading strong {
+  overflow: hidden;
+  color: var(--el-text-color-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.position-icon {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: 10px;
+  color: var(--el-color-success);
+  background: var(--el-color-success-light-9);
+}
+
+.position-icon.cloud {
+  color: var(--el-color-primary);
+  background: var(--el-color-primary-light-9);
+}
+
+.diff-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.diff-grid div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+  padding: 9px 10px;
+  border-radius: 8px;
+  background: var(--el-fill-color-light);
+}
+
+.diff-grid strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.availability {
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 600px) {
+  .local-card,
+  .candidate-top {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .diff-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .diff-grid div:last-child {
+    grid-column: 1 / -1;
+  }
+}
+</style>

--- a/crates/rgsm-core/src/cloud_sync/conflict.rs
+++ b/crates/rgsm-core/src/cloud_sync/conflict.rs
@@ -33,11 +33,6 @@ pub enum SyncRelation {
 pub enum ConflictResolution {
     KeepLocal,
     AcceptRemote,
-    /// Preserve both local and remote branches without merging.
-    ///
-    /// TODO: implement branch selection and upload semantics for this git-like fork workflow.
-    Fork,
-    Cancelled,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rgsm-core/src/cloud_sync/recovery.rs
+++ b/crates/rgsm-core/src/cloud_sync/recovery.rs
@@ -1,4 +1,3 @@
-use log::info;
 use opendal::Operator;
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -21,7 +20,6 @@ use crate::preclude::BackendError;
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ConflictResolutionOutcome {
-    Cancelled,
     KeptLocal,
     AcceptedRemote,
 }
@@ -119,18 +117,6 @@ pub async fn resolve_game_conflict(
     resolution: ConflictResolution,
 ) -> Result<ConflictResolutionOutcome, BackendError> {
     match resolution {
-        ConflictResolution::Cancelled => {
-            info!(
-                target: "rgsm::cloud::recovery",
-                "Conflict resolution cancelled for game {}",
-                game.name
-            );
-            Ok(ConflictResolutionOutcome::Cancelled)
-        }
-        ConflictResolution::Fork => {
-            // TODO: fork should preserve both branch heads without merging, like a git branch.
-            Err(BackendError::UnsupportedConflictResolution("fork".into()))
-        }
         ConflictResolution::KeepLocal | ConflictResolution::AcceptRemote => {
             let context = load_conflict_context(op, game).await?;
             match resolution {
@@ -140,7 +126,6 @@ pub async fn resolve_game_conflict(
                 ConflictResolution::AcceptRemote => {
                     accept_remote_progress(session, op, game, &context).await
                 }
-                ConflictResolution::Cancelled | ConflictResolution::Fork => unreachable!(),
             }
         }
     }
@@ -443,32 +428,6 @@ mod tests {
         let state = read_game_state(&game);
         assert_eq!(state.last_sync_result, Some(SyncResult::Conflict));
         assert_eq!(state.pending_action, PendingAction::UserDecisionRequired);
-    }
-
-    #[test]
-    fn cancelled_resolution_preserves_conflict_state() {
-        let _lock = crate::config::lock_config_test_file();
-        let temp = TempDir::new().expect("temp dir should be created");
-        let game = game();
-        let config = config_for(&temp.path().join("backup"), &game);
-        let _guard = ConfigFileGuard::write(&config);
-        let session = session();
-        write_conflict_state(&session, &game);
-        let before = read_game_state(&game);
-
-        let result = test_runtime()
-            .block_on(resolve_game_conflict(
-                &session,
-                &memory_operator(),
-                &game,
-                ConflictResolution::Cancelled,
-            ))
-            .unwrap();
-
-        assert_eq!(result, ConflictResolutionOutcome::Cancelled);
-        let after = read_game_state(&game);
-        assert_eq!(before.last_sync_result, after.last_sync_result);
-        assert_eq!(before.pending_action, after.pending_action);
     }
 
     #[test]

--- a/crates/rgsm-core/src/cloud_sync/v2/conflict_review.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/conflict_review.rs
@@ -1,0 +1,591 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+use opendal::Operator;
+use serde::Serialize;
+use specta::Type;
+use thiserror::Error;
+
+use super::{
+    CLOUD_MANIFEST_PATH, CloudManifestRepository, ManifestError, ManifestRepositoryError,
+    SnapshotState,
+};
+use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::device::DeviceId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+pub struct V2ConflictReview {
+    pub game_id: String,
+    pub manifest_revision: u64,
+    pub local: Option<LocalProgressView>,
+    pub candidates: Vec<RemoteProgressCandidate>,
+    pub requires_choice: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+pub struct LocalProgressView {
+    pub snapshot_id: String,
+    pub description: String,
+    pub local_available: bool,
+    pub cloud_available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+pub struct RemoteProgressCandidate {
+    pub snapshot_id: String,
+    pub description: String,
+    pub devices: Vec<DeviceId>,
+    pub relation: ProgressRelation,
+    pub local_unique_snapshots: usize,
+    pub remote_unique_snapshots: usize,
+    pub common_ancestor: Option<String>,
+    pub local_available: bool,
+    pub cloud_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ProgressRelation {
+    Same,
+    RemoteAhead,
+    RemoteEarlier,
+    DifferentProgress,
+    NoLocalPosition,
+}
+
+pub struct V2ConflictInspector {
+    operator: Operator,
+    local_archive_root: PathBuf,
+    current_device_id: DeviceId,
+    max_attempts: usize,
+}
+
+impl V2ConflictInspector {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        current_device_id: DeviceId,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            operator,
+            local_archive_root,
+            current_device_id,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn review(
+        &self,
+        game_id: &str,
+        local_snapshots: &GameSnapshots,
+    ) -> Result<V2ConflictReview, ConflictReviewError> {
+        let manifest = CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        )
+        .load()
+        .await?;
+        let game = manifest
+            .games
+            .get(game_id)
+            .ok_or_else(|| ConflictReviewError::GameNotFound(game_id.to_string()))?;
+        let graph = SnapshotGraph::from_sources(game, local_snapshots)?;
+        let local_head = local_snapshots
+            .head_for_device(&self.current_device_id)
+            .cloned();
+        if let Some(head) = &local_head {
+            graph.validate_chain(head)?;
+            if game
+                .snapshots
+                .get(head)
+                .is_some_and(|node| !node.state.is_live())
+            {
+                return Err(ConflictReviewError::TombstonedLocalPosition(head.clone()));
+            }
+        }
+
+        let local = local_head.as_ref().map(|snapshot_id| {
+            let node = game.snapshots.get(snapshot_id);
+            LocalProgressView {
+                snapshot_id: snapshot_id.clone(),
+                description: local_snapshots
+                    .backups
+                    .iter()
+                    .find(|snapshot| snapshot.date == *snapshot_id)
+                    .map(|snapshot| snapshot.describe.clone())
+                    .or_else(|| node.map(|node| node.description.clone()))
+                    .unwrap_or_default(),
+                local_available: local_snapshots
+                    .backups
+                    .iter()
+                    .find(|snapshot| snapshot.date == *snapshot_id)
+                    .is_some_and(|snapshot| {
+                        archive_path(
+                            &self.local_archive_root.join(game_id),
+                            snapshot_id,
+                            snapshot.archive_format,
+                        )
+                        .is_file()
+                    }),
+                cloud_available: node.is_some_and(cloud_available),
+            }
+        });
+
+        let mut grouped_heads = BTreeMap::<String, BTreeSet<DeviceId>>::new();
+        for (device, head) in &game.device_heads {
+            grouped_heads
+                .entry(head.clone())
+                .or_default()
+                .insert(device.clone());
+        }
+        let requires_choice = grouped_heads.len() > 1
+            || local_head
+                .as_ref()
+                .is_some_and(|head| !grouped_heads.contains_key(head))
+            || (local_head.is_none() && !grouped_heads.is_empty());
+        let mut candidates = Vec::with_capacity(grouped_heads.len());
+        for (snapshot_id, devices) in grouped_heads {
+            let node = game
+                .snapshots
+                .get(&snapshot_id)
+                .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id.clone()))?;
+            let diff = graph.compare(local_head.as_deref(), &snapshot_id)?;
+            candidates.push(RemoteProgressCandidate {
+                snapshot_id: snapshot_id.clone(),
+                description: node.description.clone(),
+                devices: devices.into_iter().collect(),
+                relation: diff.relation,
+                local_unique_snapshots: diff.local_unique,
+                remote_unique_snapshots: diff.remote_unique,
+                common_ancestor: diff.common_ancestor,
+                local_available: self.local_verified(game_id, game, node),
+                cloud_available: cloud_available(node),
+            });
+        }
+
+        Ok(V2ConflictReview {
+            game_id: game_id.to_string(),
+            manifest_revision: manifest.revision,
+            local,
+            candidates,
+            requires_choice,
+        })
+    }
+
+    fn local_verified(
+        &self,
+        game_id: &str,
+        game: &super::GameManifest,
+        node: &super::SnapshotNode,
+    ) -> bool {
+        let SnapshotState::Live(live) = &node.state else {
+            return false;
+        };
+        let Some(integrity) = &live.integrity else {
+            return false;
+        };
+        game.local_archives
+            .get(&self.current_device_id)
+            .is_some_and(|items| items.contains(&node.snapshot_id))
+            && file_size_matches(
+                &archive_path(
+                    &self.local_archive_root.join(game_id),
+                    &node.snapshot_id,
+                    node.archive_format,
+                ),
+                integrity.size,
+            )
+    }
+}
+
+fn cloud_available(node: &super::SnapshotNode) -> bool {
+    matches!(&node.state, SnapshotState::Live(live) if live.cloud_archive_verified)
+}
+
+fn file_size_matches(path: &Path, expected: u64) -> bool {
+    std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file() && metadata.len() == expected)
+}
+
+struct SnapshotGraph {
+    parents: BTreeMap<String, Option<String>>,
+}
+
+struct ProgressDiff {
+    relation: ProgressRelation,
+    local_unique: usize,
+    remote_unique: usize,
+    common_ancestor: Option<String>,
+}
+
+impl SnapshotGraph {
+    fn from_sources(
+        game: &super::GameManifest,
+        local: &GameSnapshots,
+    ) -> Result<Self, ConflictReviewError> {
+        game.validate()?;
+
+        let mut graph = Self::from_manifest(game);
+        for snapshot in &local.backups {
+            graph.merge_local_snapshot(game, snapshot)?;
+        }
+
+        graph.validate()?;
+        Ok(graph)
+    }
+
+    fn from_manifest(game: &super::GameManifest) -> Self {
+        Self {
+            parents: game
+                .snapshots
+                .iter()
+                .map(|(id, node)| (id.clone(), node.parent.clone()))
+                .collect(),
+        }
+    }
+
+    fn merge_local_snapshot(
+        &mut self,
+        game: &super::GameManifest,
+        snapshot: &Snapshot,
+    ) -> Result<(), ConflictReviewError> {
+        let Some(existing_parent) = self.parents.get(&snapshot.date) else {
+            self.parents
+                .insert(snapshot.date.clone(), snapshot.parent.clone());
+            return Ok(());
+        };
+        let manifest_snapshot = game.snapshots.get(&snapshot.date);
+        if shared_snapshot_matches(existing_parent, manifest_snapshot, snapshot) {
+            return Ok(());
+        }
+        Err(ConflictReviewError::SnapshotIdentityConflict(
+            snapshot.date.clone(),
+        ))
+    }
+
+    fn validate(&self) -> Result<(), ConflictReviewError> {
+        for snapshot_id in self.parents.keys() {
+            self.validate_chain(snapshot_id)?;
+        }
+        Ok(())
+    }
+
+    /// Compare two parent chains by their first shared ancestor.
+    ///
+    /// Each chain is visited once, so time and additional space are O(V) for
+    /// V nodes reachable from the two Heads.
+    fn compare(
+        &self,
+        local_head: Option<&str>,
+        remote_head: &str,
+    ) -> Result<ProgressDiff, ConflictReviewError> {
+        let Some(local_head) = local_head else {
+            return Ok(ProgressDiff {
+                relation: ProgressRelation::NoLocalPosition,
+                local_unique: 0,
+                remote_unique: self.chain(remote_head)?.len(),
+                common_ancestor: None,
+            });
+        };
+        let local_chain = self.chain(local_head)?;
+        let remote_chain = self.chain(remote_head)?;
+        let remote_positions = remote_chain
+            .iter()
+            .enumerate()
+            .map(|(index, id)| (id.as_str(), index))
+            .collect::<BTreeMap<_, _>>();
+        let shared = local_chain
+            .iter()
+            .enumerate()
+            .find_map(|(local_index, id)| {
+                remote_positions
+                    .get(id.as_str())
+                    .map(|remote_index| (local_index, *remote_index, id.clone()))
+            });
+        let (local_unique, remote_unique, common_ancestor) =
+            shared.unwrap_or((local_chain.len(), remote_chain.len(), String::new()));
+        let relation = match (local_unique, remote_unique) {
+            (0, 0) => ProgressRelation::Same,
+            (0, _) => ProgressRelation::RemoteAhead,
+            (_, 0) => ProgressRelation::RemoteEarlier,
+            _ => ProgressRelation::DifferentProgress,
+        };
+        Ok(ProgressDiff {
+            relation,
+            local_unique,
+            remote_unique,
+            common_ancestor: (!common_ancestor.is_empty()).then_some(common_ancestor),
+        })
+    }
+
+    fn validate_chain(&self, start: &str) -> Result<(), ConflictReviewError> {
+        self.chain(start).map(|_| ())
+    }
+
+    fn chain(&self, start: &str) -> Result<Vec<String>, ConflictReviewError> {
+        let mut chain = Vec::new();
+        let mut cursor = start;
+        let mut visited = HashSet::new();
+        loop {
+            if !visited.insert(cursor.to_string()) {
+                return Err(ConflictReviewError::ParentCycle(cursor.to_string()));
+            }
+            chain.push(cursor.to_string());
+            let parent = self
+                .parents
+                .get(cursor)
+                .ok_or_else(|| ConflictReviewError::MissingSnapshot(cursor.to_string()))?;
+            let Some(parent) = parent.as_deref() else {
+                return Ok(chain);
+            };
+            cursor = parent;
+        }
+    }
+}
+
+fn shared_snapshot_matches(
+    existing_parent: &Option<String>,
+    manifest_snapshot: Option<&super::SnapshotNode>,
+    local_snapshot: &Snapshot,
+) -> bool {
+    existing_parent == &local_snapshot.parent
+        && manifest_snapshot
+            .is_none_or(|node| manifest_snapshot_matches_local(node, local_snapshot))
+}
+
+fn manifest_snapshot_matches_local(
+    manifest_snapshot: &super::SnapshotNode,
+    local_snapshot: &Snapshot,
+) -> bool {
+    if manifest_snapshot.archive_format != local_snapshot.archive_format {
+        return false;
+    }
+    let SnapshotState::Live(live) = &manifest_snapshot.state else {
+        return true;
+    };
+    live.created_by == local_snapshot.created_by
+        && live
+            .integrity
+            .as_ref()
+            .is_none_or(|integrity| local_integrity_matches(local_snapshot, integrity))
+}
+
+fn local_integrity_matches(
+    local_snapshot: &Snapshot,
+    manifest_integrity: &super::ArchiveIntegrity,
+) -> bool {
+    (local_snapshot.size == 0 || manifest_integrity.size == local_snapshot.size)
+        && local_snapshot
+            .archive_hash
+            .as_ref()
+            .is_none_or(|hash| hash == &manifest_integrity.xxh3_64)
+}
+
+#[derive(Debug, Error)]
+pub enum ConflictReviewError {
+    #[error("Game does not exist in the Cloud Library: {0}")]
+    GameNotFound(String),
+    #[error("Snapshot does not exist in the combined progress graph: {0}")]
+    MissingSnapshot(String),
+    #[error("Snapshot parent cycle contains {0}")]
+    ParentCycle(String),
+    #[error("Local and Cloud progress disagree about Snapshot identity: {0}")]
+    SnapshotIdentityConflict(String),
+    #[error("The local Current Position was deleted from shared history: {0}")]
+    TombstonedLocalPosition(String),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error(transparent)]
+    Repository(#[from] ManifestRepositoryError),
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy, Snapshot};
+    use crate::cloud_sync::v2::{ArchiveIntegrity, CloudManifest, GameManifest, SnapshotNode};
+
+    fn snapshot(id: &str, parent: Option<&str>) -> Snapshot {
+        Snapshot {
+            date: id.into(),
+            describe: id.into(),
+            path: String::new(),
+            archive_format: ArchiveFormat::Zip,
+            size: 0,
+            parent: parent.map(str::to_string),
+            archive_hash: None,
+            device_id: None,
+            created_by: CreatedBy::Manual,
+        }
+    }
+
+    fn node(id: &str, parent: Option<&str>) -> SnapshotNode {
+        SnapshotNode::live(
+            id,
+            parent.map(str::to_string),
+            ArchiveIntegrity {
+                size: 1,
+                xxh3_64: "0000000000000000".into(),
+            },
+            CreatedBy::Manual,
+        )
+    }
+
+    async fn inspector(game: GameManifest, root: &Path) -> V2ConflictInspector {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec(&CloudManifest {
+                    revision: 7,
+                    games: BTreeMap::from([("game".into(), game)]),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        V2ConflictInspector::new(operator, root.to_path_buf(), "pc".into(), 2)
+    }
+
+    #[test]
+    fn shared_snapshot_identity_compares_portable_metadata() {
+        let manifest_snapshot = node("same", None);
+        let mut local_snapshot = snapshot("same", None);
+        local_snapshot.size = 1;
+        local_snapshot.archive_hash = Some("0000000000000000".into());
+
+        assert!(manifest_snapshot_matches_local(
+            &manifest_snapshot,
+            &local_snapshot
+        ));
+
+        local_snapshot.size = 2;
+        assert!(!manifest_snapshot_matches_local(
+            &manifest_snapshot,
+            &local_snapshot
+        ));
+
+        local_snapshot.size = 1;
+        local_snapshot.archive_hash = Some("different".into());
+        assert!(!manifest_snapshot_matches_local(
+            &manifest_snapshot,
+            &local_snapshot
+        ));
+
+        local_snapshot.archive_hash = Some("0000000000000000".into());
+        local_snapshot.created_by = CreatedBy::Timer;
+        assert!(!manifest_snapshot_matches_local(
+            &manifest_snapshot,
+            &local_snapshot
+        ));
+
+        local_snapshot.created_by = CreatedBy::Manual;
+        local_snapshot.archive_format = ArchiveFormat::SevenZ;
+        assert!(!manifest_snapshot_matches_local(
+            &manifest_snapshot,
+            &local_snapshot
+        ));
+    }
+
+    #[tokio::test]
+    async fn groups_devices_and_keeps_comparable_heads_as_choices() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let mut game = GameManifest::new("game");
+        for entry in [
+            node("root", None),
+            node("local", Some("root")),
+            node("remote-a", Some("local")),
+            node("remote-b", Some("remote-a")),
+        ] {
+            game.upsert_live(entry).unwrap();
+        }
+        game.set_head("deck".into(), "remote-a".into());
+        game.set_head("laptop".into(), "remote-a".into());
+        game.set_head("handheld".into(), "remote-b".into());
+        let mut local = GameSnapshots::new("Game");
+        local.backups = vec![snapshot("root", None), snapshot("local", Some("root"))];
+        local.set_head_for_device("pc".into(), Some("local".into()));
+
+        let review = inspector(game, root.path())
+            .await
+            .review("game", &local)
+            .await
+            .unwrap();
+
+        assert!(review.requires_choice);
+        assert_eq!(review.candidates.len(), 2);
+        assert_eq!(review.candidates[0].devices, vec!["deck", "laptop"]);
+        assert_eq!(review.candidates[0].relation, ProgressRelation::RemoteAhead);
+        assert_eq!(review.candidates[0].remote_unique_snapshots, 1);
+        assert_eq!(review.candidates[1].remote_unique_snapshots, 2);
+    }
+
+    #[tokio::test]
+    async fn reports_earlier_divergent_and_headless_relations() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let mut game = GameManifest::new("game");
+        for entry in [
+            node("root", None),
+            node("local", Some("root")),
+            node("local-tip", Some("local")),
+            node("earlier", Some("root")),
+            node("other", Some("root")),
+        ] {
+            game.upsert_live(entry).unwrap();
+        }
+        game.set_head("old".into(), "root".into());
+        game.set_head("other".into(), "other".into());
+        let inspector = inspector(game, root.path()).await;
+        let mut local = GameSnapshots::new("Game");
+        local.backups = vec![
+            snapshot("root", None),
+            snapshot("local", Some("root")),
+            snapshot("local-tip", Some("local")),
+        ];
+        local.set_head_for_device("pc".into(), Some("local-tip".into()));
+
+        let review = inspector.review("game", &local).await.unwrap();
+
+        assert_eq!(
+            review.candidates[0].relation,
+            ProgressRelation::DifferentProgress
+        );
+        assert_eq!(
+            review.candidates[1].relation,
+            ProgressRelation::RemoteEarlier
+        );
+        let headless = inspector
+            .review("game", &GameSnapshots::new("Game"))
+            .await
+            .unwrap();
+        assert!(
+            headless
+                .candidates
+                .iter()
+                .all(|candidate| candidate.relation == ProgressRelation::NoLocalPosition)
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_conflicting_local_snapshot_identity() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let mut game = GameManifest::new("game");
+        game.upsert_live(node("root", None)).unwrap();
+        game.upsert_live(node("same", Some("root"))).unwrap();
+        game.set_head("deck".into(), "same".into());
+        let mut local = GameSnapshots::new("Game");
+        local.backups = vec![snapshot("same", None)];
+
+        assert!(matches!(
+            inspector(game, root.path())
+                .await
+                .review("game", &local)
+                .await,
+            Err(ConflictReviewError::SnapshotIdentityConflict(id)) if id == "same"
+        ));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
@@ -31,6 +31,7 @@ pub struct CloudArchiveGameView {
     pub game_id: String,
     pub name: String,
     pub sync_mode: SyncMode,
+    pub advertised_head_count: usize,
     pub snapshots: Vec<CloudArchiveSnapshotView>,
     pub local_count: usize,
     pub cloud_count: usize,
@@ -146,6 +147,11 @@ impl CloudArchiveMaterializer {
                     .cloned()
                     .unwrap_or_else(|| game_id.clone()),
                 sync_mode: SyncMode::Manual,
+                advertised_head_count: game
+                    .device_heads
+                    .values()
+                    .collect::<std::collections::BTreeSet<_>>()
+                    .len(),
                 local_count: snapshots
                     .iter()
                     .filter(|snapshot| snapshot.local_verified)

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,4 +1,5 @@
 mod bootstrap;
+mod conflict_review;
 mod cutover;
 mod deletion;
 mod game_comparison;
@@ -14,6 +15,10 @@ mod repository;
 mod snapshot_sync;
 
 pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
+pub use conflict_review::{
+    ConflictReviewError, LocalProgressView, ProgressRelation, RemoteProgressCandidate,
+    V2ConflictInspector, V2ConflictReview,
+};
 pub use cutover::{
     CloudLibraryCutover, CloudLibraryCutoverError, CloudLibraryCutoverResult,
     CloudLibraryCutoverReview,

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -47,8 +47,6 @@ pub enum BackendError {
     GameNotFound(String),
     #[error("No unresolved cloud sync conflict for game: {0}")]
     InvalidConflictState(String),
-    #[error("Unsupported cloud conflict resolution: {0}")]
-    UnsupportedConflictResolution(String),
     #[error("Legacy cloud synchronization is unavailable after V2 Cloud Library activation")]
     V2CloudLibraryActive,
     #[error("IO error: {0:#?}")]

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -4,13 +4,14 @@ use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 
 use crate::app_dirs::resolve_app_path;
-use crate::backup::Game;
+use crate::backup::{Game, GameSnapshots};
 use crate::cloud_sync::v2::{
     CloudArchiveLibraryView, CloudArchiveMaterializer, CloudLibraryBootstrap,
     CloudLibraryBootstrapError, CloudLibraryCutover, CloudLibraryCutoverError,
     CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinReview,
-    CloudNamespaceClassification, DeviceProfileRepository, DeviceProfileRepositoryError,
-    JoinGameDecision, MaterializationError, MaterializationOutcome, MaterializationPreview,
+    CloudNamespaceClassification, ConflictReviewError, DeviceProfileRepository,
+    DeviceProfileRepositoryError, JoinGameDecision, MaterializationError, MaterializationOutcome,
+    MaterializationPreview, V2ConflictInspector, V2ConflictReview,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -102,6 +103,8 @@ pub enum CloudLibraryServiceError {
     Cutover(#[from] CloudLibraryCutoverError),
     #[error(transparent)]
     Materialization(#[from] MaterializationError),
+    #[error(transparent)]
+    ConflictReview(#[from] ConflictReviewError),
     #[error(transparent)]
     DeviceProfile(#[from] DeviceProfileRepositoryError),
     #[error("Game is not configured on this device: {0}")]
@@ -335,6 +338,43 @@ impl ServiceContext {
                 .map_or(SyncMode::Manual, |settings| settings.sync_mode);
         }
         Ok(view)
+    }
+
+    pub async fn review_v2_game_progress(
+        &self,
+        game_id: &str,
+    ) -> Result<V2ConflictReview, CloudLibraryServiceError> {
+        let (library, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let game_name = library
+            .games
+            .iter()
+            .find(|game| game.storage_key == game_id)
+            .map(|game| game.name.clone())
+            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?;
+        let local = get_config()?
+            .games
+            .into_iter()
+            .find(|game| game.storage_key == game_id)
+            .map(|game| game.get_game_snapshots_info())
+            .transpose()?
+            .unwrap_or_else(|| GameSnapshots::new(game_name));
+        let local_archive_root = profile
+            .local_archive_root
+            .as_deref()
+            .map(resolve_app_path)
+            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        Ok(V2ConflictInspector::new(
+            session.get_op()?,
+            local_archive_root,
+            local_state.current_device_id,
+            3,
+        )
+        .review(game_id, &local)
+        .await?)
     }
 
     pub async fn preview_materialize_all(

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -673,7 +673,31 @@
             "preview_failed": "Could not prepare Download All",
             "transfer_failed": "Snapshot transfer failed",
             "upload_success": "Snapshot uploaded",
-            "download_success": "Snapshot downloaded"
+            "download_success": "Snapshot downloaded",
+            "progress": {
+                "action": "Compare progress",
+                "title": "Compare progress for {game}",
+                "choice_required": "Devices have different progress. Comparing the options does not change any save data.",
+                "aligned": "Advertised devices currently agree with this position.",
+                "local_title": "Current position on this device",
+                "no_local": "No current position on this device",
+                "relation_same": "Same position",
+                "relation_ahead": "Ahead of this device",
+                "relation_earlier": "Earlier than this device",
+                "relation_different": "Different progress",
+                "relation_no_local": "Available starting point",
+                "local_unique": "Only on this device",
+                "remote_unique": "Only in this progress",
+                "shared_point": "Shared starting point",
+                "no_shared_point": "Separate history",
+                "on_device": "Archive on this device",
+                "not_on_device": "Not stored on this device",
+                "in_cloud": "Ready in cloud",
+                "not_in_cloud": "Archive not available in cloud",
+                "no_candidates": "No Device has advertised a current position yet.",
+                "decide_later": "Decide later",
+                "load_failed": "Could not compare Device progress"
+            }
         },
         "conflict": {
             "title": "Resolve cloud sync conflict",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -673,7 +673,31 @@
             "preview_failed": "无法准备全部下载",
             "transfer_failed": "快照传输失败",
             "upload_success": "快照已上传",
-            "download_success": "快照已下载"
+            "download_success": "快照已下载",
+            "progress": {
+                "action": "比较进度",
+                "title": "比较 {game} 的进度",
+                "choice_required": "不同设备记录了不同进度。比较这些选项不会更改任何存档。",
+                "aligned": "目前已记录的设备进度与此位置一致。",
+                "local_title": "本设备的当前位置",
+                "no_local": "本设备还没有当前位置",
+                "relation_same": "位置相同",
+                "relation_ahead": "比本设备更靠后",
+                "relation_earlier": "比本设备更早",
+                "relation_different": "不同进度",
+                "relation_no_local": "可选的起始进度",
+                "local_unique": "仅本设备拥有的进度",
+                "remote_unique": "仅此进度拥有的内容",
+                "shared_point": "共同起点",
+                "no_shared_point": "彼此独立的进度",
+                "on_device": "存档文件已在本设备",
+                "not_on_device": "存档文件不在本设备",
+                "in_cloud": "云端文件可用",
+                "not_in_cloud": "云端文件暂不可用",
+                "no_candidates": "还没有设备记录当前位置。",
+                "decide_later": "稍后决定",
+                "load_failed": "无法比较设备进度"
+            }
         },
         "conflict": {
             "title": "解决云同步冲突",


### PR DESCRIPTION
## 概要

- 按快照位置归并设备进度，并以父子关系展示相同、领先、更早和分叉差异
- 多个远端位置即使存在祖先关系也全部保留为独立选项
- 新增只读的本机与设备进度对比界面，明确本地和云端文件可用性
- 移除不可达的 Fork 与冲突 Cancelled 契约；关闭、Escape、遮罩和稍后决定均不写状态