### PR TITLE
fix(cloud-sync): 修复 V2 合并后的同步安全问题

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -154,6 +154,15 @@ async fn rebuild_pipeline_and_fire_config_saved(
         .await;
 }
 
+async fn reload_pipeline_and_fire_config_saved(
+    app_handle: &AppHandle,
+    source: HookSource,
+) -> Result<(), String> {
+    let config = get_config().map_err(|error| error.to_string())?;
+    rebuild_pipeline_and_fire_config_saved(app_handle, config, source).await;
+    Ok(())
+}
+
 fn batch_report_failed_item(report: &BatchSyncReport) -> Option<String> {
     let mut items = Vec::with_capacity(report.games.len() + 1);
     items.push(&report.config.status);
@@ -727,6 +736,10 @@ pub async fn keep_v2_local_progress(
     local_snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::cloud_sync::v2::KeepLocalProgressOutcome, String> {
+    let operation_lock = app_handle
+        .state::<crate::snapshot_sync::SnapshotSyncRuntimeState>()
+        .operation_lock();
+    let _guard = operation_lock.lock().await;
     svc(&app_handle)
         .keep_v2_local_progress(&game_id, manifest_revision, &local_snapshot_id)
         .await
@@ -742,6 +755,10 @@ pub async fn accept_v2_remote_progress(
     selected_snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::AcceptRemoteProgressOutcome, String> {
+    let operation_lock = app_handle
+        .state::<crate::snapshot_sync::SnapshotSyncRuntimeState>()
+        .operation_lock();
+    let _guard = operation_lock.lock().await;
     svc(&app_handle)
         .accept_v2_remote_progress(
             &game_id,
@@ -850,10 +867,12 @@ pub async fn set_device_game_visibility(
     visible: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::DeviceGameStatus, String> {
-    svc(&app_handle)
+    let status = svc(&app_handle)
         .set_device_game_visibility(&game_id, visible)
         .await
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+    reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
+    Ok(status)
 }
 
 #[tauri::command]
@@ -864,10 +883,12 @@ pub async fn set_device_game_managed(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::DeviceGameStatus, String> {
-    svc(&app_handle)
+    let status = svc(&app_handle)
         .set_device_game_managed(&game_id, managed, confirmed)
         .await
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string())?;
+    reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
+    Ok(status)
 }
 
 #[tauri::command]

--- a/apps/rgsm-gui/src-tauri/src/quick_actions/process_monitor.rs
+++ b/apps/rgsm-gui/src-tauri/src/quick_actions/process_monitor.rs
@@ -131,11 +131,21 @@ fn merge_live_save_exit_targets(
             continue;
         };
         let key = game_key(&game);
+        if let Some(entry) = entries
+            .get_mut(&key)
+            .filter(|entry| entry.process_name == target.process_name)
+        {
+            entry.automation.on_process_exit = true;
+            continue;
+        }
+        let key = if entries.contains_key(&key) {
+            format!("{key}::live-save")
+        } else {
+            key
+        };
         entries
             .entry(key.clone())
             .and_modify(|entry| {
-                entry.process_name = target.process_name.clone();
-                entry.automation.process_name = target.process_name.clone();
                 entry.automation.on_process_exit = true;
             })
             .or_insert_with(|| MonitoredProcessGame {
@@ -379,7 +389,7 @@ mod tests {
     }
 
     #[test]
-    fn live_save_exit_target_preserves_other_process_triggers() {
+    fn live_save_exit_target_does_not_retarget_other_process_triggers() {
         let mut config = rgsm_core::config::Config::default();
         config.games.push(test_game());
         let mut existing = monitored_game(Some(60));
@@ -392,11 +402,14 @@ mod tests {
             vec![live_save_target("live-game.exe", true)],
         );
 
-        let entry = &entries["game"];
-        assert_eq!(entry.process_name, "live-game.exe");
-        assert!(entry.automation.on_process_start);
-        assert!(entry.automation.on_process_exit);
-        assert_eq!(entry.automation.in_process_interval_secs, Some(60));
+        let existing = &entries["game"];
+        assert_eq!(existing.process_name, "game.exe");
+        assert!(existing.automation.on_process_start);
+        assert!(!existing.automation.on_process_exit);
+        assert_eq!(existing.automation.in_process_interval_secs, Some(60));
+        let live_save = &entries["game::live-save"];
+        assert_eq!(live_save.process_name, "live-game.exe");
+        assert!(live_save.automation.on_process_exit);
     }
 
     #[test]

--- a/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
+++ b/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
@@ -118,6 +118,24 @@ async fn run_live_save_apply(app: &AppHandle) {
         let services = rgsm_core::services::ServiceContext::new(
             app.state::<crate::hooks::HookPipelineState>().snapshot(),
         );
+        let processes = match crate::process_util::running_process_names() {
+            Ok(processes) => processes,
+            Err(error) => {
+                warn!(
+                    target: "rgsm::cloud::v2_live_save_sync",
+                    "Skipping Live Save Apply because the final process check failed: {error}"
+                );
+                continue;
+            }
+        };
+        if crate::process_util::process_is_running(&processes, &target.process_name) {
+            info!(
+                target: "rgsm::cloud::v2_live_save_sync",
+                "Skipping Live Save Apply for {} because its process started during synchronization",
+                target.game_id
+            );
+            continue;
+        }
         match services
             .accept_v2_remote_progress(
                 &plan.game_id,

--- a/apps/rgsm-tui/src/profile_import.rs
+++ b/apps/rgsm-tui/src/profile_import.rs
@@ -2,9 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
-use rgsm_core::config::{Config, set_config_local};
+use rgsm_core::config::{Config, get_config_from_data_dir, set_config_local};
 
 const CONFIG_FILE_NAME: &str = "GameSaveManager.config.json";
+const OWNER_DIRECTORY_NAME: &str = "GameSaveManager.config.v2";
 
 #[derive(Debug, Clone)]
 pub struct ImportReport {
@@ -25,13 +26,10 @@ struct CopyStats {
 
 pub fn import_gui_profile(source: &Path, target_data_dir: &Path) -> Result<ImportReport> {
     let source_config_path = resolve_source_config_path(source)?;
-    let target_config_path = target_data_dir.join(CONFIG_FILE_NAME);
-    reject_same_config(&source_config_path, &target_config_path)?;
-
-    let source_data_dir = source_config_path
-        .parent()
-        .ok_or_else(|| anyhow!("source config has no parent directory"))?;
-    let source_config = read_config(&source_config_path)?;
+    let source_data_dir = source_data_dir(&source_config_path)?;
+    reject_same_profile(source_data_dir, target_data_dir)?;
+    let source_config = get_config_from_data_dir(source_data_dir)
+        .context("failed to read authoritative GUI config")?;
     let target_config = rgsm_core::config::get_config().context("failed to read TUI config")?;
 
     let source_backup_path = resolve_profile_path(source_data_dir, &source_config.backup_path);
@@ -55,9 +53,30 @@ pub fn import_gui_profile(source: &Path, target_data_dir: &Path) -> Result<Impor
     })
 }
 
+fn source_data_dir(config_path: &Path) -> Result<&Path> {
+    let parent = config_path
+        .parent()
+        .ok_or_else(|| anyhow!("source config has no parent directory"))?;
+    if parent
+        .file_name()
+        .is_some_and(|name| name == OWNER_DIRECTORY_NAME)
+    {
+        parent
+            .parent()
+            .ok_or_else(|| anyhow!("source owner store has no parent directory"))
+    } else {
+        Ok(parent)
+    }
+}
+
 fn resolve_source_config_path(source: &Path) -> Result<PathBuf> {
     let path = if source.is_dir() {
-        source.join(CONFIG_FILE_NAME)
+        let owner_path = source.join(OWNER_DIRECTORY_NAME);
+        if owner_path.is_dir() {
+            owner_path.join("local-state.json")
+        } else {
+            source.join(CONFIG_FILE_NAME)
+        }
     } else {
         source.to_path_buf()
     };
@@ -67,25 +86,20 @@ fn resolve_source_config_path(source: &Path) -> Result<PathBuf> {
     Ok(path)
 }
 
-fn reject_same_config(source: &Path, target: &Path) -> Result<()> {
+fn reject_same_profile(source: &Path, target: &Path) -> Result<()> {
     let source = source
         .canonicalize()
-        .with_context(|| format!("failed to resolve source config path {}", source.display()))?;
+        .with_context(|| format!("failed to resolve source profile path {}", source.display()))?;
     let target = target
         .canonicalize()
-        .with_context(|| format!("failed to resolve target config path {}", target.display()))?;
+        .with_context(|| format!("failed to resolve target profile path {}", target.display()))?;
     if source == target {
         bail!(
-            "GUI source config and TUI target config are the same file: {}",
+            "GUI source profile and TUI target profile are the same directory: {}",
             source.display()
         );
     }
     Ok(())
-}
-
-fn read_config(path: &Path) -> Result<Config> {
-    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-    serde_json::from_slice(&bytes).with_context(|| format!("failed to parse {}", path.display()))
 }
 
 fn resolve_profile_path(data_dir: &Path, path: &str) -> PathBuf {

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -833,20 +833,9 @@ impl Game {
             return Ok(0);
         }
         let mut saves = self.get_game_snapshots_info()?;
-        let previous = saves.backups.len();
-        saves
-            .backups
-            .retain(|snapshot| !snapshot_ids.contains(&snapshot.date));
-        let affected_devices = saves
-            .head_entries()
-            .filter(|(_, head)| snapshot_ids.contains(head.as_str()))
-            .map(|(device_id, _)| device_id.clone())
-            .collect::<Vec<_>>();
-        for device_id in affected_devices {
-            saves.set_head_for_device(device_id, None);
-        }
-        let removed = previous - saves.backups.len();
-        if removed > 0 {
+        let previous_heads = saves.device_heads.clone();
+        let removed = saves.forget_v2_tombstones(snapshot_ids);
+        if removed > 0 || saves.device_heads != previous_heads {
             self.set_game_snapshots_info(&saves)?;
         }
         Ok(removed)

--- a/crates/rgsm-core/src/backup/game_snapshots.rs
+++ b/crates/rgsm-core/src/backup/game_snapshots.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -10,7 +10,7 @@ use crate::device::{DeviceId, get_current_device_id};
 /// A backup list info is a json file in a backup folder for a game.
 /// It contains the name of the game,
 /// and all backups' path
-#[derive(Debug, Serialize, Deserialize, Type, Clone)]
+#[derive(Debug, Serialize, Deserialize, Type, Clone, PartialEq, Eq)]
 pub struct GameSnapshots {
     pub name: String,
     pub backups: Vec<Snapshot>,
@@ -48,6 +48,15 @@ impl GameSnapshots {
             last_sync_device: None,
             last_sync_timestamp: None,
         }
+    }
+
+    pub fn forget_v2_tombstones(&mut self, snapshot_ids: &BTreeSet<String>) -> usize {
+        let previous = self.backups.len();
+        self.backups
+            .retain(|snapshot| !snapshot_ids.contains(&snapshot.date));
+        self.device_heads
+            .retain(|_, head| !snapshot_ids.contains(head));
+        previous - self.backups.len()
     }
 
     pub fn normalize_heads(&mut self) {
@@ -178,5 +187,28 @@ mod tests {
             Some("2025-01-01_00-00-00")
         );
         assert!(snapshots.head_for_device(&"device-b".to_string()).is_none());
+    }
+
+    #[test]
+    fn forgetting_v2_tombstones_clears_only_affected_heads() {
+        let mut snapshots = GameSnapshots::new("TestGame");
+        snapshots.backups = vec![
+            snapshot("deleted", Some("device-a")),
+            snapshot("kept", Some("device-b")),
+        ];
+        snapshots
+            .device_heads
+            .insert("device-a".into(), "deleted".into());
+        snapshots
+            .device_heads
+            .insert("device-b".into(), "kept".into());
+
+        assert_eq!(
+            snapshots.forget_v2_tombstones(&BTreeSet::from(["deleted".into()])),
+            1
+        );
+        assert_eq!(snapshots.backups[0].date, "kept");
+        assert!(!snapshots.device_heads.contains_key("device-a"));
+        assert_eq!(snapshots.device_heads["device-b"], "kept");
     }
 }

--- a/crates/rgsm-core/src/backup/snapshot.rs
+++ b/crates/rgsm-core/src/backup/snapshot.rs
@@ -64,7 +64,7 @@ impl CreatedBy {
 
 /// A backup archive containing all data declared by its Save Units.
 /// The date is the unique indicator for a backup
-#[derive(Debug, Serialize, Deserialize, Type, Clone)]
+#[derive(Debug, Serialize, Deserialize, Type, Clone, PartialEq, Eq)]
 pub struct Snapshot {
     pub date: String,
     pub describe: String,

--- a/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
@@ -183,7 +183,7 @@ mod tests {
                 .unwrap()
                 .objects
                 .keys()
-                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .filter(|path| prefix == "/" || path.starts_with(prefix))
                 .take(limit)
                 .cloned()
                 .collect())

--- a/crates/rgsm-core/src/cloud_sync/v2/conflict_resolution.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/conflict_resolution.rs
@@ -7,9 +7,9 @@ use specta::Type;
 use thiserror::Error;
 
 use super::{
-    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, ManifestError,
-    ManifestRepositoryError, MaterializationError, OpenDalManifestTransport, SnapshotState,
-    SnapshotSyncCoordinator, SnapshotSyncError,
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, DeletionRegistryError,
+    DeletionRegistryRepository, ManifestError, ManifestRepositoryError, MaterializationError,
+    OpenDalManifestTransport, SnapshotState, SnapshotSyncCoordinator, SnapshotSyncError,
 };
 use crate::backup::{GameSnapshots, Snapshot};
 use crate::device::DeviceId;
@@ -54,6 +54,9 @@ impl V2ConflictResolver {
         expected_local_snapshot_id: &str,
         local: &GameSnapshots,
     ) -> Result<KeepLocalProgressOutcome, KeepLocalProgressError> {
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
         let actual_local_head = local.head_for_device(&self.current_device_id).cloned();
         if actual_local_head.as_deref() != Some(expected_local_snapshot_id) {
             return Err(KeepLocalProgressError::LocalPositionChanged {
@@ -130,6 +133,9 @@ impl V2ConflictResolver {
                 expected_local_snapshot_id.to_string(),
             ));
         }
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
 
         let game_id = game_id.to_string();
         let selected_snapshot_id = expected_local_snapshot_id.to_string();
@@ -231,6 +237,8 @@ pub enum KeepLocalProgressError {
     Materialization(#[from] MaterializationError),
     #[error(transparent)]
     Repository(#[from] ManifestRepositoryError),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
 }
 
 #[cfg(test)]

--- a/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
@@ -5,7 +5,7 @@ use super::{
     SHARED_LIBRARY_PATH, SnapshotNode, SnapshotState, V2_NAMESPACE_DESCRIPTOR_PATH,
     cloud_archive_path, device_profile_path,
 };
-use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::backup::{GameSnapshots, Snapshot, snapshot_archive_path};
 use crate::cloud_sync::transfer::CloudTransfer;
 use crate::cloud_sync::utils::{
     SyncOperationError, game_cloud_archive_path, load_remote_game_snapshots,
@@ -62,6 +62,7 @@ pub struct CloudLibraryCutover {
     local_archive_root: PathBuf,
     progress_path: PathBuf,
     current_device_id: DeviceId,
+    current_device_profile: DeviceProfile,
     max_attempts: usize,
 }
 impl CloudLibraryCutover {
@@ -70,6 +71,7 @@ impl CloudLibraryCutover {
         local_archive_root: PathBuf,
         progress_path: PathBuf,
         current_device_id: DeviceId,
+        current_device_profile: DeviceProfile,
         max_attempts: usize,
     ) -> Self {
         Self {
@@ -77,6 +79,7 @@ impl CloudLibraryCutover {
             local_archive_root,
             progress_path,
             current_device_id,
+            current_device_profile,
             max_attempts: max_attempts.max(1),
         }
     }
@@ -138,7 +141,12 @@ impl CloudLibraryCutover {
             CloudNamespaceClassification::V1Only { config } => *config,
             _ => return Err(CloudLibraryCutoverError::CutoverUnavailable),
         };
-        let owners = ConfigurationOwners::from_legacy(&config, &self.current_device_id);
+        let mut owners = ConfigurationOwners::from_legacy(&config, &self.current_device_id);
+        owners.device_profiles.insert(
+            self.current_device_id.clone(),
+            self.current_device_profile
+                .for_shared_library(&owners.shared_library),
+        );
         owners.validate()?;
         let mut games = Vec::with_capacity(config.games.len());
         for game in &config.games {
@@ -225,11 +233,7 @@ impl CloudLibraryCutover {
         let verify_staging = staging_root.join(format!("{stem}.verify"));
         remove_path_if_exists(&source_staging).await?;
         remove_path_if_exists(&verify_staging).await?;
-        let local_path = archive_path(
-            &self.local_archive_root.join(game_id),
-            &snapshot.date,
-            snapshot.archive_format,
-        );
+        let local_path = snapshot_archive_path(&self.local_archive_root.join(game_id), snapshot);
         let (source, integrity, local_present) =
             if let Some(integrity) = accepted_legacy_archive(&local_path, snapshot) {
                 (local_path, integrity, true)
@@ -413,7 +417,7 @@ impl CloudLibraryCutover {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(error) => return Err(error.into()),
         };
-        let plan: CutoverPlan = serde_json::from_slice(&bytes)?;
+        let mut plan: CutoverPlan = serde_json::from_slice(&bytes)?;
         if plan.schema_version != CUTOVER_PROGRESS_SCHEMA_VERSION {
             return Err(CloudLibraryCutoverError::UnsupportedProgressSchema(
                 plan.schema_version,
@@ -436,6 +440,11 @@ impl CloudLibraryCutover {
                 .into());
             }
         }
+        plan.device_profiles.insert(
+            self.current_device_id.clone(),
+            self.current_device_profile
+                .for_shared_library(&plan.shared_library),
+        );
         Ok(Some(plan))
     }
     async fn store_progress(&self, plan: &CutoverPlan) -> Result<(), CloudLibraryCutoverError> {
@@ -591,11 +600,18 @@ mod tests {
         config_bytes
     }
     fn cutover(op: Operator, root: &Path) -> CloudLibraryCutover {
+        let device_id = "current-device".to_string();
+        let mut current_profile = ConfigurationOwners::from_legacy(&Config::default(), &device_id)
+            .device_profiles
+            .remove(&device_id)
+            .unwrap();
+        current_profile.local_archive_root = Some("current-device-private-root".into());
         CloudLibraryCutover::new(
             op,
             root.join("local"),
             root.join("progress.json"),
-            "current-device".into(),
+            device_id,
+            current_profile,
             2,
         )
     }
@@ -604,23 +620,26 @@ mod tests {
         let op = operator();
         let root = temp_dir::TempDir::new().unwrap();
         let local_bytes = b"local archive";
-        let local = snapshot("local", None, local_bytes);
+        let mut local = snapshot("local", None, local_bytes);
+        let local_path = root.path().join("relocated/local.zip");
+        local.path = local_path.to_string_lossy().into_owned();
         let missing = snapshot("missing", Some("local"), b"missing bytes");
         let mut catalog = GameSnapshots::new("test-game");
         catalog.backups = vec![local.clone(), missing];
         catalog.device_heads.insert("deck".into(), "missing".into());
         let v1_config = seed(&op, catalog, &[]).await;
-        let local_path = archive_path(
-            &root.path().join("local/test-game"),
-            &local.date,
-            local.archive_format,
-        );
         std::fs::create_dir_all(local_path.parent().unwrap()).unwrap();
         std::fs::write(&local_path, local_bytes).unwrap();
         let runner = cutover(op.clone(), root.path());
         let result = runner.execute().await.unwrap();
         assert_eq!(result.snapshot_count, 2);
         assert_eq!(result.unavailable_archives, 1);
+        assert_eq!(
+            result.device_profiles["current-device"]
+                .local_archive_root
+                .as_deref(),
+            Some("current-device-private-root")
+        );
         assert_eq!(op.read(V1_CONFIG_PATH).await.unwrap().to_vec(), v1_config);
         let manifest: CloudManifest =
             serde_json::from_slice(&op.read(CLOUD_MANIFEST_PATH).await.unwrap().to_vec()).unwrap();

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion.rs
@@ -254,7 +254,11 @@ impl GlobalSnapshotDeletion {
 
         repository
             .mutate(|manifest| {
-                manifest.game_mut(request.game_id).begin_deletion(
+                let game = manifest.game_mut(request.game_id);
+                if request.kind == DeletionKind::Retention {
+                    game.ensure_retention_deletable(request.snapshot_id)?;
+                }
+                game.begin_deletion(
                     request.snapshot_id,
                     request.acting_device,
                     request.kind.clone(),

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -70,6 +70,21 @@ impl DeletionRegistryRepository {
         Ok(registry)
     }
 
+    pub async fn ensure_active(
+        &self,
+        device_id: &str,
+        game_id: &str,
+    ) -> Result<(), DeletionRegistryError> {
+        let registry = self.load().await?;
+        if registry.deleted_profiles.contains_key(device_id) {
+            return Err(DeletionRegistryError::ProfileDeleted(device_id.to_string()));
+        }
+        if registry.deleted_games.contains_key(game_id) {
+            return Err(DeletionRegistryError::GameDeleted(game_id.to_string()));
+        }
+        Ok(())
+    }
+
     pub async fn mark_profile_deleted(
         &self,
         device_id: &str,
@@ -134,6 +149,10 @@ pub enum DeletionRegistryError {
     UnsupportedSchema(u32),
     #[error("Deletion registry update was not visible after {attempts} attempts")]
     RetryExhausted { attempts: usize },
+    #[error("Device Profile has been permanently removed: {0}")]
+    ProfileDeleted(DeviceId),
+    #[error("Shared Game has been permanently deleted: {0}")]
+    GameDeleted(String),
     #[error("Deletion registry serialization failed: {0}")]
     Serialization(#[from] serde_json::Error),
     #[error("Deletion registry transport failed: {0}")]
@@ -192,5 +211,30 @@ mod tests {
 
         assert_eq!(stored.deleted_games["game"].name, "Original");
         assert_eq!(stored.deleted_games["game"].deleted_by, "pc");
+    }
+
+    #[tokio::test]
+    async fn deleted_profile_and_game_are_rejected_as_writers() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let repository = DeletionRegistryRepository::new(operator, 2);
+        repository
+            .mark_profile_deleted("removed-device", "pc")
+            .await
+            .unwrap();
+        repository
+            .mark_game_deleted("deleted-game", "Deleted Game", "pc")
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            repository
+                .ensure_active("removed-device", "active-game")
+                .await,
+            Err(DeletionRegistryError::ProfileDeleted(device)) if device == "removed-device"
+        ));
+        assert!(matches!(
+            repository.ensure_active("pc", "deleted-game").await,
+            Err(DeletionRegistryError::GameDeleted(game)) if game == "deleted-game"
+        ));
     }
 }

--- a/crates/rgsm-core/src/cloud_sync/v2/join.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join.rs
@@ -347,7 +347,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .keys()
-                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .filter(|path| prefix == "/" || path.starts_with(prefix))
                 .take(limit)
                 .cloned()
                 .collect())

--- a/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
@@ -116,6 +116,25 @@ impl GameManifest {
         Ok(true)
     }
 
+    pub fn ensure_retention_deletable(&self, snapshot_id: &str) -> Result<(), ManifestError> {
+        let node = self
+            .snapshots
+            .get(snapshot_id)
+            .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id.to_string()))?;
+        let SnapshotState::Live(live) = &node.state else {
+            return Err(ManifestError::DeletionConflict(snapshot_id.to_string()));
+        };
+        if live.retention_protected
+            || !live.created_by.is_automatic_backup()
+            || self.device_heads.values().any(|head| head == snapshot_id)
+        {
+            return Err(ManifestError::RetentionNoLongerEligible(
+                snapshot_id.to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn mark_acting_local_removed(
         &mut self,
         snapshot_id: &str,
@@ -434,6 +453,8 @@ pub enum ManifestError {
     DeletionConflict(String),
     #[error("Snapshot deletion is already Final: {0}")]
     DeletionAlreadyFinal(String),
+    #[error("Snapshot is no longer eligible for automatic retention deletion: {0}")]
+    RetentionNoLongerEligible(String),
 }
 
 impl CloudManifest {
@@ -554,6 +575,33 @@ mod tests {
             game.upsert_live(live("snapshot", None)),
             Err(ManifestError::TombstoneResurrection("snapshot".to_string()))
         );
+    }
+
+    #[test]
+    fn retention_rechecks_head_and_protection_before_deletion() {
+        let mut game = GameManifest::new("game");
+        let mut protected = SnapshotNode::live("protected", None, integrity(), CreatedBy::Timer);
+        if let SnapshotState::Live(live) = &mut protected.state {
+            live.retention_protected = true;
+        }
+        game.upsert_live(protected).unwrap();
+        game.upsert_live(SnapshotNode::live(
+            "head",
+            Some("protected".into()),
+            integrity(),
+            CreatedBy::Timer,
+        ))
+        .unwrap();
+        game.set_head("pc".into(), "head".into());
+
+        assert!(matches!(
+            game.ensure_retention_deletable("protected"),
+            Err(ManifestError::RetentionNoLongerEligible(_))
+        ));
+        assert!(matches!(
+            game.ensure_retention_deletable("head"),
+            Err(ManifestError::RetentionNoLongerEligible(_))
+        ));
     }
 
     #[test]

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
@@ -9,9 +9,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     ArchiveIntegrity, ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudArchiveDeletionView,
-    CloudManifest, CloudManifestRepository, ManifestError, ManifestRepositoryError,
-    MaterializationOutcome, MaterializationPreview, SnapshotDeletionLifecycle,
-    SnapshotDeletionLifecycleError, SnapshotState, cloud_archive_path,
+    CloudManifest, CloudManifestRepository, DeletionRegistryError, DeletionRegistryRepository,
+    ManifestError, ManifestRepositoryError, MaterializationOutcome, MaterializationPreview,
+    SnapshotDeletionLifecycle, SnapshotDeletionLifecycleError, SnapshotState, cloud_archive_path,
 };
 use crate::backup::{ArchiveFormat, CreatedBy, archive_path};
 use crate::cloud_sync::transfer::{CloudTransfer, replace_path_preserving_existing};
@@ -209,6 +209,7 @@ impl CloudArchiveMaterializer {
         snapshot_id: &str,
     ) -> Result<(), MaterializationError> {
         self.converge_local_tombstones().await?;
+        self.ensure_active(game_id).await?;
         let manifest = self.repository().load().await?;
         let item = manifest_item(&manifest, game_id, snapshot_id, false)?;
         let local_path = self.local_path(game_id, snapshot_id, item.archive_format);
@@ -239,15 +240,28 @@ impl CloudArchiveMaterializer {
                 snapshot_id: snapshot_id.to_string(),
             });
         }
+        if let Err(error) = self.ensure_active(game_id).await {
+            if matches!(
+                &error,
+                MaterializationError::DeletionRegistry(DeletionRegistryError::GameDeleted(_))
+            ) {
+                self.operator
+                    .delete(&remote_path)
+                    .await
+                    .map_err(BackendError::from)?;
+            }
+            return Err(error);
+        }
         let current_device = self.current_device_id.clone();
-        let game_id = game_id.to_string();
+        let final_game_id = game_id.to_string();
+        let manifest_game_id = final_game_id.clone();
         let snapshot_id = snapshot_id.to_string();
         self.repository()
             .mutate(move |manifest| {
                 let game = manifest
                     .games
-                    .get_mut(&game_id)
-                    .ok_or_else(|| ManifestError::MissingGame(game_id.clone()))?;
+                    .get_mut(&manifest_game_id)
+                    .ok_or_else(|| ManifestError::MissingGame(manifest_game_id.clone()))?;
                 let node = game
                     .snapshots
                     .get_mut(&snapshot_id)
@@ -263,6 +277,18 @@ impl CloudArchiveMaterializer {
                 Ok(())
             })
             .await?;
+        if let Err(error) = self.ensure_active(&final_game_id).await {
+            if matches!(
+                &error,
+                MaterializationError::DeletionRegistry(DeletionRegistryError::GameDeleted(_))
+            ) {
+                self.operator
+                    .delete(&remote_path)
+                    .await
+                    .map_err(BackendError::from)?;
+            }
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -504,15 +530,18 @@ impl CloudArchiveMaterializer {
                 let Some(integrity) = &live.integrity else {
                     continue;
                 };
+                let local_archive_verified = self.is_locally_reported(game, &node.snapshot_id)
+                    && verify_file(
+                        integrity.clone(),
+                        self.local_path(game_id, &node.snapshot_id, node.archive_format),
+                    )
+                    .await
+                    .is_ok();
                 if !live.cloud_archive_verified
                     || max_catalog_revision.is_some_and(|maximum| node.catalog_revision > maximum)
                     || min_catalog_revision_exclusive
                         .is_some_and(|minimum| node.catalog_revision <= minimum)
-                    || (self.is_locally_reported(game, &node.snapshot_id)
-                        && local_size_matches(
-                            &self.local_path(game_id, &node.snapshot_id, node.archive_format),
-                            integrity.size,
-                        ))
+                    || local_archive_verified
                 {
                     continue;
                 }
@@ -566,6 +595,13 @@ impl CloudArchiveMaterializer {
             CLOUD_MANIFEST_PATH,
             self.max_attempts,
         )
+    }
+
+    async fn ensure_active(&self, game_id: &str) -> Result<(), MaterializationError> {
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
+        Ok(())
     }
 
     fn deletion_lifecycle(&self) -> SnapshotDeletionLifecycle {
@@ -632,7 +668,7 @@ fn manifest_item(
     })
 }
 
-async fn verify_file(
+pub(super) async fn verify_file(
     integrity: ArchiveIntegrity,
     path: PathBuf,
 ) -> Result<(), MaterializationError> {
@@ -686,6 +722,8 @@ pub enum MaterializationError {
     Manifest(#[from] ManifestRepositoryError),
     #[error(transparent)]
     Deletion(#[from] SnapshotDeletionLifecycleError),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
     #[error(transparent)]
     Backend(#[from] BackendError),
     #[error("Materialization I/O error: {0}")]

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
@@ -92,6 +92,33 @@ async fn view_keeps_catalog_cloud_and_device_availability_separate() {
 }
 
 #[tokio::test]
+async fn same_size_local_corruption_is_planned_for_repair() {
+    let operator = memory_operator();
+    let root = temp_dir::TempDir::new().expect("temporary directory should initialize");
+    let mut manifest = CloudManifest::default();
+    let mut game = GameManifest::new("game");
+    game.upsert_live(live("snapshot", b"expected", true))
+        .unwrap();
+    game.report_local_archive("pc".into(), "snapshot".into(), true);
+    manifest.games.insert("game".into(), game);
+    let local_path = archive_path(
+        &root.path().join("pc").join("game"),
+        "snapshot",
+        ArchiveFormat::Zip,
+    );
+    std::fs::create_dir_all(local_path.parent().unwrap()).unwrap();
+    std::fs::write(&local_path, b"corrupt!").unwrap();
+    write_manifest(&operator, &manifest).await;
+
+    let preview = materializer(operator, root.path(), "pc")
+        .preview_materialize_all()
+        .await
+        .unwrap();
+
+    assert_eq!(preview.snapshot_count, 1);
+}
+
+#[tokio::test]
 async fn local_eviction_keeps_shared_snapshot_and_cloud_archive() {
     let operator = memory_operator();
     let root = temp_dir::TempDir::new().expect("temporary directory should initialize");

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -158,7 +158,7 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
 
         let root_entries = self
             .transport
-            .list_sample(".", CLASSIFICATION_ENTRY_SAMPLE_LIMIT)
+            .list_sample("/", CLASSIFICATION_ENTRY_SAMPLE_LIMIT)
             .await?;
         if root_entries.is_empty() {
             Ok(CloudNamespaceClassification::Empty)
@@ -277,7 +277,7 @@ mod tests {
             Ok(self
                 .objects
                 .keys()
-                .filter(|path| prefix == "." || path.starts_with(prefix))
+                .filter(|path| prefix == "/" || path.starts_with(prefix))
                 .take(limit)
                 .cloned()
                 .collect())
@@ -463,7 +463,7 @@ mod tests {
         ));
 
         let failed_root_list = FakeTransport {
-            fail_list: Some(".".into()),
+            fail_list: Some("/".into()),
             ..FakeTransport::default()
         };
         assert!(matches!(

--- a/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
@@ -4,11 +4,13 @@ use std::path::PathBuf;
 use opendal::Operator;
 use thiserror::Error;
 
+use super::materialization::verify_file;
 use super::{
-    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, ManifestError,
-    ManifestRepositoryError, MaterializationError, OpenDalManifestTransport, SnapshotState,
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository, DeletionRegistryError,
+    DeletionRegistryRepository, ManifestError, ManifestRepositoryError, MaterializationError,
+    OpenDalManifestTransport, SnapshotState,
 };
-use crate::backup::{GameSnapshots, Snapshot, archive_path};
+use crate::backup::{GameSnapshots, Snapshot, archive_path, snapshot_archive_path};
 use crate::device::DeviceId;
 
 pub struct PreparedRemoteProgress {
@@ -70,6 +72,38 @@ impl V2RemoteProgressResolver {
             .get(game_id)
             .ok_or_else(|| AcceptRemoteProgressError::GameNotFound(game_id.to_string()))?;
         ensure_remote_candidate(game, &self.current_device_id, selected_snapshot_id, true)?;
+        let selected = game
+            .snapshots
+            .get(selected_snapshot_id)
+            .ok_or_else(|| ManifestError::MissingSnapshot(selected_snapshot_id.to_string()))?;
+        let SnapshotState::Live(live) = &selected.state else {
+            return Err(AcceptRemoteProgressError::CandidateNoLongerAdvertised(
+                selected_snapshot_id.to_string(),
+            ));
+        };
+        let integrity = live.integrity.clone().ok_or_else(|| {
+            AcceptRemoteProgressError::SelectedArchiveUnavailable(selected_snapshot_id.to_string())
+        })?;
+        let game_archive_root = self.local_archive_root.join(game_id);
+        let local_path = local
+            .backups
+            .iter()
+            .find(|snapshot| snapshot.date == selected_snapshot_id)
+            .map(|snapshot| snapshot_archive_path(&game_archive_root, snapshot))
+            .unwrap_or_else(|| {
+                archive_path(
+                    &game_archive_root,
+                    selected_snapshot_id,
+                    selected.archive_format,
+                )
+            });
+        if tokio::fs::try_exists(&local_path).await?
+            && verify_file(integrity, local_path).await.is_err()
+        {
+            return Err(AcceptRemoteProgressError::LocalArchiveConflict(
+                selected_snapshot_id.to_string(),
+            ));
+        }
 
         CloudArchiveMaterializer::new(
             self.operator.clone(),
@@ -103,6 +137,9 @@ impl V2RemoteProgressResolver {
         game_id: &str,
         selected_snapshot_id: &str,
     ) -> Result<u64, AcceptRemoteProgressError> {
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
         let game_id = game_id.to_string();
         let selected_snapshot_id = selected_snapshot_id.to_string();
         let current_device_id = self.current_device_id.clone();
@@ -242,6 +279,8 @@ pub enum AcceptRemoteProgressError {
     CandidateNoLongerAdvertised(String),
     #[error("Selected Snapshot Archive is not available in the cloud: {0}")]
     SelectedArchiveUnavailable(String),
+    #[error("A different Local Archive already uses the selected Snapshot identity: {0}")]
+    LocalArchiveConflict(String),
     #[error("Selected progress contains a deleted ancestor: {0}")]
     TombstonedLineage(String),
     #[error("Cloud Snapshot parent cycle contains {0}")]
@@ -252,6 +291,10 @@ pub enum AcceptRemoteProgressError {
     Materialization(#[from] MaterializationError),
     #[error(transparent)]
     Repository(#[from] ManifestRepositoryError),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
+    #[error("Local Archive inspection failed: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 #[cfg(test)]
@@ -365,6 +408,32 @@ mod tests {
             })
         ));
         assert_eq!(resolver.repository().load().await.unwrap().revision, 7);
+    }
+
+    #[tokio::test]
+    async fn conflicting_local_archive_is_not_overwritten() {
+        let (_operator, root, resolver, mut local) = fixture().await;
+        let local_path = root.path().join("relocated/remote.zip");
+        local.backups.push(Snapshot {
+            date: "remote".into(),
+            describe: "local collision".into(),
+            path: local_path.to_string_lossy().into_owned(),
+            archive_format: ArchiveFormat::Zip,
+            size: 6,
+            parent: Some("root".into()),
+            archive_hash: None,
+            device_id: Some("pc".into()),
+            created_by: CreatedBy::Manual,
+        });
+        std::fs::create_dir_all(local_path.parent().unwrap()).unwrap();
+        std::fs::write(&local_path, b"local!").unwrap();
+
+        assert!(matches!(
+            resolver.prepare("game", 7, None, "remote", &local).await,
+            Err(AcceptRemoteProgressError::LocalArchiveConflict(snapshot))
+                if snapshot == "remote"
+        ));
+        assert_eq!(std::fs::read(local_path).unwrap(), b"local!");
     }
 
     #[tokio::test]

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
@@ -7,9 +7,10 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     ArchiveIntegrity, ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudArchiveMaterializer,
-    CloudManifest, CloudManifestRepository, DeletionKind, ManifestError, ManifestRepositoryError,
-    SnapshotDeletionLifecycle, SnapshotDeletionLifecycleError, SnapshotNode,
-    SnapshotRetentionPlanner, SnapshotRetentionPlannerError, SnapshotState,
+    CloudManifest, CloudManifestRepository, DeletionKind, DeletionRegistryError,
+    DeletionRegistryRepository, ManifestError, ManifestRepositoryError, SnapshotDeletionLifecycle,
+    SnapshotDeletionLifecycleError, SnapshotNode, SnapshotRetentionPlanner,
+    SnapshotRetentionPlannerError, SnapshotState,
 };
 use crate::backup::{GameSnapshots, Snapshot, archive_path};
 use crate::device::DeviceId;
@@ -66,6 +67,45 @@ impl SnapshotSyncCoordinator {
         activation_revision: u64,
         local_baseline: &BTreeSet<String>,
         cancellation: &CancellationToken,
+    ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncError> {
+        self.reconcile_game_inner(
+            game_id,
+            local,
+            activation_revision,
+            local_baseline,
+            cancellation,
+            true,
+        )
+        .await
+    }
+
+    pub async fn publish_local_game(
+        &self,
+        game_id: &str,
+        local: &GameSnapshots,
+        activation_revision: u64,
+        local_baseline: &BTreeSet<String>,
+        cancellation: &CancellationToken,
+    ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncError> {
+        self.reconcile_game_inner(
+            game_id,
+            local,
+            activation_revision,
+            local_baseline,
+            cancellation,
+            false,
+        )
+        .await
+    }
+
+    async fn reconcile_game_inner(
+        &self,
+        game_id: &str,
+        local: &GameSnapshots,
+        activation_revision: u64,
+        local_baseline: &BTreeSet<String>,
+        cancellation: &CancellationToken,
+        materialize_remote: bool,
     ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncError> {
         let mut manifest = self.repository().load().await?;
         let order = publication_order(&manifest, game_id, local, local_baseline)?;
@@ -135,11 +175,13 @@ impl SnapshotSyncCoordinator {
             outcome.uploaded += 1;
         }
 
-        outcome.downloaded = self
-            .materializer
-            .materialize_game_since(game_id, activation_revision, cancellation)
-            .await?
-            .downloaded;
+        if materialize_remote {
+            outcome.downloaded = self
+                .materializer
+                .materialize_game_since(game_id, activation_revision, cancellation)
+                .await?
+                .downloaded;
+        }
         Ok(outcome)
     }
 
@@ -227,6 +269,9 @@ impl SnapshotSyncCoordinator {
         snapshot: &Snapshot,
         inherited_revision: Option<u64>,
     ) -> Result<(), SnapshotSyncError> {
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
         let local_path = self.local_path(game_id, snapshot);
         let integrity = if local_path.is_file() {
             let path = local_path.clone();
@@ -288,6 +333,9 @@ impl SnapshotSyncCoordinator {
         let Some(head) = local.head_for_device(&self.current_device_id).cloned() else {
             return Ok(());
         };
+        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
+            .ensure_active(&self.current_device_id, game_id)
+            .await?;
         let manifest = self.repository().load().await?;
         let Some(game) = manifest.games.get(game_id) else {
             return Ok(());
@@ -441,6 +489,8 @@ pub enum SnapshotSyncError {
     Retention(#[from] SnapshotRetentionPlannerError),
     #[error(transparent)]
     Deletion(#[from] SnapshotDeletionLifecycleError),
+    #[error(transparent)]
+    DeletionRegistry(#[from] DeletionRegistryError),
 }
 
 #[cfg(test)]
@@ -602,6 +652,19 @@ mod tests {
             root.path().join("progress.json"),
             2,
         );
+
+        let publish_only = coordinator
+            .publish_local_game(
+                "game",
+                &GameSnapshots::new("Game"),
+                5,
+                &BTreeSet::new(),
+                &CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(publish_only.downloaded, 0);
+        assert!(!archive_path(&archive_root.join("game"), "new", ArchiveFormat::Zip).exists());
 
         let outcome = coordinator
             .reconcile_game(

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -56,7 +56,7 @@ impl OwnerStore {
         Self::new(get_app_data_dir().clone())
     }
 
-    fn new(root: PathBuf) -> Self {
+    pub(crate) fn new(root: PathBuf) -> Self {
         Self { root }
     }
 
@@ -228,8 +228,12 @@ impl OwnerStore {
             return Err(OwnerStoreError::CutoverInputsChanged);
         }
 
+        let accepted_current_profile = current_profile.for_shared_library(accepted_library);
         owners.shared_library = accepted_library.clone();
         owners.device_profiles = accepted_profiles.clone();
+        owners
+            .device_profiles
+            .insert(current_device_id, accepted_current_profile);
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
         self.write(&owners)
     }
@@ -626,7 +630,7 @@ mod tests {
         );
         assert_eq!(
             active.device_profiles[get_current_device_id()].device.name,
-            "Migrated Device"
+            expected_profile.device.name
         );
     }
 

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex as StdMutex};
 #[cfg(test)]
 use tokio::sync::{Mutex as TokioMutex, MutexGuard};
@@ -52,6 +52,21 @@ pub fn get_config() -> Result<Config, ConfigError> {
         .lock()
         .map_err(|_| ConfigError::StoreLockPoisoned)?;
     get_config_unlocked()
+}
+
+/// Load the authoritative effective configuration from another application
+/// data directory, falling back to its legacy file only when no owner store
+/// has ever been activated there.
+pub fn get_config_from_data_dir(data_dir: &Path) -> Result<Config, ConfigError> {
+    let _guard = CONFIG_STORE_LOCK
+        .lock()
+        .map_err(|_| ConfigError::StoreLockPoisoned)?;
+    let owner_store = OwnerStore::new(data_dir.to_path_buf());
+    if owner_store.has_authoritative_state() {
+        return Ok(owner_store.load_effective()?);
+    }
+    let content = fs::read_to_string(data_dir.join("GameSaveManager.config.json"))?;
+    Ok(serde_json::from_str(&content)?)
 }
 
 pub fn cloud_namespace_generation() -> Result<CloudNamespaceGeneration, ConfigError> {
@@ -279,6 +294,30 @@ pub fn resolve_backup_path(backup_path: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn external_config_load_prefers_authoritative_owner_store() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let owner_store = OwnerStore::new(root.path().to_path_buf());
+        let owner_config = Config {
+            backup_path: "owner-backups".into(),
+            ..Config::default()
+        };
+        owner_store.initialize_from_legacy(&owner_config).unwrap();
+        let stale_legacy = Config {
+            backup_path: "stale-legacy-backups".into(),
+            ..Config::default()
+        };
+        fs::write(
+            root.path().join("GameSaveManager.config.json"),
+            serde_json::to_vec_pretty(&stale_legacy).unwrap(),
+        )
+        .unwrap();
+
+        let loaded = get_config_from_data_dir(root.path()).unwrap();
+
+        assert_eq!(loaded.backup_path, "owner-backups");
+    }
 
     #[test]
     fn test_old_config_backup_path_compatibility() {

--- a/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
+++ b/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
@@ -58,7 +58,7 @@ impl LifecycleHook for V2SnapshotSyncHook {
         let _guard = self.operation_lock.lock().await;
         let outcome = self
             .coordinator
-            .reconcile_game(
+            .publish_local_game(
                 game_id.as_ref(),
                 &ctx.snapshots,
                 target.activation_revision,
@@ -71,7 +71,7 @@ impl LifecycleHook for V2SnapshotSyncHook {
                 .coordinator
                 .enforce_retention(game_id.as_ref(), limit)
                 .await?;
-            ctx.game.forget_v2_tombstones(&retention.tombstones)?;
+            ctx.snapshots.forget_v2_tombstones(&retention.tombstones);
             retention.deleted
         } else {
             0

--- a/crates/rgsm-core/src/services/conflict_resolution.rs
+++ b/crates/rgsm-core/src/services/conflict_resolution.rs
@@ -97,7 +97,11 @@ impl ServiceContext {
             )
             .await?;
 
-        let mut staged = original.clone();
+        let latest = game.get_game_snapshots_info()?;
+        if latest != original {
+            return Err(CloudLibraryServiceError::LocalSnapshotHistoryChanged);
+        }
+        let mut staged = latest;
         merge_remote_lineage(&mut staged, &prepared.lineage)?;
         let backup_date = match self.capture_plan(&config, &game) {
             Ok(plan) => Some(game.create_overwrite_snapshot_from_capture_plan(

--- a/crates/rgsm-core/src/services/snapshot.rs
+++ b/crates/rgsm-core/src/services/snapshot.rs
@@ -74,6 +74,7 @@ impl ServiceContext {
             .await?;
 
         if let Some(snapshot) = created.snapshots.backups.last().cloned() {
+            game.set_game_snapshots_info(&created.snapshots)?;
             let mut ctx = crate::hooks::SnapshotCreatedCtx {
                 config,
                 source,
@@ -133,6 +134,7 @@ impl ServiceContext {
             )
             .await?;
         if let Some(snapshot) = created.snapshots.backups.last().cloned() {
+            game.set_game_snapshots_info(&created.snapshots)?;
             let mut ctx = crate::hooks::SnapshotCreatedCtx {
                 config,
                 source,

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -13,7 +13,8 @@ use crate::cloud_sync::v2::{
     DeviceProfileRemovalError, DeviceProfileRepository, DeviceProfileRepositoryError,
     JoinGameDecision, KeepLocalProgressError, LocalArchiveEvictionError, ManifestRepositoryError,
     MaterializationError, MaterializationOutcome, MaterializationPreview, SharedGameDeletionError,
-    SharedLibraryRepositoryError, SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
+    SharedLibraryRepositoryError, SnapshotDeletionLifecycleError, SnapshotSyncError,
+    V2ConflictInspector, V2ConflictReview,
 };
 use crate::cloud_sync::{
     BatchSyncReport, CloudBackendCheckReport, CloudSyncSessionConfig, ConflictResolution,
@@ -157,6 +158,8 @@ pub enum CloudLibraryServiceError {
     },
     #[error("Local and Cloud progress disagree about Snapshot identity: {0}")]
     RemoteSnapshotIdentityConflict(String),
+    #[error("Local Snapshot history changed while remote progress was being prepared")]
+    LocalSnapshotHistoryChanged,
 }
 
 impl ServiceContext {
@@ -376,7 +379,15 @@ impl ServiceContext {
             .games
             .into_iter()
             .find(|game| game.storage_key == game_id)
-            .map(|game| game.get_game_snapshots_info())
+            .map(|game| match game.get_game_snapshots_info() {
+                Ok(snapshots) => Ok(snapshots),
+                Err(crate::preclude::BackupError::Io(error))
+                    if error.kind() == std::io::ErrorKind::NotFound =>
+                {
+                    Ok(GameSnapshots::new(game.name))
+                }
+                Err(error) => Err(error),
+            })
             .transpose()?
             .unwrap_or_else(|| GameSnapshots::new(game_name));
         let local_archive_root = profile
@@ -446,10 +457,31 @@ impl ServiceContext {
         snapshot_id: &str,
         confirmed: bool,
     ) -> Result<(), CloudLibraryServiceError> {
+        if !confirmed {
+            return Err(CloudLibraryServiceError::ConfirmationRequired);
+        }
         let materializer = self.converged_materializer().await?;
         let deletion = materializer
             .delete_snapshot(game_id, snapshot_id, confirmed)
             .await;
+        if matches!(
+            deletion,
+            Err(MaterializationError::Deletion(
+                SnapshotDeletionLifecycleError::SnapshotNotFound(_)
+                    | SnapshotDeletionLifecycleError::GameNotFound(_)
+            ))
+        ) {
+            let game = get_config()?
+                .games
+                .into_iter()
+                .find(|game| game.storage_key == game_id)
+                .ok_or_else(|| {
+                    CloudLibraryServiceError::GameProfileNotFound(game_id.to_string())
+                })?;
+            return Ok(self
+                .delete_snapshot(&game, snapshot_id, HookSource::UserManual)
+                .await?);
+        }
         let convergence = self.converge_local_tombstone_metadata(&materializer).await;
         deletion?;
         convergence
@@ -573,6 +605,7 @@ impl ServiceContext {
             archive_root,
             progress_path,
             local_state.current_device_id.clone(),
+            profile.clone(),
             3,
         ))
     }


### PR DESCRIPTION
修复云同步 V2 合并后审查发现的状态与删除安全问题：

- 保留 Cutover 与 TUI 导入中的设备私有配置和权威配置来源
- 收紧 Snapshot 发布、冲突应用、自动 Apply 与 Archive 完整性边界
- 阻止已删除设备或游戏重新发布状态，并在 retention 删除前复核资格