### PR TITLE
feat(cloud-sync): 永久删除共享游戏

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -910,6 +910,30 @@ pub async fn remove_cloud_device_profile(
 
 #[tauri::command]
 #[specta::specta]
+pub async fn get_deleted_cloud_games(
+    app_handle: AppHandle,
+) -> Result<Vec<rgsm_core::services::DeletedCloudGameView>, String> {
+    svc(&app_handle)
+        .deleted_cloud_games()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn permanently_delete_cloud_game(
+    game_id: String,
+    confirmed: bool,
+    app_handle: AppHandle,
+) -> Result<rgsm_core::cloud_sync::v2::SharedGameDeletionOutcome, String> {
+    svc(&app_handle)
+        .permanently_delete_cloud_game(&game_id, confirmed)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn materialize_all_cloud_archives(
     app_handle: AppHandle,
 ) -> Result<MaterializationOutcome, String> {

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -141,6 +141,8 @@ pub fn run() -> anyhow::Result<()> {
             ipc_handler::evict_local_archive,
             ipc_handler::get_cloud_device_profiles,
             ipc_handler::remove_cloud_device_profile,
+            ipc_handler::get_deleted_cloud_games,
+            ipc_handler::permanently_delete_cloud_game,
             ipc_handler::materialize_all_cloud_archives,
             ipc_handler::set_game_sync_mode,
             ipc_handler::cloud_upload_all,

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -380,6 +380,22 @@ async removeCloudDeviceProfile(deviceId: string, confirmed: boolean) : Promise<R
     else return { status: "error", error: e  as any };
 }
 },
+async getDeletedCloudGames() : Promise<Result<DeletedCloudGameView[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_deleted_cloud_games") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async permanentlyDeleteCloudGame(gameId: string, confirmed: boolean) : Promise<Result<SharedGameDeletionOutcome, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("permanently_delete_cloud_game", { gameId, confirmed }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async materializeAllCloudArchives() : Promise<Result<MaterializationOutcome, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("materialize_all_cloud_archives") };
@@ -953,6 +969,7 @@ export type CreatedBy =
  * Forward-compat catch-all for variants added in future versions.
  */
 "Unknown"
+export type DeletedCloudGameView = { game_id: string; name: string; deletion_incomplete: boolean }
 export type Device = { id: string; name: string; resources?: DeviceResource[]; next_resource_id?: number }
 export type DeviceGameStatus = { game_id: string; managed: boolean; visible: boolean }
 export type DeviceProfileRemovalOutcome = { device_id: string; removed_heads: number }
@@ -1229,6 +1246,7 @@ compute_archive_hash?: boolean;
  * Verify archive hash before applying a snapshot.
  */
 verify_archive_before_apply?: boolean }
+export type SharedGameDeletionOutcome = { game_id: string; removed_snapshots: number; cleaned_profiles: number; removed_cloud_objects: number }
 /**
  * A backup archive containing all data declared by its Save Units.
  * The date is the unique indicator for a backup

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -232,6 +232,7 @@ onMounted(load);
     />
 
     <CloudDeviceProfilesPanel />
+    <CloudDeletedGamesPanel @updated="load" />
 
     <ElEmpty
       v-if="library && library.games.length === 0"
@@ -376,6 +377,7 @@ onMounted(load);
             {{ $t('sync_settings.archives.deletion_waiting') }}
           </span>
         </div>
+        <CloudGameDeletionButton :game-id="game.game_id" :game-name="game.name" @deleted="load" />
       </ElCollapseItem>
     </ElCollapse>
 

--- a/apps/rgsm-gui/src/components/CloudDeletedGamesPanel.vue
+++ b/apps/rgsm-gui/src/components/CloudDeletedGamesPanel.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { Refresh } from '@element-plus/icons-vue';
+
+import { commands, type DeletedCloudGameView } from '../bindings';
+import { $t } from '../i18n';
+import { notifyError, notifySuccess } from '../composables/useActivityCenter';
+
+const emit = defineEmits<{
+  updated: [];
+}>();
+
+const games = ref<DeletedCloudGameView[]>([]);
+const loading = ref(false);
+const retrying = ref('');
+
+async function load() {
+  loading.value = true;
+  try {
+    const result = await commands.getDeletedCloudGames();
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.games.load_deleted_failed'), result.error);
+      return;
+    }
+    games.value = result.data;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function retry(game: DeletedCloudGameView) {
+  retrying.value = game.game_id;
+  try {
+    const result = await commands.permanentlyDeleteCloudGame(game.game_id, true);
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.games.delete_incomplete'), result.error);
+    } else {
+      notifySuccess(
+        $t('sync_settings.archives.games.delete_success', {
+          snapshots: result.data.removed_snapshots,
+        })
+      );
+    }
+    await load();
+    emit('updated');
+  } finally {
+    retrying.value = '';
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <section v-if="loading || games.length > 0" v-loading="loading" class="deleted-games">
+    <div>
+      <strong>{{ $t('sync_settings.archives.games.deleted_title') }}</strong>
+      <p>{{ $t('sync_settings.archives.games.deleted_description') }}</p>
+    </div>
+    <div v-for="game in games" :key="game.game_id" class="deleted-row">
+      <span>
+        <strong>{{ game.name }}</strong>
+        <small>{{ game.game_id }}</small>
+      </span>
+      <div>
+        <ElTag :type="game.deletion_incomplete ? 'warning' : 'info'" effect="plain">
+          {{
+            game.deletion_incomplete
+              ? $t('sync_settings.archives.games.incomplete')
+              : $t('sync_settings.archives.games.removed')
+          }}
+        </ElTag>
+        <ElButton
+          v-if="game.deletion_incomplete"
+          :icon="Refresh"
+          text
+          type="warning"
+          :loading="retrying === game.game_id"
+          @click="retry(game)"
+        >
+          {{ $t('sync_settings.archives.games.retry') }}
+        </ElButton>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.deleted-games {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--el-border-color-light);
+  border-radius: 10px;
+}
+
+.deleted-games p {
+  margin: 4px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 0.82rem;
+}
+
+.deleted-row,
+.deleted-row > span,
+.deleted-row > div {
+  display: flex;
+}
+
+.deleted-row {
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--el-border-color-lighter);
+}
+
+.deleted-row > span {
+  min-width: 0;
+  flex-direction: column;
+}
+
+.deleted-row small {
+  overflow: hidden;
+  color: var(--el-text-color-secondary);
+  text-overflow: ellipsis;
+}
+
+.deleted-row > div {
+  align-items: center;
+  gap: 6px;
+}
+</style>

--- a/apps/rgsm-gui/src/components/CloudGameDeletionButton.vue
+++ b/apps/rgsm-gui/src/components/CloudGameDeletionButton.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { Delete } from '@element-plus/icons-vue';
+
+import { commands } from '../bindings';
+import { $t } from '../i18n';
+import { notifyError, notifySuccess } from '../composables/useActivityCenter';
+
+const props = defineProps<{
+  gameId: string;
+  gameName: string;
+}>();
+const emit = defineEmits<{
+  deleted: [];
+}>();
+
+const feedback = useFeedback();
+const deleting = ref(false);
+
+async function permanentlyDelete() {
+  try {
+    await feedback.confirm(
+      $t('sync_settings.archives.games.delete_confirm', { game: props.gameName }),
+      $t('sync_settings.archives.games.delete_title'),
+      {
+        confirmButtonText: $t('sync_settings.archives.games.delete_action'),
+        cancelButtonText: $t('sync_settings.cancel'),
+        type: 'error',
+      }
+    );
+  } catch {
+    return;
+  }
+
+  deleting.value = true;
+  try {
+    const result = await commands.permanentlyDeleteCloudGame(props.gameId, true);
+    if (result.status === 'error') {
+      notifyError($t('sync_settings.archives.games.delete_incomplete'), result.error);
+      emit('deleted');
+      return;
+    }
+    notifySuccess(
+      $t('sync_settings.archives.games.delete_success', {
+        snapshots: result.data.removed_snapshots,
+      })
+    );
+    emit('deleted');
+  } finally {
+    deleting.value = false;
+  }
+}
+</script>
+
+<template>
+  <div class="danger-zone">
+    <div>
+      <strong>{{ $t('sync_settings.archives.games.danger_title') }}</strong>
+      <p>{{ $t('sync_settings.archives.games.danger_description') }}</p>
+    </div>
+    <ElButton :icon="Delete" type="danger" plain :loading="deleting" @click="permanentlyDelete">
+      {{ $t('sync_settings.archives.games.delete_action') }}
+    </ElButton>
+  </div>
+</template>
+
+<style scoped>
+.danger-zone {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin: 16px 10px 8px;
+  padding: 14px 16px;
+  border: 1px solid var(--el-color-danger-light-7);
+  border-radius: 10px;
+  background: var(--el-color-danger-light-9);
+}
+
+.danger-zone p {
+  margin: 4px 0 0;
+  color: var(--el-text-color-secondary);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 640px) {
+  .danger-zone {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -36,6 +36,8 @@ pub struct ProfileDeletion {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GameDeletion {
     pub deleted_by: DeviceId,
+    #[serde(default)]
+    pub name: String,
 }
 
 pub struct DeletionRegistryRepository {
@@ -87,6 +89,7 @@ impl DeletionRegistryRepository {
     pub async fn mark_game_deleted(
         &self,
         game_id: &str,
+        game_name: &str,
         acting_device: &str,
     ) -> Result<DeletionRegistry, DeletionRegistryError> {
         self.mutate(|registry| {
@@ -95,6 +98,7 @@ impl DeletionRegistryRepository {
                 .entry(game_id.to_string())
                 .or_insert_with(|| GameDeletion {
                     deleted_by: acting_device.to_string(),
+                    name: game_name.to_string(),
                 });
         })
         .await
@@ -106,7 +110,11 @@ impl DeletionRegistryRepository {
     ) -> Result<DeletionRegistry, DeletionRegistryError> {
         for _ in 0..self.max_attempts {
             let mut accepted = self.load().await?;
+            let previous = accepted.clone();
             change(&mut accepted);
+            if accepted == previous {
+                return Ok(accepted);
+            }
             accepted.revision = accepted.revision.saturating_add(1);
             let bytes = serde_json::to_vec_pretty(&accepted)?;
             self.operator.write(DELETION_REGISTRY_PATH, bytes).await?;
@@ -166,5 +174,23 @@ mod tests {
             .unwrap();
 
         assert_eq!(stored.deleted_profiles["deck"].deleted_by, "pc");
+    }
+
+    #[tokio::test]
+    async fn game_marker_preserves_the_first_name_and_actor() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let repository = DeletionRegistryRepository::new(operator, 2);
+
+        repository
+            .mark_game_deleted("game", "Original", "pc")
+            .await
+            .unwrap();
+        let stored = repository
+            .mark_game_deleted("game", "Stale", "deck")
+            .await
+            .unwrap();
+
+        assert_eq!(stored.deleted_games["game"].name, "Original");
+        assert_eq!(stored.deleted_games["game"].deleted_by, "pc");
     }
 }

--- a/crates/rgsm-core/src/cloud_sync/v2/game_deletion.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/game_deletion.rs
@@ -1,0 +1,490 @@
+use std::path::{Component, Path, PathBuf};
+
+use futures_util::TryStreamExt;
+use opendal::Operator;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+use thiserror::Error;
+
+use super::{
+    CLOUD_ARCHIVES_PREFIX, CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryError,
+    DeletionRegistryRepository, DeviceProfileRepository, DeviceProfileRepositoryError,
+    ManifestRepositoryError, SharedLibraryRepository, SharedLibraryRepositoryError,
+};
+use crate::device::DeviceId;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct SharedGameDeletionOutcome {
+    pub game_id: String,
+    pub removed_snapshots: usize,
+    pub cleaned_profiles: usize,
+    pub removed_cloud_objects: usize,
+}
+
+pub struct SharedGameDeletion {
+    operator: Operator,
+    local_archive_root: PathBuf,
+    current_device_id: DeviceId,
+    max_attempts: usize,
+}
+
+impl SharedGameDeletion {
+    pub fn new(
+        operator: Operator,
+        local_archive_root: PathBuf,
+        current_device_id: DeviceId,
+        max_attempts: usize,
+    ) -> Self {
+        Self {
+            operator,
+            local_archive_root,
+            current_device_id,
+            max_attempts: max_attempts.max(1),
+        }
+    }
+
+    /// Permanently remove one shared Game after its global marker is durable.
+    ///
+    /// Every step is idempotent so an interrupted operation can be retried
+    /// directly. The marker is never removed and therefore always dominates
+    /// stale Shared Library, Profile, Manifest, and Archive writes.
+    pub async fn delete(
+        &self,
+        game_id: &str,
+        game_name: &str,
+        confirmed: bool,
+    ) -> Result<SharedGameDeletionOutcome, SharedGameDeletionError> {
+        if !confirmed {
+            return Err(SharedGameDeletionError::ConfirmationRequired);
+        }
+        validate_game_id(game_id)?;
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts);
+        registry
+            .mark_game_deleted(game_id, game_name, &self.current_device_id)
+            .await?;
+
+        let manifest = CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        );
+        let before = manifest.load().await?;
+        let removed_snapshots = before
+            .games
+            .get(game_id)
+            .map_or(0, |game| game.snapshots.len());
+        let archive_prefix = cloud_game_archive_prefix(game_id)?;
+        let removed_cloud_objects = self.list_cloud_objects(&archive_prefix).await?.len();
+        remove_local_game_directory(&self.local_archive_root, game_id).await?;
+        self.remove_cloud_archives(&archive_prefix).await?;
+
+        let shared = SharedLibraryRepository::new(self.operator.clone(), self.max_attempts);
+        let expected = shared.load().await?;
+        if expected
+            .games
+            .iter()
+            .any(|game| game.storage_key == game_id)
+        {
+            let mut accepted = expected.clone();
+            accepted.games.retain(|game| game.storage_key != game_id);
+            shared.compare_replace(&expected, &accepted).await?;
+        }
+
+        let profiles = DeviceProfileRepository::new(self.operator.clone(), self.max_attempts);
+        let cleaned_profiles = profiles.remove_deleted_game_state().await?;
+
+        let deleted_game_ids = registry
+            .load()
+            .await?
+            .deleted_games
+            .into_keys()
+            .collect::<Vec<_>>();
+        if before
+            .games
+            .keys()
+            .any(|game_id| deleted_game_ids.contains(game_id))
+        {
+            manifest
+                .mutate(move |accepted| {
+                    for deleted_game_id in &deleted_game_ids {
+                        accepted.games.remove(deleted_game_id);
+                    }
+                    Ok(())
+                })
+                .await?;
+        }
+
+        self.verify(game_id, game_name, &archive_prefix).await?;
+
+        Ok(SharedGameDeletionOutcome {
+            game_id: game_id.to_string(),
+            removed_snapshots,
+            cleaned_profiles,
+            removed_cloud_objects,
+        })
+    }
+
+    async fn remove_cloud_archives(&self, prefix: &str) -> Result<(), SharedGameDeletionError> {
+        for _ in 0..self.max_attempts {
+            self.operator.delete_with(prefix).recursive(true).await?;
+            if self.list_cloud_objects(prefix).await?.is_empty() {
+                return Ok(());
+            }
+        }
+        Err(SharedGameDeletionError::CloudArchivesRemain(
+            prefix.to_string(),
+        ))
+    }
+
+    async fn list_cloud_objects(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<String>, SharedGameDeletionError> {
+        let mut lister = self.operator.lister(prefix).await?;
+        let mut paths = Vec::new();
+        while let Some(entry) = lister.try_next().await? {
+            paths.push(entry.path().to_string());
+        }
+        Ok(paths)
+    }
+
+    async fn verify(
+        &self,
+        game_id: &str,
+        game_name: &str,
+        archive_prefix: &str,
+    ) -> Result<(), SharedGameDeletionError> {
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .load()
+            .await?;
+        if !registry.deleted_games.contains_key(game_id) {
+            return Err(SharedGameDeletionError::MarkerMissing(game_id.to_string()));
+        }
+        if SharedLibraryRepository::new(self.operator.clone(), self.max_attempts)
+            .load()
+            .await?
+            .games
+            .iter()
+            .any(|game| game.storage_key == game_id)
+        {
+            return Err(SharedGameDeletionError::SharedDefinitionRemains(
+                game_id.to_string(),
+            ));
+        }
+        if DeviceProfileRepository::new(self.operator.clone(), self.max_attempts)
+            .list()
+            .await?
+            .into_iter()
+            .filter(|profile| !registry.deleted_profiles.contains_key(&profile.device.id))
+            .any(|profile| profile.references_game(game_id, game_name))
+        {
+            return Err(SharedGameDeletionError::ProfileStateRemains(
+                game_id.to_string(),
+            ));
+        }
+        if CloudManifestRepository::new(
+            self.operator.clone(),
+            CLOUD_MANIFEST_PATH,
+            self.max_attempts,
+        )
+        .load()
+        .await?
+        .games
+        .contains_key(game_id)
+        {
+            return Err(SharedGameDeletionError::ManifestStateRemains(
+                game_id.to_string(),
+            ));
+        }
+        if !self.list_cloud_objects(archive_prefix).await?.is_empty() {
+            return Err(SharedGameDeletionError::CloudArchivesRemain(
+                archive_prefix.to_string(),
+            ));
+        }
+        if self.local_archive_root.join(game_id).exists() {
+            return Err(SharedGameDeletionError::LocalArchivesRemain(
+                game_id.to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub(crate) async fn remove_local_game_directory(
+    local_archive_root: &Path,
+    game_id: &str,
+) -> Result<(), SharedGameDeletionError> {
+    validate_game_id(game_id)?;
+    let path = local_archive_root.join(game_id);
+    match tokio::fs::remove_dir_all(&path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+pub(crate) fn cloud_game_archive_prefix(game_id: &str) -> Result<String, SharedGameDeletionError> {
+    validate_game_id(game_id)?;
+    Ok(format!("{CLOUD_ARCHIVES_PREFIX}{game_id}/"))
+}
+
+fn validate_game_id(game_id: &str) -> Result<(), SharedGameDeletionError> {
+    let mut components = Path::new(game_id).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(SharedGameDeletionError::UnsafeGameId(game_id.to_string())),
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SharedGameDeletionError {
+    #[error("Permanent shared Game deletion requires explicit confirmation")]
+    ConfirmationRequired,
+    #[error("Game ID is not a safe archive path segment: {0}")]
+    UnsafeGameId(String),
+    #[error("Permanent deletion marker is missing for Game {0}")]
+    MarkerMissing(String),
+    #[error("Shared Game definition remains after deletion: {0}")]
+    SharedDefinitionRemains(String),
+    #[error("Device Profile state remains after deleting Game {0}")]
+    ProfileStateRemains(String),
+    #[error("Cloud Manifest state remains after deleting Game {0}")]
+    ManifestStateRemains(String),
+    #[error("Cloud Archives remain under {0}")]
+    CloudArchivesRemain(String),
+    #[error("Local Archives remain for Game {0}")]
+    LocalArchivesRemain(String),
+    #[error(transparent)]
+    Registry(#[from] DeletionRegistryError),
+    #[error(transparent)]
+    SharedLibrary(#[from] SharedLibraryRepositoryError),
+    #[error(transparent)]
+    Profile(#[from] DeviceProfileRepositoryError),
+    #[error(transparent)]
+    Manifest(#[from] ManifestRepositoryError),
+    #[error("Local Archive deletion failed: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Cloud Archive deletion failed: {0}")]
+    Transport(#[from] opendal::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use opendal::services;
+
+    use super::*;
+    use crate::backup::{ArchiveFormat, CreatedBy};
+    use crate::cloud_sync::v2::{
+        ArchiveIntegrity, CloudManifest, DeviceProfileRepositoryError, GameManifest,
+        ManifestRepositoryError, SharedLibraryRepositoryError, SnapshotNode, cloud_archive_path,
+        device_profile_path,
+    };
+    use crate::config::{
+        ConfigurationOwners, DeviceGameProfile, InitialCatchUpPolicy, SharedGame, SharedLibrary,
+        SyncMode, V2_CONFIG_SCHEMA_VERSION,
+    };
+
+    fn device_game() -> DeviceGameProfile {
+        DeviceGameProfile {
+            visible: true,
+            sync_mode: SyncMode::SnapshotSync,
+            snapshot_sync_activation_revision: Some(1),
+            snapshot_sync_local_baseline: Default::default(),
+            initial_catch_up: InitialCatchUpPolicy::KeepRemote,
+            live_save_process_name: None,
+            live_save_snapshot_on_exit: false,
+            game_path: Some("/games/example".into()),
+            binding: None,
+            auto_backup: None,
+            save_units: Default::default(),
+        }
+    }
+
+    fn shared_library() -> SharedLibrary {
+        SharedLibrary {
+            schema_version: V2_CONFIG_SCHEMA_VERSION,
+            games: vec![SharedGame {
+                name: "Example".into(),
+                storage_key: "game".into(),
+                save_units: Vec::new(),
+                next_save_unit_id: 0,
+                ludusavi_meta: None,
+                snapshot_retention: None,
+            }],
+        }
+    }
+
+    async fn fixture() -> (Operator, temp_dir::TempDir) {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        operator
+            .write(
+                super::super::SHARED_LIBRARY_PATH,
+                serde_json::to_vec_pretty(&shared_library()).unwrap(),
+            )
+            .await
+            .unwrap();
+        let mut owners =
+            ConfigurationOwners::from_legacy(&crate::config::Config::default(), &"pc".to_string());
+        let profile = owners.device_profiles.get_mut("pc").unwrap();
+        profile.games.insert("game".into(), device_game());
+        profile.quick_action.quick_action_game_id = Some("game".into());
+        DeviceProfileRepository::new(operator.clone(), 2)
+            .publish("pc", profile)
+            .await
+            .unwrap();
+
+        let mut manifest = CloudManifest::default();
+        let mut game = GameManifest::new("game");
+        game.upsert_live(SnapshotNode::live(
+            "snapshot",
+            None,
+            ArchiveIntegrity {
+                size: 4,
+                xxh3_64: "0000000000000001".into(),
+            },
+            CreatedBy::Manual,
+        ))
+        .unwrap();
+        game.set_head("pc".into(), "snapshot".into());
+        manifest.games.insert("game".into(), game);
+        operator
+            .write(
+                CLOUD_MANIFEST_PATH,
+                serde_json::to_vec_pretty(&manifest).unwrap(),
+            )
+            .await
+            .unwrap();
+        operator
+            .write(
+                &cloud_archive_path("game", "snapshot", ArchiveFormat::Zip).unwrap(),
+                b"data".to_vec(),
+            )
+            .await
+            .unwrap();
+
+        let local = temp_dir::TempDir::new().unwrap();
+        tokio::fs::create_dir_all(local.path().join("game"))
+            .await
+            .unwrap();
+        tokio::fs::write(local.path().join("game").join("snapshot.zip"), b"data")
+            .await
+            .unwrap();
+        (operator, local)
+    }
+
+    #[tokio::test]
+    async fn marker_first_deletion_removes_every_game_owned_surface_and_is_retryable() {
+        let (operator, local) = fixture().await;
+        let deletion =
+            SharedGameDeletion::new(operator.clone(), local.path().into(), "pc".into(), 2);
+
+        let outcome = deletion.delete("game", "Example", true).await.unwrap();
+
+        assert_eq!(outcome.removed_snapshots, 1);
+        assert_eq!(outcome.cleaned_profiles, 1);
+        assert_eq!(outcome.removed_cloud_objects, 1);
+        assert!(
+            DeletionRegistryRepository::new(operator.clone(), 2)
+                .load()
+                .await
+                .unwrap()
+                .deleted_games
+                .contains_key("game")
+        );
+        assert!(
+            SharedLibraryRepository::new(operator.clone(), 2)
+                .load()
+                .await
+                .unwrap()
+                .games
+                .is_empty()
+        );
+        let profile = DeviceProfileRepository::new(operator.clone(), 2)
+            .list()
+            .await
+            .unwrap()
+            .remove(0);
+        assert!(!profile.references_game("game", "Example"));
+        assert!(
+            CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 2)
+                .load()
+                .await
+                .unwrap()
+                .games
+                .is_empty()
+        );
+        assert!(!local.path().join("game").exists());
+
+        let retry = deletion.delete("game", "Example", true).await.unwrap();
+        assert_eq!(retry.removed_snapshots, 0);
+        assert_eq!(retry.removed_cloud_objects, 0);
+    }
+
+    #[tokio::test]
+    async fn durable_marker_blocks_stale_resurrection_across_all_owner_files() {
+        let (operator, local) = fixture().await;
+        let stale_library = shared_library();
+        let stale_profile: crate::config::DeviceProfile = serde_json::from_slice(
+            &operator
+                .read(&device_profile_path("pc"))
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        SharedGameDeletion::new(operator.clone(), local.path().into(), "pc".into(), 2)
+            .delete("game", "Example", true)
+            .await
+            .unwrap();
+
+        let empty_library = SharedLibraryRepository::new(operator.clone(), 2)
+            .load()
+            .await
+            .unwrap();
+        assert!(matches!(
+            SharedLibraryRepository::new(operator.clone(), 2)
+                .compare_replace(&empty_library, &stale_library)
+                .await,
+            Err(SharedLibraryRepositoryError::DeletedGame(game)) if game == "game"
+        ));
+        assert!(matches!(
+            DeviceProfileRepository::new(operator.clone(), 2)
+                .publish("pc", &stale_profile)
+                .await,
+            Err(DeviceProfileRepositoryError::DeletedGame(game)) if game == "game"
+        ));
+        assert!(matches!(
+            CloudManifestRepository::new(operator, CLOUD_MANIFEST_PATH, 2)
+                .mutate(|manifest| {
+                    manifest.game_mut("game");
+                    Ok(())
+                })
+                .await,
+            Err(ManifestRepositoryError::DeletedGame(game)) if game == "game"
+        ));
+    }
+
+    #[tokio::test]
+    async fn confirmation_and_path_validation_fail_before_mutation() {
+        let (operator, local) = fixture().await;
+        let deletion =
+            SharedGameDeletion::new(operator.clone(), local.path().into(), "pc".into(), 2);
+
+        assert!(matches!(
+            deletion.delete("game", "Example", false).await,
+            Err(SharedGameDeletionError::ConfirmationRequired)
+        ));
+        assert!(matches!(
+            deletion.delete("../other", "Unsafe", true).await,
+            Err(SharedGameDeletionError::UnsafeGameId(_))
+        ));
+        assert!(
+            DeletionRegistryRepository::new(operator, 2)
+                .load()
+                .await
+                .unwrap()
+                .deleted_games
+                .is_empty()
+        );
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -5,6 +5,7 @@ mod cutover;
 mod deletion;
 mod deletion_registry;
 mod game_comparison;
+pub(crate) mod game_deletion;
 mod integrity;
 mod join;
 mod local_eviction;
@@ -46,6 +47,7 @@ pub use deletion_registry::{
 pub use game_comparison::{
     GameJoinCandidate, GameJoinClassification, GameJoinComparisonError, compare_join_libraries,
 };
+pub use game_deletion::{SharedGameDeletion, SharedGameDeletionError, SharedGameDeletionOutcome};
 pub use integrity::{ArchiveIntegrity, ArchiveIntegrityError};
 pub use join::{
     CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinItem, CloudLibraryJoinReview,

--- a/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
@@ -31,15 +31,20 @@ impl DeviceProfileRepository {
         acting_device_id: &str,
         profile: &DeviceProfile,
     ) -> Result<(), DeviceProfileRepositoryError> {
-        if DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
             .load()
-            .await?
-            .deleted_profiles
-            .contains_key(acting_device_id)
-        {
+            .await?;
+        if registry.deleted_profiles.contains_key(acting_device_id) {
             return Err(DeviceProfileRepositoryError::Deleted(
                 acting_device_id.to_string(),
             ));
+        }
+        if let Some(game_id) = profile
+            .games
+            .keys()
+            .find(|game_id| registry.deleted_games.contains_key(*game_id))
+        {
+            return Err(DeviceProfileRepositoryError::DeletedGame(game_id.clone()));
         }
         if profile.schema_version != V2_CONFIG_SCHEMA_VERSION {
             return Err(DeviceProfileRepositoryError::UnsupportedSchema(
@@ -110,6 +115,33 @@ impl DeviceProfileRepository {
             attempts: self.max_attempts,
         })
     }
+
+    /// Remove every durably deleted Game from all live Device Profiles.
+    ///
+    /// Cleaning all known markers together keeps overlapping Game deletions
+    /// independently retryable without temporarily republishing another
+    /// deleted Game through a whole-Profile write.
+    pub async fn remove_deleted_game_state(&self) -> Result<usize, DeviceProfileRepositoryError> {
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .load()
+            .await?;
+        let mut changed = 0;
+        for mut profile in self.list().await? {
+            if registry.deleted_profiles.contains_key(&profile.device.id) {
+                continue;
+            }
+            let mut removed = false;
+            for (game_id, deletion) in &registry.deleted_games {
+                removed |= profile.remove_game_state(game_id, &deletion.name);
+            }
+            if removed {
+                let device_id = profile.device.id.clone();
+                self.publish(&device_id, &profile).await?;
+                changed += 1;
+            }
+        }
+        Ok(changed)
+    }
 }
 
 #[derive(Debug, Error)]
@@ -120,6 +152,8 @@ pub enum DeviceProfileRepositoryError {
     WrongDevice { acting: String, profile: String },
     #[error("Device Profile {0} has been permanently removed")]
     Deleted(DeviceId),
+    #[error("Game {0} has been permanently deleted")]
+    DeletedGame(String),
     #[error("Device Profile path {path} does not match embedded Device ID {device_id}")]
     PathIdentityMismatch { path: String, device_id: DeviceId },
     #[error("Device Profile read-back verification failed after {attempts} attempts")]

--- a/crates/rgsm-core/src/cloud_sync/v2/repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/repository.rs
@@ -5,7 +5,7 @@ use opendal::{ErrorKind, Operator};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
-use super::{CloudManifest, ManifestError};
+use super::{CloudManifest, DeletionRegistryError, DeletionRegistryRepository, ManifestError};
 
 #[async_trait]
 pub trait ManifestTransport: Send + Sync {
@@ -47,16 +47,20 @@ impl ManifestTransport for OpenDalManifestTransport {
 
 pub struct CloudManifestRepository<T: ManifestTransport> {
     transport: Arc<T>,
+    deletion_operator: Option<Operator>,
     writer_lock: Mutex<()>,
     max_attempts: usize,
 }
 
 impl CloudManifestRepository<OpenDalManifestTransport> {
     pub fn new(operator: Operator, object_key: impl Into<String>, max_attempts: usize) -> Self {
-        Self::with_transport(
-            OpenDalManifestTransport::new(operator, object_key),
-            max_attempts,
-        )
+        let transport = OpenDalManifestTransport::new(operator.clone(), object_key);
+        Self {
+            transport: Arc::new(transport),
+            deletion_operator: Some(operator),
+            writer_lock: Mutex::new(()),
+            max_attempts: max_attempts.max(1),
+        }
     }
 }
 
@@ -64,6 +68,7 @@ impl<T: ManifestTransport> CloudManifestRepository<T> {
     pub fn with_transport(transport: T, max_attempts: usize) -> Self {
         Self {
             transport: Arc::new(transport),
+            deletion_operator: None,
             writer_lock: Mutex::new(()),
             max_attempts: max_attempts.max(1),
         }
@@ -89,7 +94,10 @@ impl<T: ManifestTransport> CloudManifestRepository<T> {
         let _guard = self.writer_lock.lock().await;
         for _ in 0..self.max_attempts {
             let mut manifest = self.load().await?;
+            let previous = manifest.clone();
             mutation(&mut manifest)?;
+            self.reject_deleted_game_changes(&previous, &manifest)
+                .await?;
             manifest.revision = manifest
                 .revision
                 .checked_add(1)
@@ -105,6 +113,31 @@ impl<T: ManifestTransport> CloudManifestRepository<T> {
             attempts: self.max_attempts,
         })
     }
+
+    async fn reject_deleted_game_changes(
+        &self,
+        previous: &CloudManifest,
+        accepted: &CloudManifest,
+    ) -> Result<(), ManifestRepositoryError> {
+        let Some(operator) = &self.deletion_operator else {
+            return Ok(());
+        };
+        let registry = DeletionRegistryRepository::new(operator.clone(), self.max_attempts)
+            .load()
+            .await?;
+        for game_id in registry.deleted_games.keys() {
+            match (previous.games.get(game_id), accepted.games.get(game_id)) {
+                (None, Some(_)) => {
+                    return Err(ManifestRepositoryError::DeletedGame(game_id.clone()));
+                }
+                (Some(before), Some(after)) if before != after => {
+                    return Err(ManifestRepositoryError::DeletedGame(game_id.clone()));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Error)]
@@ -119,6 +152,10 @@ pub enum ManifestRepositoryError {
     RevisionOverflow,
     #[error("Cloud Manifest read-back verification failed after {attempts} attempts")]
     RetryExhausted { attempts: usize },
+    #[error("Game {0} has been permanently deleted")]
+    DeletedGame(String),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
 }
 
 #[cfg(test)]

--- a/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
@@ -3,21 +3,28 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
-use super::{ManifestTransport, OpenDalManifestTransport, SHARED_LIBRARY_PATH};
+use super::{
+    DeletionRegistryError, DeletionRegistryRepository, ManifestTransport, OpenDalManifestTransport,
+    SHARED_LIBRARY_PATH,
+};
 use crate::config::{OwnershipError, SharedLibrary};
 
 pub struct SharedLibraryRepository<T: ManifestTransport> {
     transport: Arc<T>,
+    deletion_operator: Option<opendal::Operator>,
     writer_lock: Mutex<()>,
     max_attempts: usize,
 }
 
 impl SharedLibraryRepository<OpenDalManifestTransport> {
     pub fn new(operator: opendal::Operator, max_attempts: usize) -> Self {
-        Self::with_transport(
-            OpenDalManifestTransport::new(operator, SHARED_LIBRARY_PATH),
-            max_attempts,
-        )
+        let transport = OpenDalManifestTransport::new(operator.clone(), SHARED_LIBRARY_PATH);
+        Self {
+            transport: Arc::new(transport),
+            deletion_operator: Some(operator),
+            writer_lock: Mutex::new(()),
+            max_attempts: max_attempts.max(1),
+        }
     }
 }
 
@@ -25,6 +32,7 @@ impl<T: ManifestTransport> SharedLibraryRepository<T> {
     pub fn with_transport(transport: T, max_attempts: usize) -> Self {
         Self {
             transport: Arc::new(transport),
+            deletion_operator: None,
             writer_lock: Mutex::new(()),
             max_attempts: max_attempts.max(1),
         }
@@ -61,6 +69,7 @@ impl<T: ManifestTransport> SharedLibraryRepository<T> {
             if current != *expected {
                 return Err(SharedLibraryRepositoryError::Stale);
             }
+            self.reject_deleted_game_changes(&current, accepted).await?;
             self.transport.write(&accepted_bytes).await?;
             if self.transport.read().await?.as_deref() == Some(accepted_bytes.as_slice()) {
                 return Ok(accepted.clone());
@@ -69,6 +78,39 @@ impl<T: ManifestTransport> SharedLibraryRepository<T> {
         Err(SharedLibraryRepositoryError::RetryExhausted {
             attempts: self.max_attempts,
         })
+    }
+
+    async fn reject_deleted_game_changes(
+        &self,
+        expected: &SharedLibrary,
+        accepted: &SharedLibrary,
+    ) -> Result<(), SharedLibraryRepositoryError> {
+        let Some(operator) = &self.deletion_operator else {
+            return Ok(());
+        };
+        let registry = DeletionRegistryRepository::new(operator.clone(), self.max_attempts)
+            .load()
+            .await?;
+        for game_id in registry.deleted_games.keys() {
+            let previous = expected
+                .games
+                .iter()
+                .find(|game| game.storage_key == *game_id);
+            let next = accepted
+                .games
+                .iter()
+                .find(|game| game.storage_key == *game_id);
+            match (previous, next) {
+                (None, Some(_)) => {
+                    return Err(SharedLibraryRepositoryError::DeletedGame(game_id.clone()));
+                }
+                (Some(before), Some(after)) if before != after => {
+                    return Err(SharedLibraryRepositoryError::DeletedGame(game_id.clone()));
+                }
+                _ => {}
+            }
+        }
+        Ok(())
     }
 }
 
@@ -86,6 +128,10 @@ pub enum SharedLibraryRepositoryError {
     Serialization(#[from] serde_json::Error),
     #[error(transparent)]
     Ownership(#[from] OwnershipError),
+    #[error("Game {0} has been permanently deleted")]
+    DeletedGame(String),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
 }
 
 #[cfg(test)]

--- a/crates/rgsm-core/src/config/app_config.rs
+++ b/crates/rgsm-core/src/config/app_config.rs
@@ -115,16 +115,20 @@ pub struct FavoriteTreeNode {
 
 impl FavoriteTreeNode {
     fn remove_deleted_game_leaves(nodes: &mut Vec<Self>, deleted_game: &Game) -> bool {
+        Self::remove_game_leaves(nodes, &deleted_game.name)
+    }
+
+    pub(crate) fn remove_game_leaves(nodes: &mut Vec<Self>, game_name: &str) -> bool {
         let mut changed = false;
 
         nodes.retain_mut(|node| {
-            if node.is_leaf && node.label == deleted_game.name {
+            if node.is_leaf && node.label == game_name {
                 changed = true;
                 return false;
             }
 
             if let Some(children) = &mut node.children
-                && Self::remove_deleted_game_leaves(children, deleted_game)
+                && Self::remove_game_leaves(children, game_name)
             {
                 changed = true;
             }

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -285,6 +285,30 @@ impl OwnerStore {
         self.write(&owners)
     }
 
+    pub(crate) fn remove_shared_game(
+        &self,
+        game_id: &str,
+        game_name: &str,
+    ) -> Result<(), OwnerStoreError> {
+        let mut owners = self.load()?;
+        if owners.local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(OwnerStoreError::SharedLibraryInputsChanged);
+        }
+        let previous_game_count = owners.shared_library.games.len();
+        owners
+            .shared_library
+            .games
+            .retain(|game| game.storage_key != game_id);
+        let mut changed = owners.shared_library.games.len() != previous_game_count;
+        for profile in owners.device_profiles.values_mut() {
+            changed |= profile.remove_game_state(game_id, game_name);
+        }
+        if changed {
+            self.write(&owners)?;
+        }
+        Ok(())
+    }
+
     fn write(&self, owners: &ConfigurationOwners) -> Result<(), OwnerStoreError> {
         owners.validate()?;
         let staging = self.staging_path();
@@ -378,6 +402,7 @@ fn profile_file_name(device_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backup::Game;
     use crate::device::Device;
 
     fn store() -> (temp_dir::TempDir, OwnerStore) {
@@ -498,6 +523,44 @@ mod tests {
                 .as_deref(),
             Some("deck-only")
         );
+    }
+
+    #[test]
+    fn shared_game_removal_cleans_every_local_profile() {
+        let (_root, store) = store();
+        let mut input = config(get_current_device_id(), "before");
+        add_device(&mut input, "steam-deck", "Steam Deck");
+        input.games.push(Game {
+            name: "Example".into(),
+            storage_key: "game".into(),
+            save_paths: Vec::new(),
+            game_paths: Default::default(),
+            next_save_unit_id: 0,
+            cloud_sync_enabled: false,
+            auto_backup: None,
+            ludusavi_meta: None,
+            device_bindings: Default::default(),
+        });
+        input.quick_action.quick_action_game_id = Some("game".into());
+        store.initialize_from_legacy(&input).unwrap();
+        let mut owners = store.load().unwrap();
+        owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        owners
+            .device_profiles
+            .get_mut("steam-deck")
+            .unwrap()
+            .quick_action
+            .quick_action_game_id = Some("game".into());
+        store.write(&owners).unwrap();
+
+        store.remove_shared_game("game", "Example").unwrap();
+
+        let stored = store.load().unwrap();
+        assert!(stored.shared_library.games.is_empty());
+        assert!(stored.device_profiles.values().all(|profile| {
+            !profile.games.contains_key("game")
+                && profile.quick_action.quick_action_game_id.is_none()
+        }));
     }
 
     #[test]

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -100,6 +100,23 @@ pub struct DeviceProfile {
     pub behavior: DeviceBehaviorSettings,
 }
 
+impl DeviceProfile {
+    pub(crate) fn remove_game_state(&mut self, game_id: &str, game_name: &str) -> bool {
+        let game_changed = self.games.remove(game_id).is_some();
+        let quick_action_changed = self.quick_action.remove_game_reference(game_id, game_name);
+        let favorites_changed =
+            FavoriteTreeNode::remove_game_leaves(&mut self.private_favorites, game_name);
+        game_changed || quick_action_changed || favorites_changed
+    }
+
+    pub(crate) fn references_game(&self, game_id: &str, game_name: &str) -> bool {
+        self.games.contains_key(game_id)
+            || self
+                .quick_action
+                .references_game_identity(game_id, game_name)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, Type)]
 pub struct DeviceGameProfile {
     pub visible: bool,

--- a/crates/rgsm-core/src/config/quick_actions_settings.rs
+++ b/crates/rgsm-core/src/config/quick_actions_settings.rs
@@ -123,13 +123,14 @@ impl QuickActionsSettings {
     }
 
     pub fn remove_deleted_game_reference(&mut self, deleted_game: &Game) -> bool {
+        self.remove_game_reference(&deleted_game.storage_key, &deleted_game.name)
+    }
+
+    pub(crate) fn remove_game_reference(&mut self, game_id: &str, game_name: &str) -> bool {
         let should_clear = self
             .quick_action_game_id
             .as_deref()
-            .is_some_and(|identity| {
-                (!deleted_game.storage_key.is_empty() && identity == deleted_game.storage_key)
-                    || identity == deleted_game.name
-            });
+            .is_some_and(|identity| identity == game_id || identity == game_name);
 
         if should_clear {
             self.quick_action_game_id = None;
@@ -137,9 +138,19 @@ impl QuickActionsSettings {
 
         let before_len = self.game_automations.len();
         self.game_automations
-            .retain(|automation| !automation.references_game(deleted_game));
+            .retain(|automation| !automation.references_game_identity(game_id, game_name));
 
         should_clear || before_len != self.game_automations.len()
+    }
+
+    pub(crate) fn references_game_identity(&self, game_id: &str, game_name: &str) -> bool {
+        self.quick_action_game_id
+            .as_deref()
+            .is_some_and(|identity| identity == game_id || identity == game_name)
+            || self
+                .game_automations
+                .iter()
+                .any(|automation| automation.references_game_identity(game_id, game_name))
     }
 
     pub fn sync_updated_game_reference(&mut self, previous_game: &Game, updated_game: &Game) {
@@ -285,11 +296,14 @@ pub struct GameAutomationSettings {
 
 impl GameAutomationSettings {
     pub fn references_game(&self, game: &Game) -> bool {
-        if !self.storage_key.is_empty() && !game.storage_key.is_empty() {
-            return self.storage_key == game.storage_key;
-        }
+        self.references_game_identity(&game.storage_key, &game.name)
+    }
 
-        self.game_name == game.name
+    fn references_game_identity(&self, game_id: &str, game_name: &str) -> bool {
+        if !self.storage_key.is_empty() && !game_id.is_empty() {
+            return self.storage_key == game_id;
+        }
+        self.game_name == game_name
     }
 
     pub fn has_process_triggers(&self) -> bool {

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -160,6 +160,14 @@ pub(crate) fn remove_device_profile(device_id: &str) -> Result<(), ConfigError> 
     Ok(())
 }
 
+pub(crate) fn remove_shared_game(game_id: &str, game_name: &str) -> Result<(), ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    OwnerStore::runtime().remove_shared_game(game_id, game_name)?;
+    Ok(())
+}
+
 fn get_config_unlocked() -> Result<Config, ConfigError> {
     let owner_store = OwnerStore::runtime();
     if owner_store.has_authoritative_state() {

--- a/crates/rgsm-core/src/services/cloud_archive.rs
+++ b/crates/rgsm-core/src/services/cloud_archive.rs
@@ -1,4 +1,5 @@
-use crate::cloud_sync::v2::CloudArchiveLibraryView;
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{CloudArchiveLibraryView, DeletionRegistryRepository};
 use crate::config::cloud_bootstrap_inputs;
 
 use super::{CloudLibraryServiceError, ServiceContext};
@@ -7,8 +8,15 @@ impl ServiceContext {
     pub async fn cloud_archive_library(
         &self,
     ) -> Result<CloudArchiveLibraryView, CloudLibraryServiceError> {
+        super::game_deletion::converge_local_deleted_games().await?;
         super::retention::refresh_v2_snapshot_retention().await?;
-        let (library, profile, _) = cloud_bootstrap_inputs()?;
+        let (library, profile, local_state) = cloud_bootstrap_inputs()?;
+        let registry = DeletionRegistryRepository::new(
+            CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?,
+            3,
+        )
+        .load()
+        .await?;
         let game_names = library
             .games
             .iter()
@@ -19,6 +27,8 @@ impl ServiceContext {
             .await?
             .view(&game_names)
             .await?;
+        view.games
+            .retain(|game| !registry.deleted_games.contains_key(&game.game_id));
         for game in &mut view.games {
             if let Some(settings) = profile.games.get(&game.game_id) {
                 game.managed = true;

--- a/crates/rgsm-core/src/services/game_deletion.rs
+++ b/crates/rgsm-core/src/services/game_deletion.rs
@@ -1,0 +1,145 @@
+use futures_util::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use crate::app_dirs::resolve_app_path;
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryRepository,
+    DeviceProfileRepository, SharedGameDeletion, SharedGameDeletionOutcome,
+    SharedLibraryRepository,
+};
+use crate::config::{CloudNamespaceGeneration, cloud_bootstrap_inputs, remove_shared_game};
+
+use super::{CloudLibraryServiceError, ServiceContext};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type)]
+pub struct DeletedCloudGameView {
+    pub game_id: String,
+    pub name: String,
+    pub deletion_incomplete: bool,
+}
+
+impl ServiceContext {
+    pub async fn deleted_cloud_games(
+        &self,
+    ) -> Result<Vec<DeletedCloudGameView>, CloudLibraryServiceError> {
+        converge_local_deleted_games().await?;
+        let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+        let registry = DeletionRegistryRepository::new(operator.clone(), 3)
+            .load()
+            .await?;
+        let shared = SharedLibraryRepository::new(operator.clone(), 3)
+            .load()
+            .await?;
+        let manifest = CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 3)
+            .load()
+            .await?;
+        let profiles = DeviceProfileRepository::new(operator.clone(), 3)
+            .list()
+            .await?;
+        let local_root = profile.local_archive_root.as_deref().map(resolve_app_path);
+        let mut games = Vec::with_capacity(registry.deleted_games.len());
+        for (game_id, deletion) in &registry.deleted_games {
+            let name = if deletion.name.is_empty() {
+                game_id.clone()
+            } else {
+                deletion.name.clone()
+            };
+            let archive_prefix =
+                crate::cloud_sync::v2::game_deletion::cloud_game_archive_prefix(game_id)?;
+            let cloud_archives_remain = cloud_prefix_has_entries(&operator, &archive_prefix)
+                .await
+                .map_err(crate::preclude::BackendError::from)?;
+            let deletion_incomplete = shared.games.iter().any(|game| game.storage_key == *game_id)
+                || manifest.games.contains_key(game_id)
+                || profiles.iter().any(|profile| {
+                    !registry.deleted_profiles.contains_key(&profile.device.id)
+                        && profile.references_game(game_id, &name)
+                })
+                || cloud_archives_remain
+                || local_root
+                    .as_ref()
+                    .is_some_and(|root| root.join(game_id).exists());
+            games.push(DeletedCloudGameView {
+                game_id: game_id.clone(),
+                name,
+                deletion_incomplete,
+            });
+        }
+        Ok(games)
+    }
+
+    pub async fn permanently_delete_cloud_game(
+        &self,
+        game_id: &str,
+        confirmed: bool,
+    ) -> Result<SharedGameDeletionOutcome, CloudLibraryServiceError> {
+        let (library, profile, local_state) = cloud_bootstrap_inputs()?;
+        if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+            return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
+        }
+        let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+        let registry = DeletionRegistryRepository::new(operator.clone(), 3)
+            .load()
+            .await?;
+        let game_name = library
+            .games
+            .iter()
+            .find(|game| game.storage_key == game_id)
+            .map(|game| game.name.clone())
+            .or_else(|| {
+                registry
+                    .deleted_games
+                    .get(game_id)
+                    .map(|deletion| deletion.name.clone())
+            })
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?;
+        let local_root = profile
+            .local_archive_root
+            .as_deref()
+            .map(resolve_app_path)
+            .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
+        let outcome =
+            SharedGameDeletion::new(operator, local_root, local_state.current_device_id, 3)
+                .delete(game_id, &game_name, confirmed)
+                .await?;
+        remove_shared_game(game_id, &game_name)?;
+        Ok(outcome)
+    }
+}
+
+pub(crate) async fn converge_local_deleted_games() -> Result<(), CloudLibraryServiceError> {
+    let (_, profile, local_state) = cloud_bootstrap_inputs()?;
+    if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+        return Ok(());
+    }
+    let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+    let registry = DeletionRegistryRepository::new(operator, 3).load().await?;
+    for (game_id, deletion) in registry.deleted_games {
+        if let Some(root) = profile.local_archive_root.as_deref().map(resolve_app_path) {
+            crate::cloud_sync::v2::game_deletion::remove_local_game_directory(&root, &game_id)
+                .await?;
+        }
+        let name = if deletion.name.is_empty() {
+            game_id.as_str()
+        } else {
+            deletion.name.as_str()
+        };
+        remove_shared_game(&game_id, name)?;
+    }
+    Ok(())
+}
+
+async fn cloud_prefix_has_entries(
+    operator: &opendal::Operator,
+    prefix: &str,
+) -> Result<bool, opendal::Error> {
+    let mut lister = operator.lister(prefix).await?;
+    Ok(lister.try_next().await?.is_some())
+}

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -3,6 +3,7 @@ mod config;
 mod conflict_resolution;
 mod device_game_lifecycle;
 mod game;
+mod game_deletion;
 mod path_resolution;
 mod profile_management;
 mod retention;
@@ -16,6 +17,7 @@ use crate::hooks::HookPipeline;
 
 pub use conflict_resolution::AcceptRemoteProgressOutcome;
 pub use device_game_lifecycle::DeviceGameStatus;
+pub use game_deletion::DeletedCloudGameView;
 pub use profile_management::CloudDeviceProfileView;
 pub use retention::SnapshotRetentionOutcome;
 pub use snapshot_sync::{

--- a/crates/rgsm-core/src/services/snapshot_sync.rs
+++ b/crates/rgsm-core/src/services/snapshot_sync.rs
@@ -53,6 +53,7 @@ pub fn build_v2_snapshot_sync_hook(
 pub async fn run_v2_snapshot_sync_once(
     cancellation: &CancellationToken,
 ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncServiceError> {
+    super::game_deletion::converge_local_deleted_games().await?;
     super::retention::refresh_v2_snapshot_retention().await?;
     let Some(runtime) = load_runtime()? else {
         return Ok(SnapshotReconciliationOutcome::default());
@@ -117,6 +118,7 @@ pub async fn run_v2_snapshot_sync_once(
 pub async fn resume_v2_snapshot_sync(
     cancellation: &CancellationToken,
 ) -> Result<usize, SnapshotSyncServiceError> {
+    super::game_deletion::converge_local_deleted_games().await?;
     let Some(runtime) = load_runtime()? else {
         return Ok(0);
     };

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -12,7 +12,7 @@ use crate::cloud_sync::v2::{
     CloudNamespaceClassification, ConflictReviewError, DeletionRegistryError,
     DeviceProfileRemovalError, DeviceProfileRepository, DeviceProfileRepositoryError,
     JoinGameDecision, KeepLocalProgressError, LocalArchiveEvictionError, ManifestRepositoryError,
-    MaterializationError, MaterializationOutcome, MaterializationPreview,
+    MaterializationError, MaterializationOutcome, MaterializationPreview, SharedGameDeletionError,
     SharedLibraryRepositoryError, SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
 };
 use crate::cloud_sync::{
@@ -137,6 +137,8 @@ pub enum CloudLibraryServiceError {
     DeletionRegistry(#[from] DeletionRegistryError),
     #[error(transparent)]
     DeviceProfileRemoval(#[from] DeviceProfileRemovalError),
+    #[error(transparent)]
+    SharedGameDeletion(#[from] SharedGameDeletionError),
     #[error("Game is not configured on this device: {0}")]
     GameProfileNotFound(String),
     #[error("Game is not managed on this device: {0}")]
@@ -598,6 +600,7 @@ impl ServiceContext {
     pub(super) async fn converged_materializer(
         &self,
     ) -> Result<CloudArchiveMaterializer, CloudLibraryServiceError> {
+        super::game_deletion::converge_local_deleted_games().await?;
         let materializer = self.materializer()?;
         self.converge_local_tombstone_metadata(&materializer)
             .await?;

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -736,6 +736,21 @@
                 "remove_incomplete": "Device removal is incomplete; retry remains available",
                 "load_failed": "Could not load cloud Devices"
             },
+            "games": {
+                "danger_title": "Permanent shared Game deletion",
+                "danger_description": "Use this only when the Game and all of its shared history should disappear from every device.",
+                "delete_action": "Delete Game permanently",
+                "delete_title": "Permanently delete shared Game?",
+                "delete_confirm": "Permanently delete “{game}” from this cloud library? Its shared definition, complete Snapshot history, every Device position and per-Game setting, and all available local and cloud Archive copies will be removed. Offline devices will delete their remaining local copies when they next connect. This cannot be undone.",
+                "delete_success": "Shared Game permanently deleted; {snapshots} Snapshot(s) removed",
+                "delete_incomplete": "Shared Game deletion is incomplete; its permanent marker is active and cleanup can be retried",
+                "deleted_title": "Permanently deleted Games",
+                "deleted_description": "Permanent markers prevent offline or stale devices from restoring these Games.",
+                "removed": "Deleted",
+                "incomplete": "Cleanup incomplete",
+                "retry": "Retry cleanup",
+                "load_deleted_failed": "Could not load deleted Games"
+            },
             "evict": {
                 "action": "Remove local copy",
                 "title": "Remove this Device's Archive copy?",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -736,6 +736,21 @@
                 "remove_incomplete": "设备移除尚未完成，仍可直接重试",
                 "load_failed": "无法读取云端设备"
             },
+            "games": {
+                "danger_title": "永久删除共享游戏",
+                "danger_description": "仅当你希望此游戏及其全部共享历史从所有设备消失时使用。",
+                "delete_action": "永久删除游戏",
+                "delete_title": "永久删除共享游戏吗？",
+                "delete_confirm": "确定要从此云端资料库永久删除“{game}”吗？它的共享定义、完整快照历史、所有设备进度位置与游戏设置，以及各设备和云端已有的全部存档文件都会被删除。离线设备下次连接时也会删除残留的本地副本。此操作无法撤销。",
+                "delete_success": "共享游戏已永久删除，并移除 {snapshots} 个快照",
+                "delete_incomplete": "共享游戏删除尚未完成；永久删除标记已生效，可直接重试清理",
+                "deleted_title": "已永久删除的游戏",
+                "deleted_description": "永久删除标记会阻止离线或陈旧设备重新带回这些游戏。",
+                "removed": "已删除",
+                "incomplete": "清理未完成",
+                "retry": "重试清理",
+                "load_deleted_failed": "无法读取已删除游戏"
+            },
             "evict": {
                 "action": "移除本地副本",
                 "title": "移除此设备的存档副本吗？",


### PR DESCRIPTION
## 概要

- 先发布耐久 Game 删除标记，再立即移除本地与云端存档文件
- 清理共享定义、完整快照图、设备 Head 及所有活动设备的游戏配置，并阻止陈旧状态复活
- 提供独立危险区、永久删除记录和清理未完成的直接重试入口