### PR TITLE
feat(cloud-sync): 添加快照保留策略基础

### DIFF
--- a/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
@@ -37,6 +37,9 @@ impl SharedGame {
     /// identity, display, path-pattern, or Save Unit values.
     pub fn normalized_portable(&self) -> Self {
         let mut normalized = self.clone();
+        // Retention is shared Cloud Library policy, not part of a portable
+        // Game definition. A joining Device inherits it from the cloud side.
+        normalized.snapshot_retention = None;
         for unit in &mut normalized.save_units {
             if let SharedSaveUnitSource::ManifestPattern { constraints, .. } = &mut unit.source {
                 constraints
@@ -115,7 +118,7 @@ pub fn compare_join_libraries(
 #[cfg(test)]
 mod tests {
     use crate::backup::{LudusaviMeta, StoreGameId};
-    use crate::config::{SharedSaveUnit, V2_CONFIG_SCHEMA_VERSION};
+    use crate::config::{SharedSaveUnit, SharedSnapshotRetentionPolicy, V2_CONFIG_SCHEMA_VERSION};
     use crate::path_pattern::{ManifestPathCondition, ManifestPathConstraints, StoreKind};
 
     use super::*;
@@ -164,6 +167,7 @@ mod tests {
                     },
                 ],
             }),
+            snapshot_retention: None,
         }
     }
 
@@ -175,7 +179,7 @@ mod tests {
     }
 
     #[test]
-    fn normalization_ignores_only_unordered_portable_values() {
+    fn normalization_ignores_unordered_values_and_shared_retention_policy() {
         let original = game("game", "Game");
         let mut reordered = original.clone();
         for unit in &mut reordered.save_units {
@@ -184,6 +188,14 @@ mod tests {
             }
         }
 
+        assert_eq!(
+            original.portable_fingerprint().unwrap(),
+            reordered.portable_fingerprint().unwrap()
+        );
+
+        reordered.snapshot_retention = Some(SharedSnapshotRetentionPolicy {
+            automatic_snapshots_per_branch: 5,
+        });
         assert_eq!(
             original.portable_fingerprint().unwrap(),
             reordered.portable_fingerprint().unwrap()

--- a/crates/rgsm-core/src/cloud_sync/v2/join.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join.rs
@@ -267,7 +267,9 @@ fn apply_decisions(
                         local_game.name.clone(),
                     ));
                 }
+                let retention = latest.games[index].snapshot_retention;
                 latest.games[index] = local_game.clone();
+                latest.games[index].snapshot_retention = retention;
             }
         }
     }
@@ -319,7 +321,8 @@ mod tests {
         V2_NAMESPACE_DESCRIPTOR_PATH,
     };
     use crate::config::{
-        ConfigurationOwners, SharedSaveUnit, SharedSaveUnitSource, V2_CONFIG_SCHEMA_VERSION,
+        ConfigurationOwners, SharedSaveUnit, SharedSaveUnitSource, SharedSnapshotRetentionPolicy,
+        V2_CONFIG_SCHEMA_VERSION,
     };
 
     #[derive(Default)]
@@ -375,6 +378,7 @@ mod tests {
             }],
             next_save_unit_id: unit_id + 1,
             ludusavi_meta: None,
+            snapshot_retention: None,
         }
     }
 
@@ -468,7 +472,10 @@ mod tests {
     async fn join_adds_and_replaces_whole_games_then_publishes_profile() {
         let local_only = game("local", "Local", 1);
         let replacement = game("conflict", "Local Conflict", 2);
-        let cloud_conflict = game("conflict", "Cloud Conflict", 1);
+        let mut cloud_conflict = game("conflict", "Cloud Conflict", 1);
+        cloud_conflict.snapshot_retention = Some(SharedSnapshotRetentionPolicy {
+            automatic_snapshots_per_branch: 4,
+        });
         let local = library(vec![local_only.clone(), replacement.clone()]);
         let cloud = library(vec![cloud_conflict.clone(), game("remote", "Remote", 1)]);
         let review = build_review(&local, &cloud).unwrap();
@@ -494,7 +501,17 @@ mod tests {
             .unwrap();
 
         assert!(accepted.games.contains(&local_only));
-        assert!(accepted.games.contains(&replacement));
+        let accepted_replacement = accepted
+            .games
+            .iter()
+            .find(|game| game.storage_key == "conflict")
+            .unwrap();
+        assert_eq!(accepted_replacement.name, replacement.name);
+        assert_eq!(accepted_replacement.save_units, replacement.save_units);
+        assert_eq!(
+            accepted_replacement.snapshot_retention,
+            cloud_conflict.snapshot_retention
+        );
         assert!(
             accepted
                 .games

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -14,6 +14,8 @@ mod namespace;
 mod profile_repository;
 mod remote_resolution;
 mod repository;
+mod retention;
+mod shared_library_repository;
 mod snapshot_sync;
 
 pub use bootstrap::{CloudLibraryBootstrap, CloudLibraryBootstrapError, CloudLibraryTransport};
@@ -64,6 +66,10 @@ pub use remote_resolution::{
 pub use repository::{
     CloudManifestRepository, ManifestRepositoryError, ManifestTransport, OpenDalManifestTransport,
 };
+pub use retention::{
+    SnapshotRetentionPlan, SnapshotRetentionPlanner, SnapshotRetentionPlannerError,
+};
+pub use shared_library_repository::{SharedLibraryRepository, SharedLibraryRepositoryError};
 pub use snapshot_sync::{
     SnapshotReconciliationOutcome, SnapshotSyncCoordinator, SnapshotSyncError,
 };

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -390,6 +390,7 @@ mod tests {
             save_units: Vec::new(),
             next_save_unit_id: 0,
             ludusavi_meta: None,
+            snapshot_retention: None,
         });
         invalid_library.objects.insert(
             SHARED_LIBRARY_PATH.into(),

--- a/crates/rgsm-core/src/cloud_sync/v2/retention.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/retention.rs
@@ -1,0 +1,289 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use thiserror::Error;
+
+use super::{GameManifest, ManifestError, SnapshotState};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SnapshotRetentionPlan {
+    /// Snapshot identity is the stable set key. The set intentionally does not
+    /// imply a recency order between incomparable Branches.
+    pub candidates: BTreeSet<String>,
+}
+
+pub struct SnapshotRetentionPlanner;
+
+impl SnapshotRetentionPlanner {
+    /// Select globally deletable automatic Snapshots while preserving the
+    /// newest `limit` eligible nodes on every live Branch.
+    ///
+    /// The input must be a validated parent forest. A parent/child index and
+    /// memoized post-order live-descendant pass find maximal live endpoints in
+    /// O(V + E). A second depth-first traversal maintains one bounded lineage
+    /// window, so selection is O(V + E) time and O(V + limit) space. Missing
+    /// parents, cycles, invalid Heads, or conflicting identities fail closed
+    /// through `GameManifest::validate` before any candidate is returned.
+    pub fn plan(
+        game: &GameManifest,
+        limit: usize,
+    ) -> Result<SnapshotRetentionPlan, SnapshotRetentionPlannerError> {
+        game.validate()?;
+        let children = child_index(game);
+        let endpoints = maximal_live_endpoints(game, &children);
+        let active_heads = game.device_heads.values().cloned().collect::<BTreeSet<_>>();
+        let eligible = game
+            .snapshots
+            .iter()
+            .filter_map(|(snapshot_id, node)| {
+                let SnapshotState::Live(live) = &node.state else {
+                    return None;
+                };
+                (live.created_by.is_automatic_backup()
+                    && !live.retention_protected
+                    && !active_heads.contains(snapshot_id))
+                .then(|| snapshot_id.clone())
+            })
+            .collect::<BTreeSet<_>>();
+        let retained = retained_on_every_branch(game, &children, &endpoints, &eligible, limit);
+        Ok(SnapshotRetentionPlan {
+            candidates: eligible.difference(&retained).cloned().collect(),
+        })
+    }
+}
+
+fn child_index(game: &GameManifest) -> BTreeMap<String, Vec<String>> {
+    let mut children = game
+        .snapshots
+        .keys()
+        .map(|snapshot_id| (snapshot_id.clone(), Vec::new()))
+        .collect::<BTreeMap<_, _>>();
+    for node in game.snapshots.values() {
+        if let Some(parent) = &node.parent {
+            children
+                .get_mut(parent)
+                .expect("validated parent exists")
+                .push(node.snapshot_id.clone());
+        }
+    }
+    children
+}
+
+/// A live endpoint is a live node with no live descendant. Tombstones remain
+/// traversable, so a live node can be dominated by a live grandchild through a
+/// Tombstone. The memoized post-order map visits every edge exactly once.
+fn maximal_live_endpoints(
+    game: &GameManifest,
+    children: &BTreeMap<String, Vec<String>>,
+) -> BTreeSet<String> {
+    let roots = game
+        .snapshots
+        .values()
+        .filter(|node| node.parent.is_none())
+        .map(|node| node.snapshot_id.clone())
+        .collect::<Vec<_>>();
+    let mut subtree_has_live = BTreeMap::<String, bool>::new();
+    let mut endpoints = BTreeSet::new();
+    let mut stack = roots
+        .into_iter()
+        .rev()
+        .map(|snapshot_id| (snapshot_id, false))
+        .collect::<Vec<_>>();
+    while let Some((snapshot_id, expanded)) = stack.pop() {
+        if !expanded {
+            stack.push((snapshot_id.clone(), true));
+            for child in children[&snapshot_id].iter().rev() {
+                stack.push((child.clone(), false));
+            }
+            continue;
+        }
+        let child_has_live = children[&snapshot_id]
+            .iter()
+            .any(|child| subtree_has_live[child]);
+        let is_live = game.snapshots[&snapshot_id].state.is_live();
+        if is_live && !child_has_live {
+            endpoints.insert(snapshot_id.clone());
+        }
+        subtree_has_live.insert(snapshot_id, is_live || child_has_live);
+    }
+    endpoints
+}
+
+enum LineageVisit {
+    Enter(String),
+    Exit {
+        snapshot_id: String,
+        evicted_ancestor: Option<String>,
+    },
+}
+
+/// Walk each forest root once. Enter/Exit events backtrack one shared lineage
+/// deque instead of copying complete ancestor paths for every Branch.
+fn retained_on_every_branch(
+    game: &GameManifest,
+    children: &BTreeMap<String, Vec<String>>,
+    endpoints: &BTreeSet<String>,
+    eligible: &BTreeSet<String>,
+    limit: usize,
+) -> BTreeSet<String> {
+    let roots = game
+        .snapshots
+        .values()
+        .filter(|node| node.parent.is_none())
+        .map(|node| node.snapshot_id.clone())
+        .collect::<Vec<_>>();
+    let mut retained = BTreeSet::new();
+    let mut lineage = VecDeque::<String>::new();
+    let mut stack = roots
+        .into_iter()
+        .rev()
+        .map(LineageVisit::Enter)
+        .collect::<Vec<_>>();
+    while let Some(visit) = stack.pop() {
+        match visit {
+            LineageVisit::Enter(snapshot_id) => {
+                let evicted = if eligible.contains(&snapshot_id) {
+                    lineage.push_back(snapshot_id.clone());
+                    (lineage.len() > limit).then(|| lineage.pop_front().expect("non-empty lineage"))
+                } else {
+                    None
+                };
+                let evicted_ancestor = evicted.filter(|evicted_id| evicted_id != &snapshot_id);
+                if endpoints.contains(&snapshot_id) {
+                    retained.extend(lineage.iter().cloned());
+                }
+                stack.push(LineageVisit::Exit {
+                    snapshot_id: snapshot_id.clone(),
+                    evicted_ancestor,
+                });
+                for child in children[&snapshot_id].iter().rev() {
+                    stack.push(LineageVisit::Enter(child.clone()));
+                }
+            }
+            LineageVisit::Exit {
+                snapshot_id,
+                evicted_ancestor,
+            } => {
+                if lineage.back() == Some(&snapshot_id) {
+                    lineage.pop_back();
+                }
+                if let Some(ancestor) = evicted_ancestor {
+                    lineage.push_front(ancestor);
+                }
+            }
+        }
+    }
+    retained
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SnapshotRetentionPlannerError {
+    #[error(transparent)]
+    Manifest(#[from] ManifestError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::CreatedBy;
+    use crate::cloud_sync::v2::{ArchiveIntegrity, DeletionKind, SnapshotNode, SnapshotState};
+
+    fn node(id: &str, parent: Option<&str>, created_by: CreatedBy) -> SnapshotNode {
+        SnapshotNode::live(
+            id,
+            parent.map(str::to_string),
+            ArchiveIntegrity {
+                size: 1,
+                xxh3_64: "0000000000000000".into(),
+            },
+            created_by,
+        )
+    }
+
+    fn insert(game: &mut GameManifest, node: SnapshotNode) {
+        game.upsert_live(node).unwrap();
+    }
+
+    #[test]
+    fn linear_branch_keeps_newest_eligible_nodes_without_counting_the_head() {
+        let mut game = GameManifest::new("game");
+        insert(&mut game, node("a", None, CreatedBy::Timer));
+        insert(&mut game, node("b", Some("a"), CreatedBy::Timer));
+        insert(&mut game, node("c", Some("b"), CreatedBy::Timer));
+        insert(&mut game, node("d", Some("c"), CreatedBy::Timer));
+        insert(&mut game, node("e", Some("d"), CreatedBy::Timer));
+        game.set_head("pc".into(), "e".into());
+
+        let plan = SnapshotRetentionPlanner::plan(&game, 2).unwrap();
+
+        assert_eq!(plan.candidates, BTreeSet::from(["a".into(), "b".into()]));
+    }
+
+    #[test]
+    fn shared_ancestor_stays_when_any_branch_still_selects_it() {
+        let mut game = GameManifest::new("game");
+        insert(&mut game, node("root", None, CreatedBy::Timer));
+        insert(&mut game, node("short", Some("root"), CreatedBy::Manual));
+        insert(&mut game, node("long-1", Some("root"), CreatedBy::Timer));
+        insert(&mut game, node("long-2", Some("long-1"), CreatedBy::Timer));
+
+        let plan = SnapshotRetentionPlanner::plan(&game, 1).unwrap();
+
+        assert_eq!(plan.candidates, BTreeSet::from(["long-1".into()]));
+    }
+
+    #[test]
+    fn manual_protected_and_head_snapshots_are_never_candidates() {
+        let mut game = GameManifest::new("game");
+        insert(&mut game, node("manual", None, CreatedBy::Manual));
+        let mut protected = node("protected", Some("manual"), CreatedBy::Timer);
+        let SnapshotState::Live(live) = &mut protected.state else {
+            unreachable!()
+        };
+        live.retention_protected = true;
+        insert(&mut game, protected);
+        insert(
+            &mut game,
+            node("automatic", Some("protected"), CreatedBy::Timer),
+        );
+        insert(&mut game, node("head", Some("automatic"), CreatedBy::Timer));
+        game.set_head("deck".into(), "head".into());
+
+        let plan = SnapshotRetentionPlanner::plan(&game, 0).unwrap();
+
+        assert_eq!(plan.candidates, BTreeSet::from(["automatic".into()]));
+    }
+
+    #[test]
+    fn lineage_walk_crosses_tombstones() {
+        let mut game = GameManifest::new("game");
+        insert(&mut game, node("old", None, CreatedBy::Timer));
+        let mut deleted = node("deleted", Some("old"), CreatedBy::Timer);
+        deleted.state = SnapshotState::FinalTombstone {
+            kind: DeletionKind::User,
+        };
+        game.snapshots.insert("deleted".into(), deleted);
+        insert(
+            &mut game,
+            node("current", Some("deleted"), CreatedBy::Timer),
+        );
+        game.set_head("pc".into(), "current".into());
+
+        let plan = SnapshotRetentionPlanner::plan(&game, 0).unwrap();
+
+        assert_eq!(plan.candidates, BTreeSet::from(["old".into()]));
+    }
+
+    #[test]
+    fn malformed_graph_fails_before_returning_candidates() {
+        let mut game = GameManifest::new("game");
+        insert(&mut game, node("snapshot", None, CreatedBy::Timer));
+        game.snapshots.get_mut("snapshot").unwrap().parent = Some("missing".into());
+
+        assert!(matches!(
+            SnapshotRetentionPlanner::plan(&game, 1),
+            Err(SnapshotRetentionPlannerError::Manifest(
+                ManifestError::MissingParent { .. }
+            ))
+        ));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
@@ -1,0 +1,183 @@
+use std::sync::Arc;
+
+use thiserror::Error;
+use tokio::sync::Mutex;
+
+use super::{ManifestTransport, OpenDalManifestTransport, SHARED_LIBRARY_PATH};
+use crate::config::{OwnershipError, SharedLibrary};
+
+pub struct SharedLibraryRepository<T: ManifestTransport> {
+    transport: Arc<T>,
+    writer_lock: Mutex<()>,
+    max_attempts: usize,
+}
+
+impl SharedLibraryRepository<OpenDalManifestTransport> {
+    pub fn new(operator: opendal::Operator, max_attempts: usize) -> Self {
+        Self::with_transport(
+            OpenDalManifestTransport::new(operator, SHARED_LIBRARY_PATH),
+            max_attempts,
+        )
+    }
+}
+
+impl<T: ManifestTransport> SharedLibraryRepository<T> {
+    pub fn with_transport(transport: T, max_attempts: usize) -> Self {
+        Self {
+            transport: Arc::new(transport),
+            writer_lock: Mutex::new(()),
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn load(&self) -> Result<SharedLibrary, SharedLibraryRepositoryError> {
+        let bytes = self
+            .transport
+            .read()
+            .await?
+            .ok_or(SharedLibraryRepositoryError::Missing)?;
+        let library: SharedLibrary = serde_json::from_slice(&bytes)?;
+        library.validate()?;
+        Ok(library)
+    }
+
+    /// Compare-and-replace one complete Shared Library and verify provider
+    /// visibility. A changed remote value fails closed instead of merging or
+    /// overwriting unrelated Game definitions.
+    pub async fn compare_replace(
+        &self,
+        expected: &SharedLibrary,
+        accepted: &SharedLibrary,
+    ) -> Result<SharedLibrary, SharedLibraryRepositoryError> {
+        expected.validate()?;
+        accepted.validate()?;
+        let _guard = self.writer_lock.lock().await;
+        let accepted_bytes = serde_json::to_vec_pretty(accepted)?;
+        for _ in 0..self.max_attempts {
+            let current = self.load().await?;
+            if current == *accepted {
+                return Ok(current);
+            }
+            if current != *expected {
+                return Err(SharedLibraryRepositoryError::Stale);
+            }
+            self.transport.write(&accepted_bytes).await?;
+            if self.transport.read().await?.as_deref() == Some(accepted_bytes.as_slice()) {
+                return Ok(accepted.clone());
+            }
+        }
+        Err(SharedLibraryRepositoryError::RetryExhausted {
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SharedLibraryRepositoryError {
+    #[error("Shared Library object is missing")]
+    Missing,
+    #[error("Shared Library changed before this update could be committed")]
+    Stale,
+    #[error("Shared Library read-back verification failed after {attempts} attempts")]
+    RetryExhausted { attempts: usize },
+    #[error("Shared Library transport error: {0}")]
+    Transport(#[from] opendal::Error),
+    #[error("Shared Library serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error(transparent)]
+    Ownership(#[from] OwnershipError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex as StdMutex;
+
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::config::{SharedGame, SharedSnapshotRetentionPolicy, V2_CONFIG_SCHEMA_VERSION};
+
+    struct FakeTransport {
+        bytes: StdMutex<Option<Vec<u8>>>,
+        hide_writes: StdMutex<usize>,
+    }
+
+    #[async_trait]
+    impl ManifestTransport for FakeTransport {
+        async fn read(&self) -> Result<Option<Vec<u8>>, opendal::Error> {
+            Ok(self.bytes.lock().unwrap().clone())
+        }
+
+        async fn write(&self, bytes: &[u8]) -> Result<(), opendal::Error> {
+            let mut hidden = self.hide_writes.lock().unwrap();
+            if *hidden > 0 {
+                *hidden -= 1;
+            } else {
+                *self.bytes.lock().unwrap() = Some(bytes.to_vec());
+            }
+            Ok(())
+        }
+    }
+
+    fn library(limit: Option<u32>) -> SharedLibrary {
+        SharedLibrary {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            games: vec![SharedGame {
+                name: "Example".into(),
+                storage_key: "example".into(),
+                save_units: Vec::new(),
+                next_save_unit_id: 0,
+                ludusavi_meta: None,
+                snapshot_retention: limit.map(|automatic_snapshots_per_branch| {
+                    SharedSnapshotRetentionPolicy {
+                        automatic_snapshots_per_branch,
+                    }
+                }),
+            }],
+        }
+    }
+
+    fn repository(
+        initial: &SharedLibrary,
+        hide_writes: usize,
+        attempts: usize,
+    ) -> SharedLibraryRepository<FakeTransport> {
+        SharedLibraryRepository::with_transport(
+            FakeTransport {
+                bytes: StdMutex::new(Some(serde_json::to_vec_pretty(initial).unwrap())),
+                hide_writes: StdMutex::new(hide_writes),
+            },
+            attempts,
+        )
+    }
+
+    #[tokio::test]
+    async fn compare_replace_retries_provider_visibility() {
+        let expected = library(None);
+        let accepted = library(Some(3));
+        let repository = repository(&expected, 1, 3);
+
+        assert_eq!(
+            repository
+                .compare_replace(&expected, &accepted)
+                .await
+                .unwrap(),
+            accepted
+        );
+    }
+
+    #[tokio::test]
+    async fn compare_replace_never_overwrites_a_changed_library() {
+        let expected = library(None);
+        let changed = library(Some(5));
+        let repository = repository(&changed, 0, 3);
+
+        assert!(matches!(
+            repository
+                .compare_replace(&expected, &library(Some(3)))
+                .await,
+            Err(SharedLibraryRepositoryError::Stale)
+        ));
+        assert_eq!(repository.load().await.unwrap(), changed);
+    }
+}

--- a/crates/rgsm-core/src/config/mod.rs
+++ b/crates/rgsm-core/src/config/mod.rs
@@ -14,7 +14,7 @@ pub use ownership::{
     CloudNamespaceGeneration, ConfigurationOwners, DeviceBehaviorSettings, DeviceGameProfile,
     DeviceProfile, DeviceSaveUnitSettings, EffectiveConfiguration, InitialCatchUpPolicy,
     LocalInterfaceSettings, LocalState, OwnershipError, SharedGame, SharedLibrary, SharedSaveUnit,
-    SharedSaveUnitSource, SyncMode, V2_CONFIG_SCHEMA_VERSION,
+    SharedSaveUnitSource, SharedSnapshotRetentionPolicy, SyncMode, V2_CONFIG_SCHEMA_VERSION,
 };
 pub use quick_actions_settings::{
     GameAutomationSettings, GameAutomationSettingsDraft, QuickActionSoundPreferences,

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -37,6 +37,8 @@ pub enum OwnershipError {
     EmptySharedGameId,
     #[error("Shared Game {game_id} contains duplicate Save Unit ID {save_unit_id}")]
     DuplicateSharedSaveUnit { game_id: String, save_unit_id: u32 },
+    #[error("Shared Game {0} has an invalid Snapshot retention limit")]
+    InvalidSnapshotRetention(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
@@ -60,6 +62,13 @@ pub struct SharedGame {
     pub save_units: Vec<SharedSaveUnit>,
     pub next_save_unit_id: u32,
     pub ludusavi_meta: Option<LudusaviMeta>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snapshot_retention: Option<SharedSnapshotRetentionPolicy>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, Type, PartialEq, Eq)]
+pub struct SharedSnapshotRetentionPolicy {
+    pub automatic_snapshots_per_branch: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type, PartialEq, Eq)]
@@ -310,6 +319,18 @@ impl ConfigurationOwners {
             .cloned()
             .collect::<HashSet<_>>();
 
+        let existing_retention = self
+            .shared_library
+            .games
+            .iter()
+            .map(|game| (game.storage_key.as_str(), game.snapshot_retention))
+            .collect::<HashMap<_, _>>();
+        for game in &mut incoming.shared_library.games {
+            game.snapshot_retention = existing_retention
+                .get(game.storage_key.as_str())
+                .copied()
+                .flatten();
+        }
         self.shared_library = incoming.shared_library;
         incoming.local_state.cloud_namespace_generation =
             self.local_state.cloud_namespace_generation;
@@ -522,6 +543,14 @@ impl SharedLibrary {
                     });
                 }
             }
+            if game
+                .snapshot_retention
+                .is_some_and(|policy| policy.automatic_snapshots_per_branch == 0)
+            {
+                return Err(OwnershipError::InvalidSnapshotRetention(
+                    game.storage_key.clone(),
+                ));
+            }
         }
         Ok(())
     }
@@ -546,6 +575,7 @@ impl From<&Game> for SharedGame {
             save_units: game.save_paths.iter().map(SharedSaveUnit::from).collect(),
             next_save_unit_id: game.next_save_unit_id,
             ludusavi_meta: game.ludusavi_meta.clone(),
+            snapshot_retention: None,
         }
     }
 }

--- a/crates/rgsm-core/src/config/ownership_tests.rs
+++ b/crates/rgsm-core/src/config/ownership_tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use super::{
     CloudNamespaceGeneration, Config, ConfigurationOwners, OwnershipError, QuickActionsSettings,
+    SharedSnapshotRetentionPolicy,
 };
 use crate::backup::{Game, SaveUnit, SaveUnitType};
 use crate::device::{Device, DeviceId};
@@ -176,6 +177,26 @@ fn normal_save_preserves_other_device_private_profile_fields() {
         Some("deck-only-selection")
     );
     assert_eq!(deck.behavior.max_extra_backup_count, 37);
+}
+
+#[test]
+fn normal_save_preserves_shared_snapshot_retention() {
+    let (config, windows_id, _) = dual_device_config();
+    let mut owners = ConfigurationOwners::from_legacy(&config, &windows_id);
+    owners.shared_library.games[0].snapshot_retention = Some(SharedSnapshotRetentionPolicy {
+        automatic_snapshots_per_branch: 7,
+    });
+    let mut edited = owners.assemble_effective().unwrap();
+    edited.games[0].name = "Edited display name".into();
+
+    owners.merge_effective(&edited).unwrap();
+
+    assert_eq!(
+        owners.shared_library.games[0].snapshot_retention,
+        Some(SharedSnapshotRetentionPolicy {
+            automatic_snapshots_per_branch: 7,
+        })
+    );
 }
 
 #[test]


### PR DESCRIPTION
## 概要

- 为共享游戏加入按分支保留自动快照的策略契约
- 添加基于快照图的线性保留规划器，保护 Head、手动快照和显式保护快照
- 添加 Shared Library 的校验与 compare-replace 写入边界，并在设备加入时继承云端策略