### PR TITLE
feat(cloud-sync): 移除废弃设备 Profile

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -886,6 +886,30 @@ pub async fn evict_local_archive(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn get_cloud_device_profiles(
+    app_handle: AppHandle,
+) -> Result<Vec<rgsm_core::services::CloudDeviceProfileView>, String> {
+    svc(&app_handle)
+        .cloud_device_profiles()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn remove_cloud_device_profile(
+    device_id: String,
+    confirmed: bool,
+    app_handle: AppHandle,
+) -> Result<rgsm_core::cloud_sync::v2::DeviceProfileRemovalOutcome, String> {
+    svc(&app_handle)
+        .remove_cloud_device_profile(&device_id, confirmed)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn materialize_all_cloud_archives(
     app_handle: AppHandle,
 ) -> Result<MaterializationOutcome, String> {

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -139,6 +139,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::set_device_game_visibility,
             ipc_handler::set_device_game_managed,
             ipc_handler::evict_local_archive,
+            ipc_handler::get_cloud_device_profiles,
+            ipc_handler::remove_cloud_device_profile,
             ipc_handler::materialize_all_cloud_archives,
             ipc_handler::set_game_sync_mode,
             ipc_handler::cloud_upload_all,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -364,6 +364,22 @@ async evictLocalArchive(gameId: string, snapshotId: string, confirmed: boolean) 
     else return { status: "error", error: e  as any };
 }
 },
+async getCloudDeviceProfiles() : Promise<Result<CloudDeviceProfileView[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_cloud_device_profiles") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async removeCloudDeviceProfile(deviceId: string, confirmed: boolean) : Promise<Result<DeviceProfileRemovalOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("remove_cloud_device_profile", { deviceId, confirmed }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async materializeAllCloudArchives() : Promise<Result<MaterializationOutcome, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("materialize_all_cloud_archives") };
@@ -824,6 +840,7 @@ export type CloudBackendCheckItemStatus = "passed" | "warning" | "failed"
 export type CloudBackendCheckOutcome = "available" | "degraded" | "unavailable"
 export type CloudBackendCheckReport = { outcome: CloudBackendCheckOutcome; items: CloudBackendCheckItem[] }
 export type CloudBackendCheckStep = "prepare_backend" | "list_files" | "write_file" | "read_file" | "verify_content" | "delete_file"
+export type CloudDeviceProfileView = { device_id: string; name: string; current: boolean; deleted: boolean; deletion_incomplete: boolean; head_count: number }
 export type CloudLibraryCutoverOutcome = { game_count: number; snapshot_count: number; unavailable_archives: number }
 export type CloudLibraryCutoverReview = { game_count: number; snapshot_count: number; declared_bytes: number }
 export type CloudLibraryJoinItem = { local_game_id: string; local_name: string; local_fingerprint: string; cloud_names: string[]; cloud_fingerprint: string | null; classification: GameJoinClassification; difference: GameDefinitionDifference }
@@ -938,6 +955,7 @@ export type CreatedBy =
 "Unknown"
 export type Device = { id: string; name: string; resources?: DeviceResource[]; next_resource_id?: number }
 export type DeviceGameStatus = { game_id: string; managed: boolean; visible: boolean }
+export type DeviceProfileRemovalOutcome = { device_id: string; removed_heads: number }
 export type DeviceResource = { id: number; source: DeviceResourceSource; kind: DeviceResourceKind }
 export type DeviceResourceKind = { type: "gameRoot"; store: StoreKind; path: string } | { type: "storeAccount"; store: StoreKind; user_id: string } | { type: "gameInstallation"; root_id: number; store: StoreKind; install_dir: string; path: string; store_game_id?: string | null }
 export type DeviceResourceSource = "manual" | "detected"

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -231,6 +231,8 @@ onMounted(load);
       class="resume-alert"
     />
 
+    <CloudDeviceProfilesPanel />
+
     <ElEmpty
       v-if="library && library.games.length === 0"
       :description="$t('sync_settings.overview.no_games')"

--- a/apps/rgsm-gui/src/components/CloudDeviceProfilesPanel.vue
+++ b/apps/rgsm-gui/src/components/CloudDeviceProfilesPanel.vue
@@ -1,0 +1,180 @@
+<script setup lang="ts">
+import { Delete, Refresh } from '@element-plus/icons-vue';
+
+import { commands, type CloudDeviceProfileView } from '../bindings';
+import { $t } from '../i18n';
+import { notifyError, notifySuccess } from '../composables/useActivityCenter';
+
+const feedback = useFeedback();
+const profiles = ref<CloudDeviceProfileView[]>([]);
+const loading = ref(false);
+const removing = ref('');
+
+async function load() {
+  loading.value = true;
+  try {
+    const result = await commands.getCloudDeviceProfiles();
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.profiles.load_failed'), result.error);
+      return;
+    }
+    profiles.value = result.data;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function remove(profile: CloudDeviceProfileView) {
+  if (!profile.deleted) {
+    try {
+      await feedback.confirm(
+        $t('sync_settings.archives.profiles.remove_confirm', { device: profile.name }),
+        $t('sync_settings.archives.profiles.remove_title'),
+        {
+          confirmButtonText: $t('sync_settings.archives.profiles.remove_action'),
+          cancelButtonText: $t('sync_settings.cancel'),
+          type: 'warning',
+        }
+      );
+    } catch {
+      return;
+    }
+  }
+  removing.value = profile.device_id;
+  try {
+    const result = await commands.removeCloudDeviceProfile(profile.device_id, true);
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.profiles.remove_incomplete'), result.error);
+      await load();
+      return;
+    }
+    notifySuccess(
+      $t('sync_settings.archives.profiles.remove_success', {
+        count: result.data.removed_heads,
+      })
+    );
+    await load();
+  } finally {
+    removing.value = '';
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <section v-loading="loading" class="profiles-panel">
+    <div class="profiles-heading">
+      <div>
+        <strong>{{ $t('sync_settings.archives.profiles.title') }}</strong>
+        <p>{{ $t('sync_settings.archives.profiles.description') }}</p>
+      </div>
+      <ElButton :icon="Refresh" circle :aria-label="$t('common.refresh')" @click="load" />
+    </div>
+    <div class="profile-list">
+      <div v-for="profile in profiles" :key="profile.device_id" class="profile-row">
+        <div class="profile-name">
+          <strong>{{ profile.name }}</strong>
+          <small>{{ profile.device_id }}</small>
+        </div>
+        <div class="profile-state">
+          <ElTag v-if="profile.current" type="primary" effect="plain">
+            {{ $t('sync_settings.archives.profiles.current') }}
+          </ElTag>
+          <ElTag v-if="profile.deleted" type="info" effect="plain">
+            {{
+              profile.deletion_incomplete
+                ? $t('sync_settings.archives.profiles.incomplete')
+                : $t('sync_settings.archives.profiles.removed')
+            }}
+          </ElTag>
+          <ElTag v-if="profile.head_count > 0" effect="plain">
+            {{ $t('sync_settings.archives.profiles.heads', { count: profile.head_count }) }}
+          </ElTag>
+          <ElButton
+            v-if="!profile.current && (!profile.deleted || profile.deletion_incomplete)"
+            :icon="profile.deleted ? Refresh : Delete"
+            text
+            type="danger"
+            :loading="removing === profile.device_id"
+            @click="remove(profile)"
+          >
+            {{
+              profile.deleted
+                ? $t('sync_settings.archives.profiles.retry')
+                : $t('sync_settings.archives.profiles.remove_action')
+            }}
+          </ElButton>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.profiles-panel {
+  margin-bottom: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 10px;
+}
+
+.profiles-heading,
+.profile-row,
+.profile-state {
+  display: flex;
+  align-items: center;
+}
+
+.profiles-heading {
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.profiles-heading p {
+  margin: 4px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 0.82rem;
+}
+
+.profile-list {
+  display: grid;
+  margin-top: 10px;
+}
+
+.profile-row {
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 44px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+
+.profile-name {
+  display: grid;
+  min-width: 0;
+}
+
+.profile-name small {
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  text-overflow: ellipsis;
+}
+
+.profile-state {
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 640px) {
+  .profile-row {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 8px 0;
+  }
+
+  .profile-state {
+    justify-content: flex-start;
+  }
+}
+</style>

--- a/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
@@ -6,9 +6,9 @@ use thiserror::Error;
 
 use super::{
     CLOUD_MANIFEST_PATH, CloudManifest, CloudNamespaceClassification, CloudNamespaceClassifier,
-    CloudNamespaceDescriptor, CloudNamespaceError, ManifestError, NamespaceTransport,
-    OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_NAMESPACE_DESCRIPTOR_PATH,
-    device_profile_path,
+    CloudNamespaceDescriptor, CloudNamespaceError, DELETION_REGISTRY_PATH, DeletionRegistry,
+    ManifestError, NamespaceTransport, OpenDalNamespaceTransport, SHARED_LIBRARY_PATH,
+    V2_NAMESPACE_DESCRIPTOR_PATH, device_profile_path,
 };
 use crate::config::{DeviceProfile, OwnershipError, SharedLibrary};
 
@@ -84,6 +84,11 @@ impl<T: CloudLibraryTransport> CloudLibraryBootstrap<T> {
             .await?;
         self.write_verified(CLOUD_MANIFEST_PATH, &pretty_bytes(&manifest)?)
             .await?;
+        self.write_verified(
+            DELETION_REGISTRY_PATH,
+            &pretty_bytes(&DeletionRegistry::default())?,
+        )
+        .await?;
         self.write_verified(&profile_path, &pretty_bytes(device_profile)?)
             .await?;
         self.write_verified(V2_NAMESPACE_DESCRIPTOR_PATH, &pretty_bytes(&descriptor)?)
@@ -228,6 +233,7 @@ mod tests {
             Some(V2_NAMESPACE_DESCRIPTOR_PATH)
         );
         assert!(state.objects.contains_key(&device_profile_path("device")));
+        assert!(state.objects.contains_key(DELETION_REGISTRY_PATH));
     }
 
     #[tokio::test]

--- a/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
@@ -1,8 +1,9 @@
 use super::{
     ArchiveIntegrity, ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudManifest,
     CloudNamespaceClassification, CloudNamespaceClassifier, CloudNamespaceDescriptor,
-    CloudNamespaceError, GameManifest, ManifestError, SHARED_LIBRARY_PATH, SnapshotNode,
-    SnapshotState, V2_NAMESPACE_DESCRIPTOR_PATH, cloud_archive_path, device_profile_path,
+    CloudNamespaceError, DELETION_REGISTRY_PATH, DeletionRegistry, GameManifest, ManifestError,
+    SHARED_LIBRARY_PATH, SnapshotNode, SnapshotState, V2_NAMESPACE_DESCRIPTOR_PATH,
+    cloud_archive_path, device_profile_path,
 };
 use crate::backup::{GameSnapshots, Snapshot, archive_path};
 use crate::cloud_sync::transfer::CloudTransfer;
@@ -343,6 +344,11 @@ impl CloudLibraryCutover {
         .await?;
         self.write_verified(CLOUD_MANIFEST_PATH, &serde_json::to_vec_pretty(manifest)?)
             .await?;
+        self.write_verified(
+            DELETION_REGISTRY_PATH,
+            &serde_json::to_vec_pretty(&DeletionRegistry::default())?,
+        )
+        .await?;
         let mut profiles = plan.device_profiles.iter().collect::<Vec<_>>();
         profiles.sort_by_key(|(device_id, _)| *device_id);
         for (device_id, profile) in profiles {

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -1,0 +1,170 @@
+use std::collections::BTreeMap;
+
+use opendal::{ErrorKind, Operator};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::DELETION_REGISTRY_PATH;
+use crate::device::DeviceId;
+
+pub const DELETION_REGISTRY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeletionRegistry {
+    pub schema_version: u32,
+    pub revision: u64,
+    pub deleted_profiles: BTreeMap<DeviceId, ProfileDeletion>,
+    pub deleted_games: BTreeMap<String, GameDeletion>,
+}
+
+impl Default for DeletionRegistry {
+    fn default() -> Self {
+        Self {
+            schema_version: DELETION_REGISTRY_SCHEMA_VERSION,
+            revision: 0,
+            deleted_profiles: BTreeMap::new(),
+            deleted_games: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProfileDeletion {
+    pub deleted_by: DeviceId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GameDeletion {
+    pub deleted_by: DeviceId,
+}
+
+pub struct DeletionRegistryRepository {
+    operator: Operator,
+    max_attempts: usize,
+}
+
+impl DeletionRegistryRepository {
+    pub fn new(operator: Operator, max_attempts: usize) -> Self {
+        Self {
+            operator,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    pub async fn load(&self) -> Result<DeletionRegistry, DeletionRegistryError> {
+        let bytes = match self.operator.read(DELETION_REGISTRY_PATH).await {
+            Ok(bytes) => bytes.to_vec(),
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Ok(DeletionRegistry::default());
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let registry: DeletionRegistry = serde_json::from_slice(&bytes)?;
+        if registry.schema_version != DELETION_REGISTRY_SCHEMA_VERSION {
+            return Err(DeletionRegistryError::UnsupportedSchema(
+                registry.schema_version,
+            ));
+        }
+        Ok(registry)
+    }
+
+    pub async fn mark_profile_deleted(
+        &self,
+        device_id: &str,
+        acting_device: &str,
+    ) -> Result<DeletionRegistry, DeletionRegistryError> {
+        self.mutate(|registry| {
+            registry
+                .deleted_profiles
+                .entry(device_id.to_string())
+                .or_insert_with(|| ProfileDeletion {
+                    deleted_by: acting_device.to_string(),
+                });
+        })
+        .await
+    }
+
+    pub async fn mark_game_deleted(
+        &self,
+        game_id: &str,
+        acting_device: &str,
+    ) -> Result<DeletionRegistry, DeletionRegistryError> {
+        self.mutate(|registry| {
+            registry
+                .deleted_games
+                .entry(game_id.to_string())
+                .or_insert_with(|| GameDeletion {
+                    deleted_by: acting_device.to_string(),
+                });
+        })
+        .await
+    }
+
+    async fn mutate(
+        &self,
+        mut change: impl FnMut(&mut DeletionRegistry),
+    ) -> Result<DeletionRegistry, DeletionRegistryError> {
+        for _ in 0..self.max_attempts {
+            let mut accepted = self.load().await?;
+            change(&mut accepted);
+            accepted.revision = accepted.revision.saturating_add(1);
+            let bytes = serde_json::to_vec_pretty(&accepted)?;
+            self.operator.write(DELETION_REGISTRY_PATH, bytes).await?;
+            if self.load().await? == accepted {
+                return Ok(accepted);
+            }
+        }
+        Err(DeletionRegistryError::RetryExhausted {
+            attempts: self.max_attempts,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DeletionRegistryError {
+    #[error("Unsupported deletion registry schema: {0}")]
+    UnsupportedSchema(u32),
+    #[error("Deletion registry update was not visible after {attempts} attempts")]
+    RetryExhausted { attempts: usize },
+    #[error("Deletion registry serialization failed: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("Deletion registry transport failed: {0}")]
+    Transport(#[from] opendal::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_registry_is_empty_and_markers_are_durable() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let repository = DeletionRegistryRepository::new(operator.clone(), 2);
+
+        assert_eq!(
+            repository.load().await.unwrap(),
+            DeletionRegistry::default()
+        );
+        repository.mark_profile_deleted("deck", "pc").await.unwrap();
+
+        let stored = repository.load().await.unwrap();
+        assert_eq!(stored.deleted_profiles["deck"].deleted_by, "pc");
+        assert!(operator.exists(DELETION_REGISTRY_PATH).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn existing_markers_are_idempotent_and_preserve_the_first_actor() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let repository = DeletionRegistryRepository::new(operator, 2);
+
+        repository.mark_profile_deleted("deck", "pc").await.unwrap();
+        let stored = repository
+            .mark_profile_deleted("deck", "laptop")
+            .await
+            .unwrap();
+
+        assert_eq!(stored.deleted_profiles["deck"].deleted_by, "pc");
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -3,6 +3,7 @@ mod conflict_resolution;
 mod conflict_review;
 mod cutover;
 mod deletion;
+mod deletion_registry;
 mod game_comparison;
 mod integrity;
 mod join;
@@ -13,6 +14,7 @@ mod materialization_models;
 #[cfg(test)]
 mod materialization_tests;
 mod namespace;
+mod profile_removal;
 mod profile_repository;
 mod remote_resolution;
 mod repository;
@@ -37,6 +39,10 @@ pub use deletion::{
     GlobalSnapshotDeletionError, OpenDalArchiveDeletionBackend, SnapshotDeletionLifecycle,
     SnapshotDeletionLifecycleError, SnapshotDeletionRequest,
 };
+pub use deletion_registry::{
+    DELETION_REGISTRY_SCHEMA_VERSION, DeletionRegistry, DeletionRegistryError,
+    DeletionRegistryRepository, GameDeletion, ProfileDeletion,
+};
 pub use game_comparison::{
     GameJoinCandidate, GameJoinClassification, GameJoinComparisonError, compare_join_libraries,
 };
@@ -59,10 +65,13 @@ pub use materialization_models::{
 };
 pub use namespace::{
     CLOUD_ARCHIVES_PREFIX, CLOUD_MANIFEST_PATH, CloudNamespaceClassification,
-    CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError, NamespaceTransport,
-    OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, V2_DEVICE_PROFILES_PREFIX,
-    V2_NAMESPACE_DESCRIPTOR_PATH, V2_NAMESPACE_PREFIX, V2_NAMESPACE_SCHEMA_VERSION,
-    cloud_archive_path, device_profile_path,
+    CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError,
+    DELETION_REGISTRY_PATH, NamespaceTransport, OpenDalNamespaceTransport, SHARED_LIBRARY_PATH,
+    V2_DEVICE_PROFILES_PREFIX, V2_NAMESPACE_DESCRIPTOR_PATH, V2_NAMESPACE_PREFIX,
+    V2_NAMESPACE_SCHEMA_VERSION, cloud_archive_path, device_profile_path,
+};
+pub use profile_removal::{
+    DeviceProfileRemoval, DeviceProfileRemovalError, DeviceProfileRemovalOutcome,
 };
 pub use profile_repository::{DeviceProfileRepository, DeviceProfileRepositoryError};
 pub use remote_resolution::{

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -21,6 +21,7 @@ pub const SHARED_LIBRARY_PATH: &str = "v2/shared-library.json";
 pub const V2_DEVICE_PROFILES_PREFIX: &str = "v2/device-profiles/";
 pub const CLOUD_MANIFEST_PATH: &str = "v2/cloud-manifest.json";
 pub const CLOUD_ARCHIVES_PREFIX: &str = "v2/archives/";
+pub const DELETION_REGISTRY_PATH: &str = "v2/deletions.json";
 const CLASSIFICATION_ENTRY_SAMPLE_LIMIT: usize = 8;
 
 pub fn device_profile_path(device_id: &str) -> String {
@@ -495,6 +496,7 @@ mod tests {
             V2_DEVICE_PROFILES_PREFIX,
             CLOUD_MANIFEST_PATH,
             CLOUD_ARCHIVES_PREFIX,
+            DELETION_REGISTRY_PATH,
         ] {
             assert!(v2_path.starts_with(V2_NAMESPACE_PREFIX));
             assert_ne!(v2_path, V1_CONFIG_PATH);

--- a/crates/rgsm-core/src/cloud_sync/v2/profile_removal.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/profile_removal.rs
@@ -1,0 +1,175 @@
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+
+use super::{
+    CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryError,
+    DeletionRegistryRepository, DeviceProfileRepository, DeviceProfileRepositoryError,
+    ManifestRepositoryError,
+};
+use crate::device::DeviceId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct DeviceProfileRemovalOutcome {
+    pub device_id: DeviceId,
+    pub removed_heads: usize,
+}
+
+pub struct DeviceProfileRemoval {
+    operator: Operator,
+    current_device_id: DeviceId,
+    max_attempts: usize,
+}
+
+impl DeviceProfileRemoval {
+    pub fn new(operator: Operator, current_device_id: DeviceId, max_attempts: usize) -> Self {
+        Self {
+            operator,
+            current_device_id,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    /// Publish a durable Profile Tombstone before removing the Profile object
+    /// and all of that Device's Heads in the same retryable operation.
+    pub async fn remove(
+        &self,
+        device_id: &str,
+        confirmed: bool,
+    ) -> Result<DeviceProfileRemovalOutcome, DeviceProfileRemovalError> {
+        if !confirmed {
+            return Err(DeviceProfileRemovalError::ConfirmationRequired);
+        }
+        if device_id == self.current_device_id {
+            return Err(DeviceProfileRemovalError::CurrentDevice);
+        }
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .mark_profile_deleted(device_id, &self.current_device_id)
+            .await?;
+        DeviceProfileRepository::new(self.operator.clone(), self.max_attempts)
+            .delete(device_id)
+            .await?;
+
+        let device_id_owned = device_id.to_string();
+        let manifest_repository = CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        );
+        let before = manifest_repository.load().await?;
+        let removed_heads = before
+            .games
+            .values()
+            .filter(|game| game.device_heads.contains_key(device_id))
+            .count();
+        manifest_repository
+            .mutate(move |manifest| {
+                for game in manifest.games.values_mut() {
+                    game.device_heads.remove(&device_id_owned);
+                }
+                Ok(())
+            })
+            .await?;
+        let verified = manifest_repository.load().await?;
+        if verified
+            .games
+            .values()
+            .any(|game| game.device_heads.contains_key(device_id))
+        {
+            return Err(DeviceProfileRemovalError::HeadsRemain(
+                device_id.to_string(),
+            ));
+        }
+        Ok(DeviceProfileRemovalOutcome {
+            device_id: device_id.to_string(),
+            removed_heads,
+        })
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DeviceProfileRemovalError {
+    #[error("Removing a Device Profile requires explicit confirmation")]
+    ConfirmationRequired,
+    #[error("The current Device Profile cannot remove itself")]
+    CurrentDevice,
+    #[error("Device {0} still owns one or more Heads after removal")]
+    HeadsRemain(DeviceId),
+    #[error(transparent)]
+    Registry(#[from] DeletionRegistryError),
+    #[error(transparent)]
+    Profile(#[from] DeviceProfileRepositoryError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestRepositoryError),
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy};
+    use crate::cloud_sync::v2::{
+        ArchiveIntegrity, CloudManifest, GameManifest, SnapshotNode, device_profile_path,
+    };
+    use crate::config::ConfigurationOwners;
+
+    #[tokio::test]
+    async fn tombstone_blocks_stale_profile_and_removes_only_matching_heads() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let owners = ConfigurationOwners::from_legacy(
+            &crate::config::Config::default(),
+            &"deck".to_string(),
+        );
+        let deck = owners.device_profiles["deck"].clone();
+        DeviceProfileRepository::new(operator.clone(), 2)
+            .publish("deck", &deck)
+            .await
+            .unwrap();
+        let mut manifest = CloudManifest::default();
+        let mut game = GameManifest::new("game");
+        game.upsert_live(SnapshotNode::live(
+            "snapshot",
+            None,
+            ArchiveIntegrity {
+                size: 1,
+                xxh3_64: "0000000000000001".into(),
+            },
+            CreatedBy::Manual,
+        ))
+        .unwrap();
+        game.snapshots.get_mut("snapshot").unwrap().archive_format = ArchiveFormat::Zip;
+        game.set_head("pc".into(), "snapshot".into());
+        game.set_head("deck".into(), "snapshot".into());
+        manifest.games.insert("game".into(), game);
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec_pretty(&manifest).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let outcome = DeviceProfileRemoval::new(operator.clone(), "pc".into(), 2)
+            .remove("deck", true)
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.removed_heads, 1);
+        assert!(!operator.exists(&device_profile_path("deck")).await.unwrap());
+        let stored = CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 2)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(stored.games["game"].device_heads.len(), 1);
+        assert!(stored.games["game"].device_heads.contains_key("pc"));
+        assert!(stored.games["game"].snapshots["snapshot"].state.is_live());
+        assert!(matches!(
+            DeviceProfileRepository::new(operator, 2)
+                .publish("deck", &deck)
+                .await,
+            Err(DeviceProfileRepositoryError::Deleted(device)) if device == "deck"
+        ));
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
@@ -1,8 +1,13 @@
+use futures_util::TryStreamExt;
 use opendal::Operator;
 use thiserror::Error;
 
-use super::device_profile_path;
+use super::{
+    DeletionRegistryError, DeletionRegistryRepository, V2_DEVICE_PROFILES_PREFIX,
+    device_profile_path,
+};
 use crate::config::{DeviceProfile, V2_CONFIG_SCHEMA_VERSION};
+use crate::device::DeviceId;
 
 pub struct DeviceProfileRepository {
     operator: Operator,
@@ -26,6 +31,16 @@ impl DeviceProfileRepository {
         acting_device_id: &str,
         profile: &DeviceProfile,
     ) -> Result<(), DeviceProfileRepositoryError> {
+        if DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .load()
+            .await?
+            .deleted_profiles
+            .contains_key(acting_device_id)
+        {
+            return Err(DeviceProfileRepositoryError::Deleted(
+                acting_device_id.to_string(),
+            ));
+        }
         if profile.schema_version != V2_CONFIG_SCHEMA_VERSION {
             return Err(DeviceProfileRepositoryError::UnsupportedSchema(
                 profile.schema_version,
@@ -54,6 +69,47 @@ impl DeviceProfileRepository {
             attempts: self.max_attempts,
         })
     }
+
+    pub async fn list(&self) -> Result<Vec<DeviceProfile>, DeviceProfileRepositoryError> {
+        let mut lister = self.operator.lister(V2_DEVICE_PROFILES_PREFIX).await?;
+        let mut profiles = Vec::new();
+        while let Some(entry) = lister.try_next().await? {
+            let path = entry.path();
+            if !path.ends_with(".json") {
+                continue;
+            }
+            let bytes = self.operator.read(path).await?;
+            let profile: DeviceProfile = serde_json::from_slice(&bytes.to_vec())?;
+            if profile.schema_version != V2_CONFIG_SCHEMA_VERSION {
+                return Err(DeviceProfileRepositoryError::UnsupportedSchema(
+                    profile.schema_version,
+                ));
+            }
+            if device_profile_path(&profile.device.id) != path {
+                return Err(DeviceProfileRepositoryError::PathIdentityMismatch {
+                    path: path.to_string(),
+                    device_id: profile.device.id,
+                });
+            }
+            profiles.push(profile);
+        }
+        profiles.sort_by(|left, right| left.device.id.cmp(&right.device.id));
+        Ok(profiles)
+    }
+
+    pub async fn delete(&self, device_id: &str) -> Result<(), DeviceProfileRepositoryError> {
+        let path = device_profile_path(device_id);
+        for _ in 0..self.max_attempts {
+            self.operator.delete(&path).await?;
+            if !self.operator.exists(&path).await? {
+                return Ok(());
+            }
+        }
+        Err(DeviceProfileRepositoryError::DeleteRetryExhausted {
+            device_id: device_id.to_string(),
+            attempts: self.max_attempts,
+        })
+    }
 }
 
 #[derive(Debug, Error)]
@@ -62,12 +118,23 @@ pub enum DeviceProfileRepositoryError {
     UnsupportedSchema(u32),
     #[error("Device {acting} cannot publish Device Profile {profile}")]
     WrongDevice { acting: String, profile: String },
+    #[error("Device Profile {0} has been permanently removed")]
+    Deleted(DeviceId),
+    #[error("Device Profile path {path} does not match embedded Device ID {device_id}")]
+    PathIdentityMismatch { path: String, device_id: DeviceId },
     #[error("Device Profile read-back verification failed after {attempts} attempts")]
     RetryExhausted { attempts: usize },
+    #[error("Device Profile {device_id} remained visible after {attempts} delete attempts")]
+    DeleteRetryExhausted {
+        device_id: DeviceId,
+        attempts: usize,
+    },
     #[error("Device Profile serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
     #[error("Device Profile transport failed: {0}")]
     Transport(#[from] opendal::Error),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
 }
 
 #[cfg(test)]
@@ -121,5 +188,9 @@ mod tests {
         ));
         repository.publish("deck", &profile()).await.unwrap();
         assert!(operator.read(&device_profile_path("deck")).await.is_ok());
+        assert_eq!(
+            repository.list().await.unwrap()[0].device.name,
+            "Steam Deck"
+        );
     }
 }

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -43,6 +43,8 @@ pub enum OwnerStoreError {
     ProfileInputsChanged,
     #[error("The Shared Library changed while it was being saved")]
     SharedLibraryInputsChanged,
+    #[error("The current Device Profile cannot remove itself")]
+    CurrentProfileRemoval,
 }
 
 pub(crate) struct OwnerStore {
@@ -268,6 +270,18 @@ impl OwnerStore {
         }
         accepted.validate()?;
         owners.shared_library = accepted.clone();
+        self.write(&owners)
+    }
+
+    pub(crate) fn remove_device_profile(&self, device_id: &str) -> Result<(), OwnerStoreError> {
+        let mut owners = self.load()?;
+        if owners.local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(OwnerStoreError::ProfileInputsChanged);
+        }
+        if owners.local_state.current_device_id == device_id {
+            return Err(OwnerStoreError::CurrentProfileRemoval);
+        }
+        owners.device_profiles.remove(device_id);
         self.write(&owners)
     }
 

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -152,6 +152,14 @@ pub(crate) fn replace_shared_library(
     Ok(())
 }
 
+pub(crate) fn remove_device_profile(device_id: &str) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    OwnerStore::runtime().remove_device_profile(device_id)?;
+    Ok(())
+}
+
 fn get_config_unlocked() -> Result<Config, ConfigError> {
     let owner_store = OwnerStore::runtime();
     if owner_store.has_authoritative_state() {

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -4,6 +4,7 @@ mod conflict_resolution;
 mod device_game_lifecycle;
 mod game;
 mod path_resolution;
+mod profile_management;
 mod retention;
 mod snapshot;
 mod snapshot_sync;
@@ -15,6 +16,7 @@ use crate::hooks::HookPipeline;
 
 pub use conflict_resolution::AcceptRemoteProgressOutcome;
 pub use device_game_lifecycle::DeviceGameStatus;
+pub use profile_management::CloudDeviceProfileView;
 pub use retention::SnapshotRetentionOutcome;
 pub use snapshot_sync::{
     DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES, LiveSaveApplyPlan, LiveSaveSyncTarget,

--- a/crates/rgsm-core/src/services/profile_management.rs
+++ b/crates/rgsm-core/src/services/profile_management.rs
@@ -1,0 +1,93 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryRepository, DeviceProfileRemoval,
+    DeviceProfileRemovalOutcome, DeviceProfileRepository,
+};
+use crate::config::{CloudNamespaceGeneration, cloud_bootstrap_inputs, remove_device_profile};
+
+use super::{CloudLibraryServiceError, ServiceContext};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct CloudDeviceProfileView {
+    pub device_id: String,
+    pub name: String,
+    pub current: bool,
+    pub deleted: bool,
+    pub deletion_incomplete: bool,
+    pub head_count: usize,
+}
+
+impl ServiceContext {
+    pub async fn cloud_device_profiles(
+        &self,
+    ) -> Result<Vec<CloudDeviceProfileView>, CloudLibraryServiceError> {
+        let (_, _, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let operator = session.get_op()?;
+        let profiles = DeviceProfileRepository::new(operator.clone(), 3)
+            .list()
+            .await?
+            .into_iter()
+            .map(|profile| (profile.device.id.clone(), profile))
+            .collect::<BTreeMap<_, _>>();
+        let registry = DeletionRegistryRepository::new(operator.clone(), 3)
+            .load()
+            .await?;
+        let manifest = CloudManifestRepository::new(operator, CLOUD_MANIFEST_PATH, 3)
+            .load()
+            .await?;
+        let device_ids = profiles
+            .keys()
+            .chain(registry.deleted_profiles.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        Ok(device_ids
+            .into_iter()
+            .map(|device_id| {
+                let profile = profiles.get(&device_id);
+                let deleted = registry.deleted_profiles.contains_key(&device_id);
+                let head_count = manifest
+                    .games
+                    .values()
+                    .filter(|game| game.device_heads.contains_key(&device_id))
+                    .count();
+                CloudDeviceProfileView {
+                    name: profile
+                        .map(|profile| profile.device.name.clone())
+                        .unwrap_or_else(|| device_id.clone()),
+                    current: device_id == local_state.current_device_id,
+                    deletion_incomplete: deleted && (profile.is_some() || head_count > 0),
+                    device_id,
+                    deleted,
+                    head_count,
+                }
+            })
+            .collect())
+    }
+
+    pub async fn remove_cloud_device_profile(
+        &self,
+        device_id: &str,
+        confirmed: bool,
+    ) -> Result<DeviceProfileRemovalOutcome, CloudLibraryServiceError> {
+        let (_, _, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let outcome =
+            DeviceProfileRemoval::new(session.get_op()?, local_state.current_device_id, 3)
+                .remove(device_id, confirmed)
+                .await?;
+        remove_device_profile(device_id)?;
+        Ok(outcome)
+    }
+}

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -9,11 +9,11 @@ use crate::cloud_sync::v2::{
     AcceptRemoteProgressError, CloudArchiveMaterializer, CloudLibraryBootstrap,
     CloudLibraryBootstrapError, CloudLibraryCutover, CloudLibraryCutoverError,
     CloudLibraryCutoverReview, CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinReview,
-    CloudNamespaceClassification, ConflictReviewError, DeviceProfileRepository,
-    DeviceProfileRepositoryError, JoinGameDecision, KeepLocalProgressError,
-    LocalArchiveEvictionError, ManifestRepositoryError, MaterializationError,
-    MaterializationOutcome, MaterializationPreview, SharedLibraryRepositoryError,
-    SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
+    CloudNamespaceClassification, ConflictReviewError, DeletionRegistryError,
+    DeviceProfileRemovalError, DeviceProfileRepository, DeviceProfileRepositoryError,
+    JoinGameDecision, KeepLocalProgressError, LocalArchiveEvictionError, ManifestRepositoryError,
+    MaterializationError, MaterializationOutcome, MaterializationPreview,
+    SharedLibraryRepositoryError, SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -133,6 +133,10 @@ pub enum CloudLibraryServiceError {
     SnapshotSync(#[from] SnapshotSyncError),
     #[error(transparent)]
     LocalArchiveEviction(#[from] LocalArchiveEvictionError),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
+    #[error(transparent)]
+    DeviceProfileRemoval(#[from] DeviceProfileRemovalError),
     #[error("Game is not configured on this device: {0}")]
     GameProfileNotFound(String),
     #[error("Game is not managed on this device: {0}")]

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -721,6 +721,21 @@
                 "stop_success": "This device stopped managing the game",
                 "management_failed": "Could not update Device management"
             },
+            "profiles": {
+                "title": "Devices in this cloud library",
+                "description": "Removing an abandoned Device blocks its stale Profile from returning and clears its progress pointers. Shared Snapshots and Archive files are not deleted.",
+                "current": "This device",
+                "heads": "{count} position(s)",
+                "removed": "Removed",
+                "incomplete": "Removal incomplete",
+                "remove_action": "Remove device",
+                "retry": "Retry cleanup",
+                "remove_title": "Permanently remove Device Profile?",
+                "remove_confirm": "Remove “{device}” from this cloud library? Its Device Profile and all of its progress pointers will be removed, and an offline stale copy cannot publish this Device ID again. Shared Snapshots and local or cloud Archive files are not deleted.",
+                "remove_success": "Device Profile removed; {count} progress pointer(s) cleared",
+                "remove_incomplete": "Device removal is incomplete; retry remains available",
+                "load_failed": "Could not load cloud Devices"
+            },
             "evict": {
                 "action": "Remove local copy",
                 "title": "Remove this Device's Archive copy?",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -721,6 +721,21 @@
                 "stop_success": "此设备已停止管理该游戏",
                 "management_failed": "无法更新本设备的管理状态"
             },
+            "profiles": {
+                "title": "此云端资料库中的设备",
+                "description": "移除废弃设备后，其陈旧 Profile 无法重新出现，设备进度指针也会被清除；共享快照和存档文件不会被删除。",
+                "current": "本设备",
+                "heads": "{count} 个进度位置",
+                "removed": "已移除",
+                "incomplete": "移除未完成",
+                "remove_action": "移除设备",
+                "retry": "重试清理",
+                "remove_title": "永久移除此设备 Profile 吗？",
+                "remove_confirm": "要从此云端资料库移除“{device}”吗？该设备的 Profile 和全部进度指针都会被移除，离线的陈旧副本也无法再次发布同一设备 ID。共享快照以及本地或云端存档文件不会被删除。",
+                "remove_success": "设备 Profile 已移除，并清除 {count} 个进度指针",
+                "remove_incomplete": "设备移除尚未完成，仍可直接重试",
+                "load_failed": "无法读取云端设备"
+            },
             "evict": {
                 "action": "移除本地副本",
                 "title": "移除此设备的存档副本吗？",


### PR DESCRIPTION
## 概要

- 添加全局删除注册表，使用耐久 Profile 标记阻止离线陈旧设备复活
- 移除废弃 Profile 后立即清除该设备在所有游戏中的 Head，并保留共享快照与归档
- 在云端设备列表展示当前、已移除和清理未完成状态，支持直接重试