### PR TITLE
feat(cloud-sync): keep local V2 progress safely

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -705,6 +705,20 @@ pub async fn review_v2_game_progress(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn keep_v2_local_progress(
+    game_id: String,
+    manifest_revision: u64,
+    local_snapshot_id: String,
+    app_handle: AppHandle,
+) -> Result<rgsm_core::cloud_sync::v2::KeepLocalProgressOutcome, String> {
+    svc(&app_handle)
+        .keep_v2_local_progress(&game_id, manifest_revision, &local_snapshot_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn preview_materialize_all(
     app_handle: AppHandle,
 ) -> Result<MaterializationPreview, String> {

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::cutover_cloud_library,
             ipc_handler::get_cloud_archive_library,
             ipc_handler::review_v2_game_progress,
+            ipc_handler::keep_v2_local_progress,
             ipc_handler::preview_materialize_all,
             ipc_handler::upload_cloud_archive,
             ipc_handler::download_cloud_archive,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -260,6 +260,14 @@ async reviewV2GameProgress(gameId: string) : Promise<Result<V2ConflictReview, st
     else return { status: "error", error: e  as any };
 }
 },
+async keepV2LocalProgress(gameId: string, manifestRevision: number, localSnapshotId: string) : Promise<Result<KeepLocalProgressOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("keep_v2_local_progress", { gameId, manifestRevision, localSnapshotId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async previewMaterializeAll() : Promise<Result<MaterializationPreview, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("preview_materialize_all") };
@@ -969,6 +977,7 @@ export type InitialCatchUpPolicy = "keep_remote" | "download_existing"
 export type IpcNotification = { level: NotificationLevel; title: string; msg: string }
 export type JoinGameAction = "keep_cloud" | "add_local" | "replace_cloud"
 export type JoinGameDecision = { local_game_id: string; local_fingerprint: string; cloud_fingerprint: string | null; action: JoinGameAction }
+export type KeepLocalProgressOutcome = { snapshot_id: string; prepared_snapshots: number; uploaded_archives: number; manifest_revision: number }
 export type LocalProgressView = { snapshot_id: string; description: string; local_available: boolean; cloud_available: boolean }
 export type LudusaviManifestStatus = {
 /**

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -308,6 +308,10 @@ onMounted(load);
       :game-id="progressGame.game_id"
       :game-name="progressGame.name"
       @update:model-value="progressGame = null"
+      @resolved="
+        progressGame = null;
+        load();
+      "
     />
 
     <ElDialog

--- a/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
+++ b/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
@@ -8,7 +8,7 @@ import {
   type RemoteProgressCandidate,
   type V2ConflictReview,
 } from '../bindings';
-import { notifyError } from '../composables/useActivityCenter';
+import { notifyError, notifySuccess } from '../composables/useActivityCenter';
 import { $t } from '../i18n';
 
 const props = defineProps<{
@@ -19,10 +19,13 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (event: 'update:modelValue', value: boolean): void;
+  (event: 'resolved'): void;
 }>();
 
+const feedback = useFeedback();
 const review = ref<V2ConflictReview | null>(null);
 const loading = ref(false);
+const resolving = ref(false);
 
 const visible = computed({
   get: () => props.modelValue,
@@ -64,6 +67,46 @@ async function load() {
     review.value = result.data;
   } finally {
     loading.value = false;
+  }
+}
+
+async function keepLocal() {
+  const current = review.value;
+  if (!current?.local) return;
+  try {
+    await feedback.confirm(
+      $t('sync_settings.archives.progress.keep_local_confirm'),
+      $t('sync_settings.archives.progress.keep_local_title'),
+      {
+        confirmButtonText: $t('sync_settings.archives.progress.keep_local'),
+        cancelButtonText: $t('sync_settings.cancel'),
+        type: 'warning',
+      }
+    );
+  } catch {
+    return;
+  }
+  resolving.value = true;
+  try {
+    const result = await commands.keepV2LocalProgress(
+      props.gameId,
+      current.manifest_revision,
+      current.local.snapshot_id
+    );
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.progress.resolve_failed'), result.error);
+      await load();
+      return;
+    }
+    notifySuccess(
+      $t('sync_settings.archives.progress.keep_local_success', {
+        count: result.data.uploaded_archives,
+      })
+    );
+    emit('resolved');
+    visible.value = false;
+  } finally {
+    resolving.value = false;
   }
 }
 
@@ -191,8 +234,16 @@ watch(
     </div>
 
     <template #footer>
-      <ElButton @click="visible = false">
+      <ElButton :disabled="resolving" @click="visible = false">
         {{ $t('sync_settings.archives.progress.decide_later') }}
+      </ElButton>
+      <ElButton
+        v-if="review?.requires_choice && review.local"
+        type="success"
+        :loading="resolving"
+        @click="keepLocal"
+      >
+        {{ $t('sync_settings.archives.progress.keep_local') }}
       </ElButton>
     </template>
   </ElDialog>

--- a/crates/rgsm-core/src/cloud_sync/v2/conflict_resolution.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/conflict_resolution.rs
@@ -1,0 +1,384 @@
+use std::collections::{BTreeMap, HashSet};
+use std::path::PathBuf;
+
+use opendal::Operator;
+use serde::Serialize;
+use specta::Type;
+use thiserror::Error;
+
+use super::{
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, ManifestError,
+    ManifestRepositoryError, MaterializationError, OpenDalManifestTransport, SnapshotState,
+    SnapshotSyncCoordinator, SnapshotSyncError,
+};
+use crate::backup::{GameSnapshots, Snapshot};
+use crate::device::DeviceId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+pub struct KeepLocalProgressOutcome {
+    pub snapshot_id: String,
+    pub prepared_snapshots: usize,
+    pub uploaded_archives: usize,
+    pub manifest_revision: u64,
+}
+
+pub struct V2ConflictResolver {
+    operator: Operator,
+    local_archive_root: PathBuf,
+    current_device_id: DeviceId,
+    progress_path: PathBuf,
+    max_attempts: usize,
+}
+
+impl V2ConflictResolver {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        current_device_id: DeviceId,
+        progress_path: PathBuf,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            operator,
+            local_archive_root,
+            current_device_id,
+            progress_path,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn keep_local(
+        &self,
+        game_id: &str,
+        expected_manifest_revision: u64,
+        expected_local_snapshot_id: &str,
+        local: &GameSnapshots,
+    ) -> Result<KeepLocalProgressOutcome, KeepLocalProgressError> {
+        let actual_local_head = local.head_for_device(&self.current_device_id).cloned();
+        if actual_local_head.as_deref() != Some(expected_local_snapshot_id) {
+            return Err(KeepLocalProgressError::LocalPositionChanged {
+                expected: expected_local_snapshot_id.to_string(),
+                actual: actual_local_head,
+            });
+        }
+
+        let repository = self.repository();
+        let initial = repository.load().await?;
+        if initial.revision != expected_manifest_revision {
+            return Err(KeepLocalProgressError::StaleReview {
+                expected: expected_manifest_revision,
+                actual: initial.revision,
+            });
+        }
+        if !initial.games.contains_key(game_id) {
+            return Err(KeepLocalProgressError::GameNotFound(game_id.to_string()));
+        }
+
+        let history = local_history(local, expected_local_snapshot_id)?;
+        let coordinator = SnapshotSyncCoordinator::new(
+            self.operator.clone(),
+            self.local_archive_root.clone(),
+            self.current_device_id.clone(),
+            self.progress_path.clone(),
+            self.max_attempts,
+        );
+        for snapshot in &history {
+            coordinator
+                .publish_local_node(game_id, snapshot, None)
+                .await?;
+        }
+
+        let materializer = CloudArchiveMaterializer::new(
+            self.operator.clone(),
+            self.local_archive_root.clone(),
+            self.current_device_id.clone(),
+            self.progress_path.clone(),
+            self.max_attempts,
+        );
+        let mut uploaded_archives = 0;
+        for snapshot in &history {
+            let manifest = repository.load().await?;
+            let cloud_verified = manifest
+                .games
+                .get(game_id)
+                .and_then(|game| game.snapshots.get(&snapshot.date))
+                .is_some_and(|node| {
+                    matches!(
+                        &node.state,
+                        SnapshotState::Live(live) if live.cloud_archive_verified
+                    )
+                });
+            if !cloud_verified && coordinator.local_path(game_id, snapshot).is_file() {
+                materializer.upload(game_id, &snapshot.date).await?;
+                uploaded_archives += 1;
+            }
+        }
+
+        let prepared = repository.load().await?;
+        let selected_is_available = prepared
+            .games
+            .get(game_id)
+            .and_then(|game| game.snapshots.get(expected_local_snapshot_id))
+            .is_some_and(|node| {
+                matches!(
+                    &node.state,
+                    SnapshotState::Live(live) if live.cloud_archive_verified
+                )
+            });
+        if !selected_is_available {
+            return Err(KeepLocalProgressError::SelectedArchiveUnavailable(
+                expected_local_snapshot_id.to_string(),
+            ));
+        }
+
+        let game_id = game_id.to_string();
+        let selected_snapshot_id = expected_local_snapshot_id.to_string();
+        let current_device_id = self.current_device_id.clone();
+        let stored = repository
+            .mutate(move |manifest| {
+                let game = manifest
+                    .games
+                    .get_mut(&game_id)
+                    .ok_or_else(|| ManifestError::MissingGame(game_id.clone()))?;
+                let selected = game
+                    .snapshots
+                    .get(&selected_snapshot_id)
+                    .ok_or_else(|| ManifestError::MissingSnapshot(selected_snapshot_id.clone()))?;
+                if !matches!(
+                    &selected.state,
+                    SnapshotState::Live(live) if live.cloud_archive_verified
+                ) {
+                    return Err(ManifestError::InvalidIntegrity(
+                        selected_snapshot_id.clone(),
+                    ));
+                }
+                game.set_head(current_device_id.clone(), selected_snapshot_id.clone());
+                Ok(())
+            })
+            .await?;
+
+        Ok(KeepLocalProgressOutcome {
+            snapshot_id: expected_local_snapshot_id.to_string(),
+            prepared_snapshots: history.len(),
+            uploaded_archives,
+            manifest_revision: stored.revision,
+        })
+    }
+
+    fn repository(&self) -> CloudManifestRepository<OpenDalManifestTransport> {
+        CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        )
+    }
+}
+
+/// Return the selected local Head and all of its ancestors in parent-first order.
+///
+/// The walk follows exactly one parent edge per Snapshot. The visited set makes
+/// malformed cycles fail closed, giving O(V) time and O(V) additional space for
+/// V Snapshots on the selected lineage.
+fn local_history(
+    local: &GameSnapshots,
+    selected_snapshot_id: &str,
+) -> Result<Vec<Snapshot>, KeepLocalProgressError> {
+    let snapshots = local
+        .backups
+        .iter()
+        .map(|snapshot| (snapshot.date.as_str(), snapshot))
+        .collect::<BTreeMap<_, _>>();
+    let mut lineage = Vec::new();
+    let mut visited = HashSet::new();
+    let mut cursor = selected_snapshot_id;
+    loop {
+        if !visited.insert(cursor.to_string()) {
+            return Err(KeepLocalProgressError::LocalParentCycle(cursor.to_string()));
+        }
+        let snapshot = snapshots
+            .get(cursor)
+            .ok_or_else(|| KeepLocalProgressError::MissingLocalSnapshot(cursor.to_string()))?;
+        lineage.push((*snapshot).clone());
+        let Some(parent) = snapshot.parent.as_deref() else {
+            break;
+        };
+        cursor = parent;
+    }
+    lineage.reverse();
+    Ok(lineage)
+}
+
+#[derive(Debug, Error)]
+pub enum KeepLocalProgressError {
+    #[error("Cloud progress review is stale: expected revision {expected}, found {actual}")]
+    StaleReview { expected: u64, actual: u64 },
+    #[error("Local Current Position changed: expected {expected}, found {actual:?}")]
+    LocalPositionChanged {
+        expected: String,
+        actual: Option<String>,
+    },
+    #[error("Game does not exist in the Cloud Library: {0}")]
+    GameNotFound(String),
+    #[error("Local progress is missing Snapshot {0}")]
+    MissingLocalSnapshot(String),
+    #[error("Local Snapshot parent cycle contains {0}")]
+    LocalParentCycle(String),
+    #[error("Selected local Snapshot Archive is not available locally or in the cloud: {0}")]
+    SelectedArchiveUnavailable(String),
+    #[error(transparent)]
+    SnapshotSync(#[from] SnapshotSyncError),
+    #[error(transparent)]
+    Materialization(#[from] MaterializationError),
+    #[error(transparent)]
+    Repository(#[from] ManifestRepositoryError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy, archive_path};
+    use crate::cloud_sync::v2::{
+        ArchiveIntegrity, CloudManifest, GameManifest, SnapshotNode, cloud_archive_path,
+    };
+
+    fn snapshot(id: &str, parent: Option<&str>) -> Snapshot {
+        Snapshot {
+            date: id.into(),
+            describe: id.into(),
+            path: String::new(),
+            archive_format: ArchiveFormat::Zip,
+            size: 0,
+            parent: parent.map(str::to_string),
+            archive_hash: None,
+            device_id: Some("pc".into()),
+            created_by: CreatedBy::Manual,
+        }
+    }
+
+    fn node(id: &str) -> SnapshotNode {
+        SnapshotNode::live(
+            id,
+            None,
+            ArchiveIntegrity {
+                size: 6,
+                xxh3_64: "0000000000000000".into(),
+            },
+            CreatedBy::Manual,
+        )
+    }
+
+    async fn fixture() -> (
+        Operator,
+        temp_dir::TempDir,
+        V2ConflictResolver,
+        GameSnapshots,
+    ) {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let root = temp_dir::TempDir::new().unwrap();
+        let archive_root = root.path().join("archives");
+        let game_root = archive_root.join("game");
+        std::fs::create_dir_all(&game_root).unwrap();
+        std::fs::write(
+            archive_path(&game_root, "root", ArchiveFormat::Zip),
+            b"root",
+        )
+        .unwrap();
+        std::fs::write(
+            archive_path(&game_root, "local", ArchiveFormat::Zip),
+            b"local",
+        )
+        .unwrap();
+        let mut game = GameManifest::new("game");
+        game.upsert_live(node("remote")).unwrap();
+        game.set_head("deck".into(), "remote".into());
+        game.set_head("pc".into(), "remote".into());
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec_pretty(&CloudManifest {
+                    revision: 7,
+                    games: BTreeMap::from([("game".into(), game)]),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        let mut local = GameSnapshots::new("Game");
+        local.backups = vec![snapshot("root", None), snapshot("local", Some("root"))];
+        local.set_head_for_device("pc".into(), Some("local".into()));
+        let resolver = V2ConflictResolver::new(
+            operator.clone(),
+            archive_root,
+            "pc".into(),
+            root.path().join("progress.json"),
+            2,
+        );
+        (operator, root, resolver, local)
+    }
+
+    #[tokio::test]
+    async fn uploads_selected_lineage_before_moving_only_current_device_head() {
+        let (operator, _root, resolver, local) = fixture().await;
+
+        let outcome = resolver
+            .keep_local("game", 7, "local", &local)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.prepared_snapshots, 2);
+        assert_eq!(outcome.uploaded_archives, 2);
+        let manifest = resolver.repository().load().await.unwrap();
+        let game = &manifest.games["game"];
+        assert_eq!(game.device_heads["pc"], "local");
+        assert_eq!(game.device_heads["deck"], "remote");
+        assert!(game.snapshots.get("local").is_some_and(
+            |node| matches!(&node.state, SnapshotState::Live(live) if live.cloud_archive_verified)
+        ));
+        assert!(
+            operator
+                .exists(&cloud_archive_path("game", "local", ArchiveFormat::Zip).unwrap())
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_review_fails_before_any_manifest_mutation() {
+        let (_operator, _root, resolver, local) = fixture().await;
+
+        assert!(matches!(
+            resolver.keep_local("game", 6, "local", &local).await,
+            Err(KeepLocalProgressError::StaleReview {
+                expected: 6,
+                actual: 7
+            })
+        ));
+        let manifest = resolver.repository().load().await.unwrap();
+        assert_eq!(manifest.revision, 7);
+        assert_eq!(manifest.games["game"].device_heads["pc"], "remote");
+    }
+
+    #[tokio::test]
+    async fn unavailable_selected_archive_never_moves_the_device_head() {
+        let (_operator, _root, resolver, local) = fixture().await;
+        std::fs::remove_file(archive_path(
+            &resolver.local_archive_root.join("game"),
+            "local",
+            ArchiveFormat::Zip,
+        ))
+        .unwrap();
+
+        assert!(matches!(
+            resolver.keep_local("game", 7, "local", &local).await,
+            Err(KeepLocalProgressError::SelectedArchiveUnavailable(id)) if id == "local"
+        ));
+        let manifest = resolver.repository().load().await.unwrap();
+        assert_eq!(manifest.games["game"].device_heads["pc"], "remote");
+        assert_eq!(manifest.games["game"].device_heads["deck"], "remote");
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -1,4 +1,5 @@
 mod bootstrap;
+mod conflict_resolution;
 mod conflict_review;
 mod cutover;
 mod deletion;
@@ -15,6 +16,9 @@ mod repository;
 mod snapshot_sync;
 
 pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
+pub use conflict_resolution::{
+    KeepLocalProgressError, KeepLocalProgressOutcome, V2ConflictResolver,
+};
 pub use conflict_review::{
     ConflictReviewError, LocalProgressView, ProgressRelation, RemoteProgressCandidate,
     V2ConflictInspector, V2ConflictReview,

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
@@ -147,7 +147,7 @@ impl SnapshotSyncCoordinator {
             .map_or(0, |outcome| outcome.downloaded))
     }
 
-    async fn publish_local_node(
+    pub(crate) async fn publish_local_node(
         &self,
         game_id: &str,
         snapshot: &Snapshot,
@@ -249,7 +249,7 @@ impl SnapshotSyncCoordinator {
         )
     }
 
-    fn local_path(&self, game_id: &str, snapshot: &Snapshot) -> PathBuf {
+    pub(crate) fn local_path(&self, game_id: &str, snapshot: &Snapshot) -> PathBuf {
         archive_path(
             &self.local_archive_root.join(game_id),
             &snapshot.date,

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -10,8 +10,9 @@ use crate::cloud_sync::v2::{
     CloudLibraryBootstrapError, CloudLibraryCutover, CloudLibraryCutoverError,
     CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinReview,
     CloudNamespaceClassification, ConflictReviewError, DeviceProfileRepository,
-    DeviceProfileRepositoryError, JoinGameDecision, MaterializationError, MaterializationOutcome,
-    MaterializationPreview, V2ConflictInspector, V2ConflictReview,
+    DeviceProfileRepositoryError, JoinGameDecision, KeepLocalProgressError,
+    KeepLocalProgressOutcome, MaterializationError, MaterializationOutcome, MaterializationPreview,
+    V2ConflictInspector, V2ConflictResolver, V2ConflictReview,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -105,6 +106,8 @@ pub enum CloudLibraryServiceError {
     Materialization(#[from] MaterializationError),
     #[error(transparent)]
     ConflictReview(#[from] ConflictReviewError),
+    #[error(transparent)]
+    KeepLocalProgress(#[from] KeepLocalProgressError),
     #[error(transparent)]
     DeviceProfile(#[from] DeviceProfileRepositoryError),
     #[error("Game is not configured on this device: {0}")]
@@ -374,6 +377,39 @@ impl ServiceContext {
             3,
         )
         .review(game_id, &local)
+        .await?)
+    }
+
+    pub async fn keep_v2_local_progress(
+        &self,
+        game_id: &str,
+        manifest_revision: u64,
+        local_snapshot_id: &str,
+    ) -> Result<KeepLocalProgressOutcome, CloudLibraryServiceError> {
+        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let local = get_config()?
+            .games
+            .into_iter()
+            .find(|game| game.storage_key == game_id)
+            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?
+            .get_game_snapshots_info()?;
+        let local_archive_root = profile
+            .local_archive_root
+            .as_deref()
+            .map(resolve_app_path)
+            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        Ok(V2ConflictResolver::new(
+            session.get_op()?,
+            local_archive_root,
+            local_state.current_device_id,
+            resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
+            3,
+        )
+        .keep_local(game_id, manifest_revision, local_snapshot_id, &local)
         .await?)
     }
 

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -696,6 +696,11 @@
                 "not_in_cloud": "Archive not available in cloud",
                 "no_candidates": "No Device has advertised a current position yet.",
                 "decide_later": "Decide later",
+                "keep_local": "Keep this device",
+                "keep_local_title": "Keep this device's progress?",
+                "keep_local_confirm": "The app will upload the available Snapshot history first, then move only this device's cloud position. Other devices and their progress will remain unchanged. This does not restore or modify live save files.",
+                "keep_local_success": "This device now keeps its local progress. Uploaded {count} archives.",
+                "resolve_failed": "Could not resolve progress",
                 "load_failed": "Could not compare Device progress"
             }
         },

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -696,6 +696,11 @@
                 "not_in_cloud": "云端文件暂不可用",
                 "no_candidates": "还没有设备记录当前位置。",
                 "decide_later": "稍后决定",
+                "keep_local": "保留本机进度",
+                "keep_local_title": "保留本机当前进度？",
+                "keep_local_confirm": "应用会先上传本机可用的快照历史，确认成功后仅移动本设备的云端位置。其他设备及其进度不会改变，也不会恢复或修改游戏的实时存档。",
+                "keep_local_success": "已保留本机进度，并上传 {count} 个归档。",
+                "resolve_failed": "无法解决进度冲突",
                 "load_failed": "无法比较设备进度"
             }
         },


### PR DESCRIPTION
## 概要

- 冲突审阅过期或本机当前位置变化时，在任何写入前拒绝操作
- 按父子顺序补齐本机进度图并上传可用归档，选中归档确认可用后才移动 Head
- 仅更新当前设备的 Head，保留其他设备位置和全部远端快照
- 在对比界面新增“保留本机进度”及风险确认，不恢复或修改实时存档