### PR TITLE
feat(cloud-sync): apply selected V2 progress safely

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -719,6 +719,26 @@ pub async fn keep_v2_local_progress(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn accept_v2_remote_progress(
+    game_id: String,
+    manifest_revision: u64,
+    expected_local_snapshot_id: Option<String>,
+    selected_snapshot_id: String,
+    app_handle: AppHandle,
+) -> Result<rgsm_core::services::AcceptRemoteProgressOutcome, String> {
+    svc(&app_handle)
+        .accept_v2_remote_progress(
+            &game_id,
+            manifest_revision,
+            expected_local_snapshot_id.as_deref(),
+            &selected_snapshot_id,
+        )
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn preview_materialize_all(
     app_handle: AppHandle,
 ) -> Result<MaterializationPreview, String> {

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -127,6 +127,7 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::get_cloud_archive_library,
             ipc_handler::review_v2_game_progress,
             ipc_handler::keep_v2_local_progress,
+            ipc_handler::accept_v2_remote_progress,
             ipc_handler::preview_materialize_all,
             ipc_handler::upload_cloud_archive,
             ipc_handler::download_cloud_archive,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -268,6 +268,14 @@ async keepV2LocalProgress(gameId: string, manifestRevision: number, localSnapsho
     else return { status: "error", error: e  as any };
 }
 },
+async acceptV2RemoteProgress(gameId: string, manifestRevision: number, expectedLocalSnapshotId: string | null, selectedSnapshotId: string) : Promise<Result<AcceptRemoteProgressOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("accept_v2_remote_progress", { gameId, manifestRevision, expectedLocalSnapshotId, selectedSnapshotId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async previewMaterializeAll() : Promise<Result<MaterializationPreview, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("preview_materialize_all") };
@@ -692,6 +700,7 @@ export const DEFAULT_CONFIG = {"backup_path":"save_data","devices":{},"favorites
 
 /** user-defined types **/
 
+export type AcceptRemoteProgressOutcome = { snapshot_id: string; safety_backup_created: boolean; manifest_revision: number }
 export type AppearanceSettings = { custom_font_enabled?: boolean; ui_font_family?: string }
 /**
  * Container format used by a Snapshot archive.

--- a/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
+++ b/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
@@ -26,6 +26,8 @@ const feedback = useFeedback();
 const review = ref<V2ConflictReview | null>(null);
 const loading = ref(false);
 const resolving = ref(false);
+const acceptingSnapshotId = ref('');
+const busy = computed(() => resolving.value || acceptingSnapshotId.value !== '');
 
 const visible = computed({
   get: () => props.modelValue,
@@ -107,6 +109,49 @@ async function keepLocal() {
     visible.value = false;
   } finally {
     resolving.value = false;
+  }
+}
+
+async function acceptRemote(candidate: RemoteProgressCandidate) {
+  const current = review.value;
+  if (!current || !candidate.cloud_available) return;
+  try {
+    await feedback.confirm(
+      $t('sync_settings.archives.progress.accept_remote_confirm', {
+        progress: snapshotLabel(candidate.description, candidate.snapshot_id),
+      }),
+      $t('sync_settings.archives.progress.accept_remote_title'),
+      {
+        confirmButtonText: $t('sync_settings.archives.progress.accept_remote'),
+        cancelButtonText: $t('sync_settings.cancel'),
+        type: 'warning',
+      }
+    );
+  } catch {
+    return;
+  }
+  acceptingSnapshotId.value = candidate.snapshot_id;
+  try {
+    const result = await commands.acceptV2RemoteProgress(
+      props.gameId,
+      current.manifest_revision,
+      current.local?.snapshot_id ?? null,
+      candidate.snapshot_id
+    );
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.progress.resolve_failed'), result.error);
+      await load();
+      return;
+    }
+    notifySuccess(
+      result.data.safety_backup_created
+        ? $t('sync_settings.archives.progress.accept_remote_success_with_backup')
+        : $t('sync_settings.archives.progress.accept_remote_success')
+    );
+    emit('resolved');
+    visible.value = false;
+  } finally {
+    acceptingSnapshotId.value = '';
   }
 }
 
@@ -209,21 +254,33 @@ watch(
             </div>
           </div>
 
-          <div class="availability">
-            <ElTag :type="candidate.local_available ? 'success' : 'info'" effect="plain" round>
-              {{
-                candidate.local_available
-                  ? $t('sync_settings.archives.progress.on_device')
-                  : $t('sync_settings.archives.progress.not_on_device')
-              }}
-            </ElTag>
-            <ElTag :type="candidate.cloud_available ? 'primary' : 'warning'" effect="plain" round>
-              {{
-                candidate.cloud_available
-                  ? $t('sync_settings.archives.progress.in_cloud')
-                  : $t('sync_settings.archives.progress.not_in_cloud')
-              }}
-            </ElTag>
+          <div class="candidate-actions">
+            <div class="availability">
+              <ElTag :type="candidate.local_available ? 'success' : 'info'" effect="plain" round>
+                {{
+                  candidate.local_available
+                    ? $t('sync_settings.archives.progress.on_device')
+                    : $t('sync_settings.archives.progress.not_on_device')
+                }}
+              </ElTag>
+              <ElTag :type="candidate.cloud_available ? 'primary' : 'warning'" effect="plain" round>
+                {{
+                  candidate.cloud_available
+                    ? $t('sync_settings.archives.progress.in_cloud')
+                    : $t('sync_settings.archives.progress.not_in_cloud')
+                }}
+              </ElTag>
+            </div>
+            <ElButton
+              v-if="candidate.relation !== 'same'"
+              type="primary"
+              plain
+              :disabled="busy || !candidate.cloud_available"
+              :loading="acceptingSnapshotId === candidate.snapshot_id"
+              @click="acceptRemote(candidate)"
+            >
+              {{ $t('sync_settings.archives.progress.accept_remote') }}
+            </ElButton>
           </div>
         </article>
       </div>
@@ -234,12 +291,13 @@ watch(
     </div>
 
     <template #footer>
-      <ElButton :disabled="resolving" @click="visible = false">
+      <ElButton :disabled="busy" @click="visible = false">
         {{ $t('sync_settings.archives.progress.decide_later') }}
       </ElButton>
       <ElButton
         v-if="review?.requires_choice && review.local"
         type="success"
+        :disabled="busy"
         :loading="resolving"
         @click="keepLocal"
       >
@@ -282,7 +340,8 @@ watch(
 
 .candidate-top,
 .position-heading,
-.availability {
+.availability,
+.candidate-actions {
   display: flex;
   align-items: center;
 }
@@ -364,6 +423,11 @@ watch(
   gap: 8px;
 }
 
+.candidate-actions {
+  justify-content: space-between;
+  gap: 12px;
+}
+
 @media (max-width: 600px) {
   .local-card,
   .candidate-top {
@@ -377,6 +441,11 @@ watch(
 
   .diff-grid div:last-child {
     grid-column: 1 / -1;
+  }
+
+  .candidate-actions {
+    align-items: stretch;
+    flex-direction: column;
   }
 }
 </style>

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -730,7 +730,7 @@ impl Game {
         backup_base: &Path,
         preset: crate::backup::CompressionPreset,
         max_extra_backup_count: u32,
-    ) -> Result<(), BackupError> {
+    ) -> Result<String, BackupError> {
         let extra_backup_path = backup_base
             .join(self.backup_dir_name().as_ref())
             .join("extra_backup");
@@ -741,7 +741,7 @@ impl Game {
         let archive_path = extra_backup_path.join(archive_file_name(&date, ArchiveFormat::SevenZ));
         SevenZBackend.compress_capture_plan(plan, &archive_path, preset, None)?;
         cleanup_oldest_extra_backups(&extra_backup_path, max_extra_backup_count)?;
-        Ok(())
+        Ok(date)
     }
     pub async fn delete_snapshot(&self, date: &str) -> Result<SnapshotDeleted, BackupError> {
         let mut saves = self.get_game_snapshots_info()?;

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -12,6 +12,7 @@ mod materialization;
 mod materialization_tests;
 mod namespace;
 mod profile_repository;
+mod remote_resolution;
 mod repository;
 mod snapshot_sync;
 
@@ -55,6 +56,9 @@ pub use namespace::{
     cloud_archive_path, device_profile_path,
 };
 pub use profile_repository::{DeviceProfileRepository, DeviceProfileRepositoryError};
+pub use remote_resolution::{
+    AcceptRemoteProgressError, PreparedRemoteProgress, V2RemoteProgressResolver,
+};
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,
 };

--- a/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
@@ -1,0 +1,387 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use opendal::Operator;
+use thiserror::Error;
+
+use super::{
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, ManifestError,
+    ManifestRepositoryError, MaterializationError, OpenDalManifestTransport, SnapshotState,
+};
+use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::device::DeviceId;
+
+pub struct PreparedRemoteProgress {
+    pub selected_snapshot_id: String,
+    pub lineage: Vec<Snapshot>,
+}
+
+pub struct V2RemoteProgressResolver {
+    operator: Operator,
+    local_archive_root: PathBuf,
+    current_device_id: DeviceId,
+    progress_path: PathBuf,
+    max_attempts: usize,
+}
+
+impl V2RemoteProgressResolver {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        current_device_id: DeviceId,
+        progress_path: PathBuf,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            operator,
+            local_archive_root,
+            current_device_id,
+            progress_path,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn prepare(
+        &self,
+        game_id: &str,
+        expected_manifest_revision: u64,
+        expected_local_snapshot_id: Option<&str>,
+        selected_snapshot_id: &str,
+        local: &GameSnapshots,
+    ) -> Result<PreparedRemoteProgress, AcceptRemoteProgressError> {
+        let actual_local_head = local.head_for_device(&self.current_device_id).cloned();
+        if actual_local_head.as_deref() != expected_local_snapshot_id {
+            return Err(AcceptRemoteProgressError::LocalPositionChanged {
+                expected: expected_local_snapshot_id.map(str::to_string),
+                actual: actual_local_head,
+            });
+        }
+
+        let repository = self.repository();
+        let initial = repository.load().await?;
+        if initial.revision != expected_manifest_revision {
+            return Err(AcceptRemoteProgressError::StaleReview {
+                expected: expected_manifest_revision,
+                actual: initial.revision,
+            });
+        }
+        let game = initial
+            .games
+            .get(game_id)
+            .ok_or_else(|| AcceptRemoteProgressError::GameNotFound(game_id.to_string()))?;
+        ensure_remote_candidate(game, &self.current_device_id, selected_snapshot_id, true)?;
+
+        CloudArchiveMaterializer::new(
+            self.operator.clone(),
+            self.local_archive_root.clone(),
+            self.current_device_id.clone(),
+            self.progress_path.clone(),
+            self.max_attempts,
+        )
+        .download(game_id, selected_snapshot_id)
+        .await?;
+
+        let prepared = repository.load().await?;
+        let game = prepared
+            .games
+            .get(game_id)
+            .ok_or_else(|| AcceptRemoteProgressError::GameNotFound(game_id.to_string()))?;
+        ensure_remote_candidate(game, &self.current_device_id, selected_snapshot_id, false)?;
+        Ok(PreparedRemoteProgress {
+            selected_snapshot_id: selected_snapshot_id.to_string(),
+            lineage: remote_lineage(
+                game_id,
+                game,
+                selected_snapshot_id,
+                &self.local_archive_root,
+            )?,
+        })
+    }
+
+    pub async fn commit_current_device_head(
+        &self,
+        game_id: &str,
+        selected_snapshot_id: &str,
+    ) -> Result<u64, AcceptRemoteProgressError> {
+        let game_id = game_id.to_string();
+        let selected_snapshot_id = selected_snapshot_id.to_string();
+        let current_device_id = self.current_device_id.clone();
+        let stored =
+            self.repository()
+                .mutate(move |manifest| {
+                    let game = manifest
+                        .games
+                        .get_mut(&game_id)
+                        .ok_or_else(|| ManifestError::MissingGame(game_id.clone()))?;
+                    let selected = game.snapshots.get(&selected_snapshot_id).ok_or_else(|| {
+                        ManifestError::MissingSnapshot(selected_snapshot_id.clone())
+                    })?;
+                    if !matches!(
+                        &selected.state,
+                        SnapshotState::Live(live) if live.cloud_archive_verified
+                    ) || !game.device_heads.iter().any(|(device, head)| {
+                        device != &current_device_id && head == &selected_snapshot_id
+                    }) {
+                        return Err(ManifestError::InvalidHead {
+                            device: current_device_id.clone(),
+                            snapshot: selected_snapshot_id.clone(),
+                        });
+                    }
+                    game.set_head(current_device_id.clone(), selected_snapshot_id.clone());
+                    Ok(())
+                })
+                .await?;
+        Ok(stored.revision)
+    }
+
+    fn repository(&self) -> CloudManifestRepository<OpenDalManifestTransport> {
+        CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        )
+    }
+}
+
+fn ensure_remote_candidate(
+    game: &super::GameManifest,
+    current_device_id: &str,
+    selected_snapshot_id: &str,
+    require_cloud_archive: bool,
+) -> Result<(), AcceptRemoteProgressError> {
+    if !game
+        .device_heads
+        .iter()
+        .any(|(device, head)| device != current_device_id && head == selected_snapshot_id)
+    {
+        return Err(AcceptRemoteProgressError::CandidateNoLongerAdvertised(
+            selected_snapshot_id.to_string(),
+        ));
+    }
+    let selected = game
+        .snapshots
+        .get(selected_snapshot_id)
+        .ok_or_else(|| ManifestError::MissingSnapshot(selected_snapshot_id.to_string()))?;
+    let SnapshotState::Live(live) = &selected.state else {
+        return Err(AcceptRemoteProgressError::CandidateNoLongerAdvertised(
+            selected_snapshot_id.to_string(),
+        ));
+    };
+    if require_cloud_archive && !live.cloud_archive_verified {
+        return Err(AcceptRemoteProgressError::SelectedArchiveUnavailable(
+            selected_snapshot_id.to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Build one selected parent chain in parent-first order.
+///
+/// Each node is visited once. The cycle guard makes the traversal O(V) time
+/// and O(V) additional space for V Snapshots on the selected lineage.
+fn remote_lineage(
+    game_id: &str,
+    game: &super::GameManifest,
+    selected_snapshot_id: &str,
+    local_archive_root: &std::path::Path,
+) -> Result<Vec<Snapshot>, AcceptRemoteProgressError> {
+    let mut lineage = Vec::new();
+    let mut visited = HashSet::new();
+    let mut cursor = selected_snapshot_id;
+    loop {
+        if !visited.insert(cursor.to_string()) {
+            return Err(AcceptRemoteProgressError::ParentCycle(cursor.to_string()));
+        }
+        let node = game
+            .snapshots
+            .get(cursor)
+            .ok_or_else(|| ManifestError::MissingSnapshot(cursor.to_string()))?;
+        let SnapshotState::Live(live) = &node.state else {
+            return Err(AcceptRemoteProgressError::TombstonedLineage(
+                cursor.to_string(),
+            ));
+        };
+        lineage.push(Snapshot {
+            date: node.snapshot_id.clone(),
+            describe: node.description.clone(),
+            path: archive_path(
+                &local_archive_root.join(game_id),
+                &node.snapshot_id,
+                node.archive_format,
+            )
+            .to_string_lossy()
+            .into_owned(),
+            archive_format: node.archive_format,
+            size: live.integrity.as_ref().map_or(0, |value| value.size),
+            parent: node.parent.clone(),
+            archive_hash: live.integrity.as_ref().map(|value| value.xxh3_64.clone()),
+            device_id: None,
+            created_by: live.created_by.clone(),
+        });
+        let Some(parent) = node.parent.as_deref() else {
+            break;
+        };
+        cursor = parent;
+    }
+    lineage.reverse();
+    Ok(lineage)
+}
+
+#[derive(Debug, Error)]
+pub enum AcceptRemoteProgressError {
+    #[error("Cloud progress review is stale: expected revision {expected}, found {actual}")]
+    StaleReview { expected: u64, actual: u64 },
+    #[error("Local Current Position changed: expected {expected:?}, found {actual:?}")]
+    LocalPositionChanged {
+        expected: Option<String>,
+        actual: Option<String>,
+    },
+    #[error("Game does not exist in the Cloud Library: {0}")]
+    GameNotFound(String),
+    #[error("Selected progress is no longer advertised by another Device: {0}")]
+    CandidateNoLongerAdvertised(String),
+    #[error("Selected Snapshot Archive is not available in the cloud: {0}")]
+    SelectedArchiveUnavailable(String),
+    #[error("Selected progress contains a deleted ancestor: {0}")]
+    TombstonedLineage(String),
+    #[error("Cloud Snapshot parent cycle contains {0}")]
+    ParentCycle(String),
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+    #[error(transparent)]
+    Materialization(#[from] MaterializationError),
+    #[error(transparent)]
+    Repository(#[from] ManifestRepositoryError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy};
+    use crate::cloud_sync::v2::{
+        ArchiveIntegrity, CloudManifest, GameManifest, SnapshotNode, cloud_archive_path,
+    };
+
+    async fn fixture() -> (
+        Operator,
+        temp_dir::TempDir,
+        V2RemoteProgressResolver,
+        GameSnapshots,
+    ) {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let root = temp_dir::TempDir::new().unwrap();
+        let mut game = GameManifest::new("game");
+        let mut root_node = SnapshotNode::live(
+            "root",
+            None,
+            ArchiveIntegrity {
+                size: 4,
+                xxh3_64: "89b1c2d328a57a3c".into(),
+            },
+            CreatedBy::Manual,
+        );
+        let mut remote = SnapshotNode::live(
+            "remote",
+            Some("root".into()),
+            ArchiveIntegrity {
+                size: 6,
+                xxh3_64: "8353b2824506ea9b".into(),
+            },
+            CreatedBy::Manual,
+        );
+        if let SnapshotState::Live(live) = &mut root_node.state {
+            live.cloud_archive_verified = true;
+        }
+        if let SnapshotState::Live(live) = &mut remote.state {
+            live.cloud_archive_verified = true;
+        }
+        game.upsert_live(root_node).unwrap();
+        game.upsert_live(remote).unwrap();
+        game.set_head("deck".into(), "remote".into());
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec_pretty(&CloudManifest {
+                    revision: 7,
+                    games: BTreeMap::from([("game".into(), game)]),
+                    ..Default::default()
+                })
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        operator
+            .write(
+                &cloud_archive_path("game", "remote", ArchiveFormat::Zip).unwrap(),
+                b"remote".to_vec(),
+            )
+            .await
+            .unwrap();
+        let local = GameSnapshots::new("Game");
+        let resolver = V2RemoteProgressResolver::new(
+            operator.clone(),
+            root.path().join("archives"),
+            "pc".into(),
+            root.path().join("progress.json"),
+            2,
+        );
+        (operator, root, resolver, local)
+    }
+
+    #[tokio::test]
+    async fn downloads_selected_candidate_and_preserves_its_lineage() {
+        let (_operator, _root, resolver, local) = fixture().await;
+
+        let prepared = resolver
+            .prepare("game", 7, None, "remote", &local)
+            .await
+            .unwrap();
+
+        assert_eq!(prepared.selected_snapshot_id, "remote");
+        assert_eq!(
+            prepared
+                .lineage
+                .iter()
+                .map(|snapshot| snapshot.date.as_str())
+                .collect::<Vec<_>>(),
+            vec!["root", "remote"]
+        );
+        assert!(std::path::Path::new(&prepared.lineage[1].path).is_file());
+    }
+
+    #[tokio::test]
+    async fn stale_review_does_not_download_or_mutate_manifest() {
+        let (_operator, _root, resolver, local) = fixture().await;
+
+        assert!(matches!(
+            resolver.prepare("game", 6, None, "remote", &local).await,
+            Err(AcceptRemoteProgressError::StaleReview {
+                expected: 6,
+                actual: 7
+            })
+        ));
+        assert_eq!(resolver.repository().load().await.unwrap().revision, 7);
+    }
+
+    #[tokio::test]
+    async fn commit_moves_only_the_current_device_head() {
+        let (_operator, _root, resolver, local) = fixture().await;
+        resolver
+            .prepare("game", 7, None, "remote", &local)
+            .await
+            .unwrap();
+
+        resolver
+            .commit_current_device_head("game", "remote")
+            .await
+            .unwrap();
+
+        let manifest = resolver.repository().load().await.unwrap();
+        assert_eq!(manifest.games["game"].device_heads["pc"], "remote");
+        assert_eq!(manifest.games["game"].device_heads["deck"], "remote");
+    }
+}

--- a/crates/rgsm-core/src/hooks/contexts.rs
+++ b/crates/rgsm-core/src/hooks/contexts.rs
@@ -18,6 +18,7 @@ pub enum HookSource {
     QuickActionTray,
     ProcessMonitorAutoBackup,
     CloudSync,
+    CloudConflictResolution,
     Internal,
 }
 

--- a/crates/rgsm-core/src/hooks/pipeline.rs
+++ b/crates/rgsm-core/src/hooks/pipeline.rs
@@ -367,6 +367,7 @@ mod tests {
     fn hook_source_variants_are_distinct() {
         assert_ne!(HookSource::UserManual, HookSource::TimerAutoBackup);
         assert_ne!(HookSource::QuickActionHotkey, HookSource::CloudSync);
+        assert_ne!(HookSource::CloudSync, HookSource::CloudConflictResolution);
         assert_ne!(HookSource::QuickActionTray, HookSource::QuickActionHotkey);
         assert_eq!(HookSource::Internal, HookSource::Internal);
     }

--- a/crates/rgsm-core/src/hooks/pre_restore_backup_hook.rs
+++ b/crates/rgsm-core/src/hooks/pre_restore_backup_hook.rs
@@ -30,6 +30,12 @@ impl LifecycleHook for PreRestoreBackupHook {
     }
 
     async fn on_before_restore(&self, ctx: &BeforeRestoreCtx) -> Result<(), BackupError> {
+        // V2 conflict resolution creates a mandatory, checked backup and keeps
+        // its identifier for rollback. A second hook backup could evict that
+        // exact archive under a one-item retention policy.
+        if ctx.source == super::HookSource::CloudConflictResolution {
+            return Ok(());
+        }
         info!(
             target: "rgsm::hooks::pre_restore_backup",
             "Creating extra backup before restoring {} / {}",

--- a/crates/rgsm-core/src/services/conflict_resolution.rs
+++ b/crates/rgsm-core/src/services/conflict_resolution.rs
@@ -1,0 +1,266 @@
+use serde::Serialize;
+use specta::Type;
+
+use crate::app_dirs::resolve_app_path;
+use crate::backup::{CapturePlanError, Game, GameSnapshots, Snapshot};
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{
+    KeepLocalProgressOutcome, V2ConflictResolver, V2RemoteProgressResolver,
+};
+use crate::config::{
+    CloudNamespaceGeneration, cloud_bootstrap_inputs, get_config, resolve_backup_path,
+};
+use crate::hooks::HookSource;
+
+use super::{CloudLibraryServiceError, ServiceContext};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Type)]
+pub struct AcceptRemoteProgressOutcome {
+    pub snapshot_id: String,
+    pub safety_backup_created: bool,
+    pub manifest_revision: u64,
+}
+
+impl ServiceContext {
+    pub async fn keep_v2_local_progress(
+        &self,
+        game_id: &str,
+        manifest_revision: u64,
+        local_snapshot_id: &str,
+    ) -> Result<KeepLocalProgressOutcome, CloudLibraryServiceError> {
+        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let local = get_config()?
+            .games
+            .into_iter()
+            .find(|game| game.storage_key == game_id)
+            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?
+            .get_game_snapshots_info()?;
+        let local_archive_root = profile
+            .local_archive_root
+            .as_deref()
+            .map(resolve_app_path)
+            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        Ok(V2ConflictResolver::new(
+            session.get_op()?,
+            local_archive_root,
+            local_state.current_device_id,
+            resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
+            3,
+        )
+        .keep_local(game_id, manifest_revision, local_snapshot_id, &local)
+        .await?)
+    }
+
+    pub async fn accept_v2_remote_progress(
+        &self,
+        game_id: &str,
+        manifest_revision: u64,
+        expected_local_snapshot_id: Option<&str>,
+        selected_snapshot_id: &str,
+    ) -> Result<AcceptRemoteProgressOutcome, CloudLibraryServiceError> {
+        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let config = get_config()?;
+        let game = config
+            .games
+            .iter()
+            .find(|game| game.storage_key == game_id)
+            .cloned()
+            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?;
+        let original = game.get_game_snapshots_info()?;
+        let local_archive_root = profile
+            .local_archive_root
+            .as_deref()
+            .map(resolve_app_path)
+            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let resolver = V2RemoteProgressResolver::new(
+            session.get_op()?,
+            local_archive_root,
+            local_state.current_device_id,
+            resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
+            3,
+        );
+        let prepared = resolver
+            .prepare(
+                game_id,
+                manifest_revision,
+                expected_local_snapshot_id,
+                selected_snapshot_id,
+                &original,
+            )
+            .await?;
+
+        let mut staged = original.clone();
+        merge_remote_lineage(&mut staged, &prepared.lineage)?;
+        let backup_date = match self.capture_plan(&config, &game) {
+            Ok(plan) => Some(game.create_overwrite_snapshot_from_capture_plan(
+                &plan,
+                &resolve_backup_path(&config.backup_path),
+                config.settings.compression_preset,
+                config.settings.max_extra_backup_count,
+            )?),
+            Err(CapturePlanError::NoDataMatched) => None,
+            Err(error) => return Err(crate::preclude::BackupError::from(error).into()),
+        };
+
+        game.set_game_snapshots_info(&staged)?;
+        if let Err(error) = self
+            .restore_snapshot(
+                &game,
+                &prepared.selected_snapshot_id,
+                HookSource::CloudConflictResolution,
+                None,
+            )
+            .await
+        {
+            return Err(CloudLibraryServiceError::RemoteProgressApply {
+                stage: "Apply",
+                operation: error.to_string(),
+                rollback: rollback_remote_progress(self, &game, &original, backup_date.as_deref()),
+            });
+        }
+
+        let manifest_revision = match resolver
+            .commit_current_device_head(game_id, &prepared.selected_snapshot_id)
+            .await
+        {
+            Ok(revision) => revision,
+            Err(error) => {
+                return Err(CloudLibraryServiceError::RemoteProgressApply {
+                    stage: "Head publication",
+                    operation: error.to_string(),
+                    rollback: rollback_remote_progress(
+                        self,
+                        &game,
+                        &original,
+                        backup_date.as_deref(),
+                    ),
+                });
+            }
+        };
+        Ok(AcceptRemoteProgressOutcome {
+            snapshot_id: prepared.selected_snapshot_id,
+            safety_backup_created: backup_date.is_some(),
+            manifest_revision,
+        })
+    }
+}
+
+fn merge_remote_lineage(
+    local: &mut GameSnapshots,
+    lineage: &[Snapshot],
+) -> Result<(), CloudLibraryServiceError> {
+    for remote in lineage {
+        if let Some(existing) = local
+            .backups
+            .iter_mut()
+            .find(|snapshot| snapshot.date == remote.date)
+        {
+            if existing.parent != remote.parent
+                || existing.archive_format != remote.archive_format
+                || existing.created_by != remote.created_by
+                || (existing.size > 0 && remote.size > 0 && existing.size != remote.size)
+                || matches!(
+                    (&existing.archive_hash, &remote.archive_hash),
+                    (Some(local), Some(cloud)) if local != cloud
+                )
+            {
+                return Err(CloudLibraryServiceError::RemoteSnapshotIdentityConflict(
+                    remote.date.clone(),
+                ));
+            }
+            if std::path::Path::new(&remote.path).is_file() {
+                existing.path = remote.path.clone();
+            }
+            existing.size = existing.size.max(remote.size);
+            if existing.archive_hash.is_none() {
+                existing.archive_hash = remote.archive_hash.clone();
+            }
+            if existing.describe.is_empty() {
+                existing.describe = remote.describe.clone();
+            }
+        } else {
+            local.backups.push(remote.clone());
+        }
+    }
+    Ok(())
+}
+
+fn rollback_remote_progress(
+    services: &ServiceContext,
+    game: &Game,
+    original: &GameSnapshots,
+    backup_date: Option<&str>,
+) -> String {
+    let mut failures = Vec::new();
+    match backup_date {
+        Some(date) => {
+            if let Err(error) = services.restore_extra_backup(game, date, None) {
+                failures.push(format!("live save: {error}"));
+            }
+        }
+        None => failures.push("live save: no prior save data was available to archive".to_string()),
+    }
+    if let Err(error) = game.set_game_snapshots_info(original) {
+        failures.push(format!("Snapshot metadata: {error}"));
+    }
+    if failures.is_empty() {
+        "completed".to_string()
+    } else {
+        failures.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy};
+
+    fn snapshot(id: &str, parent: Option<&str>) -> Snapshot {
+        Snapshot {
+            date: id.into(),
+            describe: id.into(),
+            path: String::new(),
+            archive_format: ArchiveFormat::Zip,
+            size: 5,
+            parent: parent.map(str::to_string),
+            archive_hash: Some("0000000000000000".into()),
+            device_id: None,
+            created_by: CreatedBy::Manual,
+        }
+    }
+
+    #[test]
+    fn remote_lineage_is_merged_without_moving_any_local_head() {
+        let mut local = GameSnapshots::new("Game");
+        local.backups.push(snapshot("local", None));
+        local.set_head_for_device("pc".into(), Some("local".into()));
+
+        merge_remote_lineage(
+            &mut local,
+            &[snapshot("root", None), snapshot("remote", Some("root"))],
+        )
+        .unwrap();
+
+        assert_eq!(local.head_for_device(&"pc".to_string()).unwrap(), "local");
+        assert_eq!(local.backups.len(), 3);
+    }
+
+    #[test]
+    fn conflicting_snapshot_identity_fails_closed() {
+        let mut local = GameSnapshots::new("Game");
+        local.backups.push(snapshot("same", None));
+
+        assert!(matches!(
+            merge_remote_lineage(&mut local, &[snapshot("same", Some("other"))]),
+            Err(CloudLibraryServiceError::RemoteSnapshotIdentityConflict(id)) if id == "same"
+        ));
+    }
+}

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -1,4 +1,5 @@
 mod config;
+mod conflict_resolution;
 mod game;
 mod path_resolution;
 mod snapshot;
@@ -9,6 +10,7 @@ use std::sync::Arc;
 
 use crate::hooks::HookPipeline;
 
+pub use conflict_resolution::AcceptRemoteProgressOutcome;
 pub use snapshot_sync::{
     DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES, SnapshotSyncServiceError, build_v2_snapshot_sync_hook,
     resume_v2_snapshot_sync, run_v2_snapshot_sync_once, v2_snapshot_sync_poll_minutes,

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -6,13 +6,13 @@ use tokio_util::sync::CancellationToken;
 use crate::app_dirs::resolve_app_path;
 use crate::backup::{Game, GameSnapshots};
 use crate::cloud_sync::v2::{
-    CloudArchiveLibraryView, CloudArchiveMaterializer, CloudLibraryBootstrap,
-    CloudLibraryBootstrapError, CloudLibraryCutover, CloudLibraryCutoverError,
-    CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinReview,
-    CloudNamespaceClassification, ConflictReviewError, DeviceProfileRepository,
-    DeviceProfileRepositoryError, JoinGameDecision, KeepLocalProgressError,
-    KeepLocalProgressOutcome, MaterializationError, MaterializationOutcome, MaterializationPreview,
-    V2ConflictInspector, V2ConflictResolver, V2ConflictReview,
+    AcceptRemoteProgressError, CloudArchiveLibraryView, CloudArchiveMaterializer,
+    CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryCutover,
+    CloudLibraryCutoverError, CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError,
+    CloudLibraryJoinReview, CloudNamespaceClassification, ConflictReviewError,
+    DeviceProfileRepository, DeviceProfileRepositoryError, JoinGameDecision,
+    KeepLocalProgressError, MaterializationError, MaterializationOutcome, MaterializationPreview,
+    V2ConflictInspector, V2ConflictReview,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -109,6 +109,8 @@ pub enum CloudLibraryServiceError {
     #[error(transparent)]
     KeepLocalProgress(#[from] KeepLocalProgressError),
     #[error(transparent)]
+    AcceptRemoteProgress(#[from] AcceptRemoteProgressError),
+    #[error(transparent)]
     DeviceProfile(#[from] DeviceProfileRepositoryError),
     #[error("Game is not configured on this device: {0}")]
     GameProfileNotFound(String),
@@ -118,6 +120,14 @@ pub enum CloudLibraryServiceError {
     StorageLocationRequired,
     #[error("Cloud Cutover progress identity could not be created: {0}")]
     CutoverProgressIdentity(#[from] serde_json::Error),
+    #[error("Remote progress {stage} failed: {operation}; rollback: {rollback}")]
+    RemoteProgressApply {
+        stage: &'static str,
+        operation: String,
+        rollback: String,
+    },
+    #[error("Local and Cloud progress disagree about Snapshot identity: {0}")]
+    RemoteSnapshotIdentityConflict(String),
 }
 
 impl ServiceContext {
@@ -377,39 +387,6 @@ impl ServiceContext {
             3,
         )
         .review(game_id, &local)
-        .await?)
-    }
-
-    pub async fn keep_v2_local_progress(
-        &self,
-        game_id: &str,
-        manifest_revision: u64,
-        local_snapshot_id: &str,
-    ) -> Result<KeepLocalProgressOutcome, CloudLibraryServiceError> {
-        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
-        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
-            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
-        }
-        let local = get_config()?
-            .games
-            .into_iter()
-            .find(|game| game.storage_key == game_id)
-            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?
-            .get_game_snapshots_info()?;
-        let local_archive_root = profile
-            .local_archive_root
-            .as_deref()
-            .map(resolve_app_path)
-            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-        Ok(V2ConflictResolver::new(
-            session.get_op()?,
-            local_archive_root,
-            local_state.current_device_id,
-            resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
-            3,
-        )
-        .keep_local(game_id, manifest_revision, local_snapshot_id, &local)
         .await?)
     }
 

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -700,6 +700,11 @@
                 "keep_local_title": "Keep this device's progress?",
                 "keep_local_confirm": "The app will upload the available Snapshot history first, then move only this device's cloud position. Other devices and their progress will remain unchanged. This does not restore or modify live save files.",
                 "keep_local_success": "This device now keeps its local progress. Uploaded {count} archives.",
+                "accept_remote": "Use this progress",
+                "accept_remote_title": "Apply another device's progress?",
+                "accept_remote_confirm": "Apply “{progress}” to this device? The cloud Archive will be downloaded and verified first. If live save data is found, a mandatory safety backup is created before replacement. Keep the game closed during this operation.",
+                "accept_remote_success": "The selected progress was applied. No previous live save data needed a safety backup.",
+                "accept_remote_success_with_backup": "The selected progress was applied after creating a safety backup.",
                 "resolve_failed": "Could not resolve progress",
                 "load_failed": "Could not compare Device progress"
             }

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -700,6 +700,11 @@
                 "keep_local_title": "保留本机当前进度？",
                 "keep_local_confirm": "应用会先上传本机可用的快照历史，确认成功后仅移动本设备的云端位置。其他设备及其进度不会改变，也不会恢复或修改游戏的实时存档。",
                 "keep_local_success": "已保留本机进度，并上传 {count} 个归档。",
+                "accept_remote": "使用此进度",
+                "accept_remote_title": "应用其他设备的进度？",
+                "accept_remote_confirm": "要将“{progress}”应用到本设备吗？应用会先下载并校验云端归档；如果检测到现有实时存档，会在替换前强制创建安全备份。操作期间请保持游戏关闭。",
+                "accept_remote_success": "已应用所选进度；此前未检测到需要安全备份的实时存档。",
+                "accept_remote_success_with_backup": "已创建安全备份并应用所选进度。",
                 "resolve_failed": "无法解决进度冲突",
                 "load_failed": "无法比较设备进度"
             }


### PR DESCRIPTION
## 概要

- 只允许选择仍由其他设备声明且云端归档可校验的进度，过期审阅和本机位置变化会直接拒绝
- 下载并校验所选归档后合并其历史，保留本机原分支，不在准备阶段移动 Head
- 检测到实时存档时强制创建可定位的额外备份，Apply 或 Head 发布失败会尝试回滚
- Apply 成功后才更新当前设备 Head；其他设备位置和远端快照保持不变
- 对比界面为每个候选提供独立操作，明确不可用状态和高风险确认