### PR TITLE
feat(cloud-sync): add local folder backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4223,6 +4223,7 @@ dependencies = [
  "opendal-layer-logging",
  "opendal-layer-retry",
  "opendal-layer-timeout",
+ "opendal-service-fs",
  "opendal-service-s3",
  "opendal-service-webdav",
 ]
@@ -4296,6 +4297,20 @@ checksum = "1e91f731724c213af81e9d03517859c8fc47b4578e64ad61ae4f099f10fe36e3"
 dependencies = [
  "opendal-core",
  "tokio",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e89a665fef0e6bd249cf5ea47fc174b7ba892159bee4b9382528b1ca873a2c"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
 ]
 
 [[package]]
@@ -9105,6 +9120,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xkeysym"

--- a/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
+++ b/apps/rgsm-gui/src-tauri/src/ipc_handler.rs
@@ -550,12 +550,8 @@ pub async fn open_backup_folder(game: Game) -> Result<bool, String> {
         error!(target:"rgsm::ipc", "Failed to get backup path: {:?}", e);
         e.to_string()
     })?;
-    let p = game_backup_folder_path(&backup_path, &game);
+    let p = game.backup_folder_path(&backup_path);
     Ok(open::that(p).is_ok())
-}
-
-fn game_backup_folder_path(backup_root: &std::path::Path, game: &Game) -> std::path::PathBuf {
-    backup_root.join(game.backup_dir_name().as_ref())
 }
 
 #[tauri::command]
@@ -1730,12 +1726,7 @@ pub async fn sync_config(app_handle: AppHandle) -> Result<(), String> {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-    use std::path::Path;
-
-    use rgsm_core::backup::Game;
-
-    use super::{IpcNotification, NotificationLevel, game_backup_folder_path};
+    use super::{IpcNotification, NotificationLevel};
 
     #[test]
     fn test1() {
@@ -1749,25 +1740,5 @@ mod test {
             a,
             "{\"level\":\"error\",\"title\":\"title1\",\"msg\":\"msg1\"}"
         )
-    }
-
-    #[test]
-    fn renamed_game_backup_folder_uses_stable_storage_key() {
-        let game = Game {
-            name: "Need for Speed Unbound 极品飞车22：不羁1".to_string(),
-            storage_key: "Need for Speed Unbound".to_string(),
-            save_paths: Vec::new(),
-            game_paths: HashMap::new(),
-            next_save_unit_id: 0,
-            cloud_sync_enabled: true,
-            auto_backup: None,
-            ludusavi_meta: None,
-            device_bindings: HashMap::new(),
-        };
-
-        assert_eq!(
-            game_backup_folder_path(Path::new("save_data"), &game),
-            Path::new("save_data").join("Need for Speed Unbound")
-        );
     }
 }

--- a/apps/rgsm-gui/src/bindings.ts
+++ b/apps/rgsm-gui/src/bindings.ts
@@ -829,6 +829,13 @@ max_backup_count?: number | null }
 export type AutoBackupGameStatus = { game_name: string; interval_secs: number }
 export type Backend = { type: "Disabled" } |
 /**
+ * Local filesystem backend powered by OpenDAL.
+ *
+ * The physical root is stored in [`CloudSettings::root_path`] so all
+ * backends keep using the same operator-construction contract.
+ */
+{ type: "Fs" } |
+/**
  * WebDAV 后端
  * 参考：https://docs.rs/opendal/latest/opendal/services/struct.Webdav.html
  * 不支持 blocking

--- a/apps/rgsm-gui/src/pages/SyncSettings.vue
+++ b/apps/rgsm-gui/src/pages/SyncSettings.vue
@@ -55,7 +55,12 @@ interface BatchSyncReportLike {
   games: BatchSyncItemReportLike[];
 }
 
-const backends = ['WebDAV', 'S3', 'Disabled'];
+const backends = [
+  { value: 'WebDAV', label: 'sync_settings.backend_label.webdav' },
+  { value: 'S3', label: 'sync_settings.backend_label.s3' },
+  { value: 'Fs', label: 'sync_settings.backend_label.fs' },
+  { value: 'Disabled', label: 'sync_settings.backend_label.disabled' },
+] as const;
 
 const { config, refreshConfig, saveConfig } = useConfig();
 const { withLoading } = useGlobalLoading();
@@ -114,6 +119,7 @@ function loadBackendSettings() {
     case 'S3':
       s3_settings.value = cloneValue(cloud_settings.value.backend as S3);
       break;
+    case 'Fs':
     case 'Disabled':
       break;
     default:
@@ -428,10 +434,20 @@ function currentBackend(): Backend | null {
     trimEndpoint(s3_settings.value);
     return cloneValue(s3_settings.value);
   }
+  if (type === 'Fs') {
+    return { type: 'Fs' } as Backend;
+  }
   if (type === 'Disabled') {
     return { type: 'Disabled' } as Backend;
   }
   return null;
+}
+
+async function chooseFsRoot() {
+  const result = await commands.chooseSaveDir();
+  if (result.status === 'ok') {
+    cloud_settings.value.root_path = result.data;
+  }
 }
 
 function currentSessionConfig(): CloudSyncSessionConfig | null {
@@ -784,7 +800,12 @@ onMounted(async () => {
                 v-model="cloud_settings!.backend!.type"
                 :placeholder="$t('sync_settings.backend')"
               >
-                <ElOption v-for="b in backends" :key="b" :label="b" :value="b" />
+                <ElOption
+                  v-for="backend in backends"
+                  :key="backend.value"
+                  :label="$t(backend.label)"
+                  :value="backend.value"
+                />
               </ElSelect>
             </ElFormItem>
 
@@ -834,7 +855,20 @@ onMounted(async () => {
               </ElFormItem>
             </template>
 
-            <ElFormItem :label="$t('sync_settings.cloud_root')">
+            <ElFormItem
+              v-if="cloud_settings!.backend!.type === 'Fs'"
+              :label="$t('sync_settings.fs.root')"
+            >
+              <ElInput v-model="cloud_settings!.root_path">
+                <template #append>
+                  <ElButton @click="chooseFsRoot">
+                    {{ $t('sync_settings.fs.choose') }}
+                  </ElButton>
+                </template>
+              </ElInput>
+              <span class="field-hint">{{ $t('sync_settings.fs.root_hint') }}</span>
+            </ElFormItem>
+            <ElFormItem v-else :label="$t('sync_settings.cloud_root')">
               <ElInput v-model="cloud_settings!.root_path" />
               <span class="field-hint">{{ $t('sync_settings.cloud_root_hint') }}</span>
             </ElFormItem>

--- a/apps/rgsm-tui/src/operations.rs
+++ b/apps/rgsm-tui/src/operations.rs
@@ -618,6 +618,7 @@ pub fn parse_cloud_settings_draft(input: &str, current: &CloudSettings) -> Resul
 
     settings.backend = match kind.to_ascii_lowercase().as_str() {
         "disabled" | "off" | "none" => Backend::Disabled,
+        "fs" | "filesystem" => Backend::Fs,
         "webdav" => Backend::WebDAV {
             endpoint: field_or_current(
                 &fields,
@@ -811,6 +812,7 @@ pub fn cloud_settings_draft(current: &CloudSettings) -> String {
     let shared = format!("root={} max={}", current.root_path, current.max_concurrency);
     match &current.backend {
         Backend::Disabled => format!("disabled {shared}"),
+        Backend::Fs => format!("fs {shared}"),
         Backend::WebDAV {
             endpoint, username, ..
         } => {
@@ -910,6 +912,24 @@ mod tests {
         } else {
             panic!("expected S3 backend");
         }
+    }
+
+    #[test]
+    fn fs_cloud_settings_draft_round_trips_an_absolute_path_with_spaces() {
+        let current = CloudSettings {
+            root_path: r"C:\Game Save Sync".to_string(),
+            max_concurrency: 2,
+            backend: Backend::Fs,
+            ..Default::default()
+        };
+
+        let draft = cloud_settings_draft(&current);
+        let parsed = parse_cloud_settings_draft(&draft, &CloudSettings::default()).unwrap();
+
+        assert_eq!(draft, r"fs root=C:\Game Save Sync max=2");
+        assert_eq!(parsed.root_path, r"C:\Game Save Sync");
+        assert_eq!(parsed.max_concurrency, 2);
+        assert!(matches!(parsed.backend, Backend::Fs));
     }
 
     #[test]

--- a/apps/rgsm-tui/src/ui.rs
+++ b/apps/rgsm-tui/src/ui.rs
@@ -290,6 +290,7 @@ fn sync_error(state: &GameSyncState) -> Option<&str> {
 fn backend_label(backend: &Backend) -> String {
     match backend {
         Backend::Disabled => t!("sync_settings.backend_label.disabled").to_string(),
+        Backend::Fs => t!("sync_settings.backend_label.fs").to_string(),
         Backend::WebDAV { .. } => t!("sync_settings.backend_label.webdav").to_string(),
         Backend::S3 { .. } => t!("sync_settings.backend_label.s3").to_string(),
     }

--- a/apps/rgsm-tui/src/ui/screens.rs
+++ b/apps/rgsm-tui/src/ui/screens.rs
@@ -510,13 +510,18 @@ fn list_title(base: &str, filter: &str, sort: crate::model::ListSort, count: usi
 
 fn cloud_detail_lines(app: &App) -> Vec<String> {
     let settings = &app.data.config.settings.cloud_settings;
+    let root_label = if matches!(&settings.backend, Backend::Fs) {
+        t!("sync_settings.fs.root")
+    } else {
+        t!("sync_settings.cloud_root")
+    };
     let mut lines = vec![
         format!(
             "{}: {}",
             t!("sync_settings.backend"),
             backend_label(&settings.backend)
         ),
-        format!("{}: {}", t!("sync_settings.cloud_root"), settings.root_path),
+        format!("{}: {}", root_label, settings.root_path),
         format!(
             "{}: {}",
             t!("sync_settings.max_concurrency"),
@@ -526,6 +531,7 @@ fn cloud_detail_lines(app: &App) -> Vec<String> {
     ];
     match &settings.backend {
         Backend::Disabled => lines.push(t!("sync_settings.overview.status_disabled").to_string()),
+        Backend::Fs => {}
         Backend::WebDAV {
             endpoint, username, ..
         } => {

--- a/crates/rgsm-core/Cargo.toml
+++ b/crates/rgsm-core/Cargo.toml
@@ -24,7 +24,7 @@ thiserror.workspace = true
 chrono = "0.4.44"
 tokio.workspace = true
 tokio-util.workspace = true
-opendal = { version = "0.57.0", features = ["services-webdav", "services-s3"] }
+opendal = { version = "0.57.0", features = ["services-webdav", "services-s3", "services-fs"] }
 zip.workspace = true
 sevenz-rust2.workspace = true
 fs_extra = "1.3.0"

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -345,6 +345,11 @@ impl Game {
         }
     }
 
+    /// Resolve this game's local backup folder beneath an explicit backup root.
+    pub fn backup_folder_path(&self, backup_root: &Path) -> PathBuf {
+        backup_root.join(self.backup_dir_name().as_ref())
+    }
+
     /// Return whether two persisted game references identify the same game.
     ///
     /// Current configs use `storage_key` as the stable identity. Legacy configs

--- a/crates/rgsm-core/src/backup/tests/game.rs
+++ b/crates/rgsm-core/src/backup/tests/game.rs
@@ -1189,6 +1189,26 @@ fn backup_dir_name_uses_storage_key_over_raw_name() {
 }
 
 #[test]
+fn renamed_game_backup_folder_uses_stable_storage_key() {
+    let game = Game {
+        name: "Need for Speed Unbound 极品飞车22：不羁1".to_string(),
+        storage_key: "Need for Speed Unbound".to_string(),
+        save_paths: Vec::new(),
+        game_paths: HashMap::new(),
+        next_save_unit_id: 0,
+        cloud_sync_enabled: true,
+        auto_backup: None,
+        ludusavi_meta: None,
+        device_bindings: HashMap::new(),
+    };
+
+    assert_eq!(
+        game.backup_folder_path(Path::new("save_data")),
+        Path::new("save_data").join("Need for Speed Unbound")
+    );
+}
+
+#[test]
 fn backup_dir_name_fallback_sanitizes_when_storage_key_empty() {
     let game = Game {
         name: "Game: Special <Edition>".to_string(),

--- a/crates/rgsm-core/src/cloud_sync/backend.rs
+++ b/crates/rgsm-core/src/cloud_sync/backend.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -116,6 +117,11 @@ fn endpoint_host_range(endpoint: &str) -> Option<(usize, usize)> {
 #[serde(tag = "type")]
 pub enum Backend {
     Disabled,
+    /// Local filesystem backend powered by OpenDAL.
+    ///
+    /// The physical root is stored in [`CloudSettings::root_path`] so all
+    /// backends keep using the same operator-construction contract.
+    Fs,
     /// WebDAV 后端
     /// 参考：https://docs.rs/opendal/latest/opendal/services/struct.Webdav.html
     /// 不支持 blocking
@@ -271,6 +277,15 @@ impl Backend {
     pub fn get_op_with_root(&self, root: &str) -> Result<Operator, BackendError> {
         match self {
             Backend::Disabled => Err(BackendError::Disabled),
+            Backend::Fs => {
+                if !Path::new(root).is_absolute() {
+                    return Err(BackendError::OperatorCheck(
+                        "Local folder backend requires an absolute root path.".to_string(),
+                    ));
+                }
+                let builder = services::Fs::default().root(root);
+                Ok(Operator::new(builder)?.layer(Self::retry_layer()).finish())
+            }
             Backend::WebDAV {
                 endpoint,
                 username,
@@ -459,6 +474,7 @@ impl Sanitizable for Backend {
     fn sanitize(self) -> Self {
         match self {
             Backend::Disabled => Backend::Disabled,
+            Backend::Fs => Backend::Fs,
             Backend::WebDAV {
                 endpoint,
                 username: _,
@@ -489,9 +505,12 @@ impl Sanitizable for Backend {
 
 #[cfg(test)]
 mod tests {
+    use crate::preclude::Sanitizable;
+
     use super::{
-        CloudBackendCheckItem, CloudBackendCheckOutcome, CloudBackendCheckReport,
-        CloudBackendCheckStep, S3AddressingStyle, normalize_virtual_host_endpoint,
+        Backend, CloudBackendCheckItem, CloudBackendCheckOutcome, CloudBackendCheckReport,
+        CloudBackendCheckStep, CloudSyncSessionConfig, S3AddressingStyle,
+        normalize_virtual_host_endpoint,
     };
 
     #[test]
@@ -565,6 +584,86 @@ mod tests {
         } else {
             panic!("expected S3 backend");
         }
+    }
+
+    #[test]
+    fn fs_backend_round_trips_as_a_fieldless_variant() {
+        let json = serde_json::to_string(&Backend::Fs).unwrap();
+        assert_eq!(json, r#"{"type":"Fs"}"#);
+
+        let backend: Backend = serde_json::from_str(&json).unwrap();
+        assert!(matches!(backend, Backend::Fs));
+        assert!(matches!(backend.sanitize(), Backend::Fs));
+    }
+
+    #[test]
+    fn fs_backend_rejects_a_relative_root_before_writing() {
+        let result = Backend::Fs.get_op_with_root("relative/cloud/root");
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn fs_backend_uses_the_selected_folder_as_its_exact_persistent_root() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let root_path = root.path().to_string_lossy().into_owned();
+        let session = CloudSyncSessionConfig {
+            root_path,
+            max_concurrency: 2,
+            backend: Backend::Fs,
+        };
+
+        let first = session.get_op().unwrap();
+        first
+            .write("snapshot.bin", b"persistent bytes".as_slice())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read(root.path().join("snapshot.bin")).unwrap(),
+            b"persistent bytes"
+        );
+        assert!(!root.path().join("game-save-manager").exists());
+
+        let second = session.get_op().unwrap();
+        assert_eq!(
+            second.read("snapshot.bin").await.unwrap().to_vec(),
+            b"persistent bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn fs_backend_health_check_succeeds_without_leaving_a_probe_file() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let session = CloudSyncSessionConfig {
+            root_path: root.path().to_string_lossy().into_owned(),
+            max_concurrency: 1,
+            backend: Backend::Fs,
+        };
+
+        let report = session.check_report().await;
+
+        assert_eq!(report.outcome, CloudBackendCheckOutcome::Available);
+        assert!(std::fs::read_dir(root.path()).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn fs_backend_fingerprint_distinguishes_roots_and_backend_types() {
+        let fs = CloudSyncSessionConfig {
+            root_path: r"C:\sync-one".to_string(),
+            max_concurrency: 1,
+            backend: Backend::Fs,
+        };
+        let another_root = CloudSyncSessionConfig {
+            root_path: r"C:\sync-two".to_string(),
+            ..fs.clone()
+        };
+        let disabled = CloudSyncSessionConfig {
+            backend: Backend::Disabled,
+            ..fs.clone()
+        };
+
+        assert_ne!(fs.fingerprint(), another_root.fingerprint());
+        assert_ne!(fs.fingerprint(), disabled.fingerprint());
     }
 
     #[test]

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -545,6 +545,17 @@
         "cloud_root_hint": "Do not end with /, do not leave empty spaces",
         "backend": "Sync backend",
         "backend_hint": "Choose the service backend",
+        "backend_label": {
+            "disabled": "Disabled",
+            "fs": "Local folder",
+            "webdav": "WebDAV",
+            "s3": "S3"
+        },
+        "fs": {
+            "root": "Local folder",
+            "root_hint": "Cloud Sync data is stored directly in this folder. An absolute path is required.",
+            "choose": "Choose folder"
+        },
         "sync_success": "Successfully synced",
         "sync_failed": "Sync failed",
         "config_retry": "Retry",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -545,6 +545,17 @@
         "cloud_root_hint": "不要以/结尾，不要留空",
         "backend": "同步后端",
         "backend_hint": "选择云存档的服务后端",
+        "backend_label": {
+            "disabled": "已禁用",
+            "fs": "本地文件夹",
+            "webdav": "WebDAV",
+            "s3": "S3"
+        },
+        "fs": {
+            "root": "本地文件夹",
+            "root_hint": "同步数据会直接保存在此文件夹中，必须使用绝对路径。",
+            "choose": "选择文件夹"
+        },
         "sync_success": "同步成功",
         "sync_failed": "同步失败",
         "config_retry": "重试",


### PR DESCRIPTION
Closes #472

Adds an OpenDAL Fs backend that treats the selected absolute folder as the exact Cloud Sync root. The existing provider-neutral sync repositories are reused, while GUI/TUI configuration and tier-1 localization expose the new backend.

Verified with filesystem integration tests and the actual Tauri WebView; the backend probe completed successfully and removed its temporary file.