### PR TITLE
test(cloud-sync): cover V2 paths with Fs backend

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Run configuration upgrade compatibility tests
         run: cargo test -p rgsm-core --test config_upgrade_compatibility
 
+      - name: Run Fs cloud sync domain tests
+        run: cargo test -p rgsm-core --test cloud_sync_v2_fs
+
       - name: Run workspace checks
         run: |
           cargo check --workspace

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -113,6 +113,9 @@ impl NamespaceTransport for OpenDalNamespaceTransport {
             let Some(entry) = lister.try_next().await? else {
                 break;
             };
+            if entry.path() == prefix {
+                continue;
+            }
             paths.push(entry.path().to_string());
         }
         Ok(paths)
@@ -522,5 +525,17 @@ mod tests {
                 .unwrap(),
             CloudNamespaceClassification::V1Only { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn opendal_adapter_ignores_the_listed_directory_itself() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let operator =
+            Operator::new(services::Fs::default().root(root.path().to_string_lossy().as_ref()))
+                .unwrap()
+                .finish();
+        let transport = OpenDalNamespaceTransport::new(operator);
+
+        assert!(transport.list_sample("/", 10).await.unwrap().is_empty());
     }
 }

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
@@ -1,0 +1,4 @@
+#[path = "cloud_sync_v2_fs/normal_path.rs"]
+mod normal_path;
+#[path = "cloud_sync_v2_fs/support.rs"]
+mod support;

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
@@ -1,3 +1,5 @@
+#[path = "cloud_sync_v2_fs/interleaving.rs"]
+mod interleaving;
 #[path = "cloud_sync_v2_fs/normal_path.rs"]
 mod normal_path;
 #[path = "cloud_sync_v2_fs/support.rs"]

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
@@ -1,0 +1,21 @@
+# Cloud Sync V2 Fs Test Matrix
+
+This matrix tracks domain behavior exercised through the production OpenDAL Fs
+backend. Fine-grained Memory and fake-transport tests remain responsible for
+operation-level failures and retry mechanics.
+
+| Domain invariant | Fs scenario | Status |
+| --- | --- | --- |
+| The selected Fs folder is the exact cloud root | `bootstrap_persists_complete_v2_namespace_across_fresh_operators` | Covered |
+| A complete V2 bootstrap survives a fresh Operator | `bootstrap_persists_complete_v2_namespace_across_fresh_operators` | Covered |
+| Shared Library and Device Profile normal publication | Normal single-device path | Planned in this PR |
+| Snapshot metadata, Device Head, and archive bytes persist | Normal single-device path | Planned in this PR |
+| Reconciliation is idempotent | Normal single-device path | Planned in this PR |
+| Stale Shared Library replacement cannot overwrite newer state | Two-device interleaving | Planned in this PR |
+| Sequential device sync preserves independent Device Heads | Two-device interleaving | Planned in this PR |
+| Conflict review and resolution | Follow-up | Deferred |
+| Retention, deletion, tombstones, and profile removal | Follow-up | Deferred |
+| Corrupt, missing, partial, and resurrected remote objects | Follow-up | Deferred |
+| Interrupted publication/deletion and restart recovery | Follow-up | Deferred |
+| Cross-process Cloud Manifest conditional writes | Missing provider CAS contract | Blocked |
+| S3 and WebDAV compatibility | Issues #480 and #481 | Out of scope |

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
@@ -8,11 +8,12 @@ operation-level failures and retry mechanics.
 | --- | --- | --- |
 | The selected Fs folder is the exact cloud root | `bootstrap_persists_complete_v2_namespace_across_fresh_operators` | Covered |
 | A complete V2 bootstrap survives a fresh Operator | `bootstrap_persists_complete_v2_namespace_across_fresh_operators` | Covered |
-| Shared Library and Device Profile normal publication | Normal single-device path | Planned in this PR |
-| Snapshot metadata, Device Head, and archive bytes persist | Normal single-device path | Planned in this PR |
-| Reconciliation is idempotent | Normal single-device path | Planned in this PR |
-| Stale Shared Library replacement cannot overwrite newer state | Two-device interleaving | Planned in this PR |
-| Sequential device sync preserves independent Device Heads | Two-device interleaving | Planned in this PR |
+| Shared Library and Device Profile normal publication | `single_device_snapshot_round_trip_survives_fresh_operators` | Covered |
+| Snapshot metadata, Device Head, and archive bytes persist | `single_device_snapshot_round_trip_survives_fresh_operators` | Covered |
+| Local eviction followed by cloud materialization restores exact bytes | `single_device_snapshot_round_trip_survives_fresh_operators` | Covered |
+| Reconciliation is idempotent | `single_device_snapshot_round_trip_survives_fresh_operators` | Covered |
+| Stale Shared Library replacement cannot overwrite newer state | `two_devices_rebase_stale_library_changes_and_preserve_independent_heads` | Covered |
+| Sequential device sync preserves independent Device Heads | `two_devices_rebase_stale_library_changes_and_preserve_independent_heads` | Covered |
 | Conflict review and resolution | Follow-up | Deferred |
 | Retention, deletion, tombstones, and profile removal | Follow-up | Deferred |
 | Corrupt, missing, partial, and resurrected remote objects | Follow-up | Deferred |

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/interleaving.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/interleaving.rs
@@ -1,0 +1,153 @@
+use rgsm_core::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudManifestRepository, DeviceProfileRepository,
+    SharedLibraryRepository, SharedLibraryRepositoryError, SnapshotSyncCoordinator,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, no_baseline, snapshot};
+
+#[tokio::test]
+async fn two_devices_rebase_stale_library_changes_and_preserve_independent_heads() {
+    const GAME_ID: &str = "example-game";
+    const GAME_NAME: &str = "Example Game";
+    const OTHER_GAME_ID: &str = "other-game";
+    const SNAPSHOT_A: &str = "snapshot-a";
+    const SNAPSHOT_B: &str = "snapshot-b";
+    const ARCHIVE_A: &[u8] = b"opaque archive bytes from device A";
+    const ARCHIVE_B: &[u8] = b"opaque archive bytes from device B";
+
+    let cloud = FsCloudFixture::new();
+    let device_a = DeviceFixture::new("device-a");
+    let device_b = DeviceFixture::new("device-b");
+    let (empty_library, empty_profile) = device_a.empty_library_and_profile();
+    CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .create_empty(&empty_library, &empty_profile)
+        .await
+        .expect("empty Fs root should bootstrap");
+
+    let repository_a = SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS);
+    let repository_b = SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS);
+    let expected_a = repository_a
+        .load()
+        .await
+        .expect("device A should load Shared Library");
+    let expected_b = repository_b
+        .load()
+        .await
+        .expect("device B should load the same Shared Library");
+    let (library_a, profile_a) = device_a.library_and_profile_with_game(GAME_ID, GAME_NAME);
+    let (library_b_only, _) = device_b.library_and_profile_with_game(OTHER_GAME_ID, "Other Game");
+    repository_a
+        .compare_replace(&expected_a, &library_a)
+        .await
+        .expect("device A should publish its Shared Library change");
+    assert!(matches!(
+        repository_b
+            .compare_replace(&expected_b, &library_b_only)
+            .await,
+        Err(SharedLibraryRepositoryError::Stale)
+    ));
+
+    let current = repository_b
+        .load()
+        .await
+        .expect("device B should reload after stale replacement");
+    let mut merged = current.clone();
+    merged.games.extend(library_b_only.games);
+    repository_b
+        .compare_replace(&current, &merged)
+        .await
+        .expect("device B should publish its rebased change");
+    let final_library = SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .load()
+        .await
+        .expect("rebased Shared Library should persist");
+    assert_eq!(final_library, merged);
+
+    let (_, profile_b) = device_b.library_and_profile_with_game(GAME_ID, GAME_NAME);
+    DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .publish(&device_a.id, &profile_a)
+        .await
+        .expect("device A profile should publish");
+    DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .publish(&device_b.id, &profile_b)
+        .await
+        .expect("device B profile should publish");
+
+    let snapshot_a = snapshot(SNAPSHOT_A, None, &device_a.id, ARCHIVE_A.len());
+    device_a.write_archive(GAME_ID, &snapshot_a, ARCHIVE_A);
+    let snapshots_a = device_a.snapshots(GAME_NAME, vec![snapshot_a.clone()], SNAPSHOT_A);
+    SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device_a.archive_root.clone(),
+        device_a.id.clone(),
+        device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        GAME_ID,
+        &snapshots_a,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("device A should publish its Snapshot");
+
+    let snapshot_b = snapshot(SNAPSHOT_B, Some(SNAPSHOT_A), &device_b.id, ARCHIVE_B.len());
+    device_b.write_archive(GAME_ID, &snapshot_b, ARCHIVE_B);
+    let snapshots_b = device_b.snapshots(GAME_NAME, vec![snapshot_a, snapshot_b], SNAPSHOT_B);
+    SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device_b.archive_root.clone(),
+        device_b.id.clone(),
+        device_b.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        GAME_ID,
+        &snapshots_b,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("device B should publish its child Snapshot");
+
+    SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device_a.archive_root.clone(),
+        device_a.id.clone(),
+        device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        GAME_ID,
+        &snapshots_a,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("device A should reconcile after device B");
+
+    let manifest =
+        CloudManifestRepository::new(cloud.new_operator(), CLOUD_MANIFEST_PATH, MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("final Cloud Manifest should load");
+    let game = manifest
+        .games
+        .get(GAME_ID)
+        .expect("interleaved Game should exist");
+    assert_eq!(
+        game.device_heads.get(&device_a.id).map(String::as_str),
+        Some(SNAPSHOT_A)
+    );
+    assert_eq!(
+        game.device_heads.get(&device_b.id).map(String::as_str),
+        Some(SNAPSHOT_B)
+    );
+    assert!(game.snapshots.contains_key(SNAPSHOT_A));
+    assert!(game.snapshots.contains_key(SNAPSHOT_B));
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
@@ -1,9 +1,13 @@
+use rgsm_core::backup::{ArchiveFormat, archive_path};
 use rgsm_core::cloud_sync::v2::{
-    CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudNamespaceClassification,
-    DELETION_REGISTRY_PATH, SHARED_LIBRARY_PATH, V2_NAMESPACE_DESCRIPTOR_PATH, device_profile_path,
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudLibraryBootstrap, CloudManifestRepository,
+    CloudNamespaceClassification, DELETION_REGISTRY_PATH, DeviceProfileRepository,
+    LocalArchiveEviction, SHARED_LIBRARY_PATH, SharedLibraryRepository, SnapshotState,
+    SnapshotSyncCoordinator, V2_NAMESPACE_DESCRIPTOR_PATH, cloud_archive_path, device_profile_path,
 };
+use tokio_util::sync::CancellationToken;
 
-use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS};
+use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, no_baseline, snapshot};
 
 #[tokio::test]
 async fn bootstrap_persists_complete_v2_namespace_across_fresh_operators() {
@@ -51,4 +55,151 @@ async fn bootstrap_persists_complete_v2_namespace_across_fresh_operators() {
     }
 
     assert!(!cloud.root().join("game-save-manager").exists());
+}
+
+#[tokio::test]
+async fn single_device_snapshot_round_trip_survives_fresh_operators() {
+    const GAME_ID: &str = "example-game";
+    const GAME_NAME: &str = "Example Game";
+    const SNAPSHOT_ID: &str = "snapshot-a";
+    const ARCHIVE_BYTES: &[u8] = b"opaque archive bytes from device A";
+
+    let cloud = FsCloudFixture::new();
+    let device = DeviceFixture::new("device-a");
+    let (empty_library, empty_profile) = device.empty_library_and_profile();
+    CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .create_empty(&empty_library, &empty_profile)
+        .await
+        .expect("empty Fs root should bootstrap");
+
+    let (library, profile) = device.library_and_profile_with_game(GAME_ID, GAME_NAME);
+    SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .compare_replace(&empty_library, &library)
+        .await
+        .expect("Shared Library should publish");
+    DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .publish(&device.id, &profile)
+        .await
+        .expect("Device Profile should publish");
+
+    let local_snapshot = snapshot(SNAPSHOT_ID, None, &device.id, ARCHIVE_BYTES.len());
+    let local_path = device.write_archive(GAME_ID, &local_snapshot, ARCHIVE_BYTES);
+    let local_snapshots = device.snapshots(GAME_NAME, vec![local_snapshot.clone()], SNAPSHOT_ID);
+    let first = SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device.archive_root.clone(),
+        device.id.clone(),
+        device.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        GAME_ID,
+        &local_snapshots,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("first reconciliation should publish and upload");
+    assert_eq!(first.published, 1);
+    assert_eq!(first.uploaded, 1);
+    assert_eq!(first.downloaded, 0);
+
+    let fresh_operator = cloud.new_operator();
+    let manifest =
+        CloudManifestRepository::new(fresh_operator.clone(), CLOUD_MANIFEST_PATH, MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Cloud Manifest should load through a fresh Operator");
+    let game = manifest
+        .games
+        .get(GAME_ID)
+        .expect("synced Game should exist");
+    assert_eq!(
+        game.device_heads.get(&device.id).map(String::as_str),
+        Some(SNAPSHOT_ID)
+    );
+    assert!(
+        game.local_archives
+            .get(&device.id)
+            .is_some_and(|items| items.contains(SNAPSHOT_ID))
+    );
+    let node = game
+        .snapshots
+        .get(SNAPSHOT_ID)
+        .expect("synced Snapshot should exist");
+    let SnapshotState::Live(live) = &node.state else {
+        panic!("synced Snapshot should be live");
+    };
+    assert!(live.cloud_archive_verified);
+    assert_eq!(
+        live.integrity.as_ref().map(|integrity| integrity.size),
+        Some(ARCHIVE_BYTES.len() as u64)
+    );
+    let remote_path = cloud_archive_path(GAME_ID, SNAPSHOT_ID, ArchiveFormat::Zip)
+        .expect("cloud archive path should be valid");
+    assert_eq!(
+        fresh_operator
+            .read(&remote_path)
+            .await
+            .expect("cloud archive should be readable")
+            .to_vec(),
+        ARCHIVE_BYTES
+    );
+
+    assert!(
+        LocalArchiveEviction::new(
+            cloud.new_operator(),
+            device.archive_root.clone(),
+            device.id.clone(),
+            MAX_ATTEMPTS,
+        )
+        .evict(GAME_ID, SNAPSHOT_ID)
+        .await
+        .expect("local archive should evict")
+    );
+    assert!(!local_path.exists());
+
+    CloudArchiveMaterializer::new(
+        cloud.new_operator(),
+        device.archive_root.clone(),
+        device.id.clone(),
+        device.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .download(GAME_ID, SNAPSHOT_ID)
+    .await
+    .expect("cloud archive should materialize");
+    assert_eq!(
+        std::fs::read(&local_path).expect("materialized archive should be readable"),
+        ARCHIVE_BYTES
+    );
+    assert_eq!(
+        local_path,
+        archive_path(
+            &device.archive_root.join(GAME_ID),
+            SNAPSHOT_ID,
+            ArchiveFormat::Zip
+        )
+    );
+
+    let repeated = SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device.archive_root.clone(),
+        device.id.clone(),
+        device.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        GAME_ID,
+        &local_snapshots,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("repeated reconciliation should succeed");
+    assert_eq!(repeated.published, 0);
+    assert_eq!(repeated.uploaded, 0);
+    assert_eq!(repeated.downloaded, 0);
 }

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
@@ -1,0 +1,54 @@
+use rgsm_core::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudNamespaceClassification,
+    DELETION_REGISTRY_PATH, SHARED_LIBRARY_PATH, V2_NAMESPACE_DESCRIPTOR_PATH, device_profile_path,
+};
+
+use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS};
+
+#[tokio::test]
+async fn bootstrap_persists_complete_v2_namespace_across_fresh_operators() {
+    let cloud = FsCloudFixture::new();
+    let device = DeviceFixture::new("device-a");
+    let (shared_library, device_profile) = device.empty_library_and_profile();
+
+    CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .create_empty(&shared_library, &device_profile)
+        .await
+        .expect("empty Fs root should bootstrap");
+
+    let fresh_operator = cloud.new_operator();
+    let classification = CloudLibraryBootstrap::new(fresh_operator.clone(), MAX_ATTEMPTS)
+        .inspect()
+        .await
+        .expect("persisted namespace should classify");
+
+    let CloudNamespaceClassification::SupportedV2 {
+        descriptor,
+        shared_library: stored_library,
+        manifest,
+    } = classification
+    else {
+        panic!("bootstrapped Fs root should classify as V2");
+    };
+    assert_eq!(descriptor, Default::default());
+    assert_eq!(stored_library, shared_library);
+    assert_eq!(manifest, Default::default());
+
+    for path in [
+        V2_NAMESPACE_DESCRIPTOR_PATH,
+        SHARED_LIBRARY_PATH,
+        CLOUD_MANIFEST_PATH,
+        DELETION_REGISTRY_PATH,
+        &device_profile_path(&device.id),
+    ] {
+        assert!(
+            fresh_operator
+                .exists(path)
+                .await
+                .expect("required object existence should be readable"),
+            "required V2 object should persist: {path}"
+        );
+    }
+
+    assert!(!cloud.root().join("game-save-manager").exists());
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use opendal::Operator;
+use rgsm_core::cloud_sync::{Backend, CloudSyncSessionConfig};
+use rgsm_core::config::{
+    Config, ConfigurationOwners, DeviceProfile, SharedLibrary, V2_CONFIG_SCHEMA_VERSION,
+};
+use rgsm_core::device::DeviceId;
+
+pub const MAX_ATTEMPTS: usize = 2;
+
+pub struct FsCloudFixture {
+    root: temp_dir::TempDir,
+}
+
+impl FsCloudFixture {
+    pub fn new() -> Self {
+        Self {
+            root: temp_dir::TempDir::new().expect("temporary cloud root should initialize"),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        self.root.path()
+    }
+
+    pub fn new_operator(&self) -> Operator {
+        CloudSyncSessionConfig {
+            root_path: self.root.path().to_string_lossy().into_owned(),
+            max_concurrency: 2,
+            backend: Backend::Fs,
+        }
+        .get_op()
+        .expect("Fs cloud operator should initialize")
+    }
+}
+
+pub struct DeviceFixture {
+    pub id: DeviceId,
+}
+
+impl DeviceFixture {
+    pub fn new(id: &str) -> Self {
+        Self { id: id.to_string() }
+    }
+
+    pub fn empty_library_and_profile(&self) -> (SharedLibrary, DeviceProfile) {
+        let owners = ConfigurationOwners::from_legacy(&Config::default(), &self.id);
+        let profile = owners
+            .device_profiles
+            .get(&self.id)
+            .expect("current device profile should exist")
+            .clone();
+        (
+            SharedLibrary {
+                schema_version: V2_CONFIG_SCHEMA_VERSION,
+                games: Vec::new(),
+            },
+            profile,
+        )
+    }
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
@@ -1,6 +1,8 @@
-use std::path::Path;
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
 
 use opendal::Operator;
+use rgsm_core::backup::{ArchiveFormat, CreatedBy, Game, GameSnapshots, Snapshot, archive_path};
 use rgsm_core::cloud_sync::{Backend, CloudSyncSessionConfig};
 use rgsm_core::config::{
     Config, ConfigurationOwners, DeviceProfile, SharedLibrary, V2_CONFIG_SCHEMA_VERSION,
@@ -37,11 +39,20 @@ impl FsCloudFixture {
 
 pub struct DeviceFixture {
     pub id: DeviceId,
+    pub archive_root: PathBuf,
+    pub progress_path: PathBuf,
+    _root: temp_dir::TempDir,
 }
 
 impl DeviceFixture {
     pub fn new(id: &str) -> Self {
-        Self { id: id.to_string() }
+        let root = temp_dir::TempDir::new().expect("temporary device root should initialize");
+        Self {
+            id: id.to_string(),
+            archive_root: root.path().join("archives"),
+            progress_path: root.path().join("materialization-progress.json"),
+            _root: root,
+        }
     }
 
     pub fn empty_library_and_profile(&self) -> (SharedLibrary, DeviceProfile) {
@@ -59,4 +70,70 @@ impl DeviceFixture {
             profile,
         )
     }
+
+    pub fn library_and_profile_with_game(
+        &self,
+        game_id: &str,
+        game_name: &str,
+    ) -> (SharedLibrary, DeviceProfile) {
+        let config = Config {
+            backup_path: self.archive_root.to_string_lossy().into_owned(),
+            games: vec![Game {
+                name: game_name.to_string(),
+                storage_key: game_id.to_string(),
+                save_paths: Vec::new(),
+                game_paths: HashMap::new(),
+                next_save_unit_id: 0,
+                cloud_sync_enabled: true,
+                auto_backup: None,
+                ludusavi_meta: None,
+                device_bindings: HashMap::new(),
+            }],
+            ..Config::default()
+        };
+        let owners = ConfigurationOwners::from_legacy(&config, &self.id);
+        let profile = owners
+            .device_profiles
+            .get(&self.id)
+            .expect("current device profile should exist")
+            .clone();
+        (owners.shared_library, profile)
+    }
+
+    pub fn write_archive(&self, game_id: &str, snapshot: &Snapshot, bytes: &[u8]) -> PathBuf {
+        let path = archive_path(
+            &self.archive_root.join(game_id),
+            &snapshot.date,
+            snapshot.archive_format,
+        );
+        std::fs::create_dir_all(path.parent().expect("archive path should have a parent"))
+            .expect("archive directory should initialize");
+        std::fs::write(&path, bytes).expect("archive bytes should be writable");
+        path
+    }
+
+    pub fn snapshots(&self, game_name: &str, backups: Vec<Snapshot>, head: &str) -> GameSnapshots {
+        let mut snapshots = GameSnapshots::new(game_name);
+        snapshots.backups = backups;
+        snapshots.set_head_for_device(self.id.clone(), Some(head.to_string()));
+        snapshots
+    }
+}
+
+pub fn snapshot(id: &str, parent: Option<&str>, device_id: &str, size: usize) -> Snapshot {
+    Snapshot {
+        date: id.to_string(),
+        describe: format!("Snapshot {id}"),
+        path: format!("{id}.zip"),
+        archive_format: ArchiveFormat::Zip,
+        size: size as u64,
+        parent: parent.map(str::to_string),
+        archive_hash: None,
+        device_id: Some(device_id.to_string()),
+        created_by: CreatedBy::Manual,
+    }
+}
+
+pub fn no_baseline() -> BTreeSet<String> {
+    BTreeSet::new()
 }


### PR DESCRIPTION
## Summary

- exercise Cloud Sync V2 through the production OpenDAL Fs backend with persistent single-device and deterministic two-device scenarios
- verify bootstrap, owner publication, archive round trips, idempotent reconciliation, stale Shared Library rejection, and independent Device Heads
- ignore the Fs lister's self-entry so an empty selected folder classifies correctly, and run the suite explicitly in CI

Refs #479