### PR TITLE
fix(cloud-sync): :shield: block writes before library activation

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
@@ -14,10 +14,10 @@ pub use rgsm_core::hooks::*;
 
 use std::sync::{Arc, RwLock};
 
-use log::warn;
+use log::{info, warn};
 use tauri::{AppHandle, Manager};
 
-use rgsm_core::cloud_sync::{Backend, CloudSyncTaskManager};
+use rgsm_core::cloud_sync::Backend;
 use rgsm_core::config::{CloudNamespaceGeneration, Config, cloud_namespace_generation};
 
 pub struct HookPipelineState {
@@ -45,11 +45,7 @@ impl HookPipelineState {
     }
 }
 
-pub fn build_builtin_pipeline(
-    app: &AppHandle,
-    task_manager: Arc<CloudSyncTaskManager>,
-    config: &Config,
-) -> HookPipeline {
+pub fn build_builtin_pipeline(app: &AppHandle, config: &Config) -> HookPipeline {
     let mut hooks: Vec<Box<dyn LifecycleHook>> = Vec::new();
 
     if config.settings.extra_backup_when_apply {
@@ -82,12 +78,10 @@ pub fn build_builtin_pipeline(
     )));
     if !matches!(config.settings.cloud_settings.backend, Backend::Disabled) {
         match cloud_namespace_generation() {
-            Ok(CloudNamespaceGeneration::LegacyV1) => {
-                let sync_queue: Arc<dyn SyncJobQueue> = task_manager;
-                hooks.push(Box::new(
-                    rgsm_core::hooks::cloud_sync_hook::CloudSyncEnqueueHook::new(sync_queue),
-                ));
-            }
+            Ok(CloudNamespaceGeneration::LegacyV1) => info!(
+                target: "rgsm::hooks::cloud_sync",
+                "Automatic legacy cloud writes are paused until Cloud Library activation"
+            ),
             Ok(CloudNamespaceGeneration::V2) => {
                 let state = app.state::<crate::snapshot_sync::SnapshotSyncRuntimeState>();
                 match rgsm_core::services::build_v2_snapshot_sync_hook(state.operation_lock()) {
@@ -114,6 +108,5 @@ pub fn build_builtin_pipeline(
 
 pub fn rebuild_pipeline(app: &AppHandle, config: &Config) -> Arc<HookPipeline> {
     let pipeline_state = app.state::<HookPipelineState>();
-    let cloud_sync_manager = app.state::<Arc<CloudSyncTaskManager>>().inner().clone();
-    pipeline_state.replace(build_builtin_pipeline(app, cloud_sync_manager, config))
+    pipeline_state.replace(build_builtin_pipeline(app, config))
 }

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -7,7 +7,7 @@ use rust_i18n::{i18n, t};
 i18n!("../../../locales", fallback = ["en_US", "zh_SIMPLIFIED"]);
 
 use rgsm_core::cloud_sync::SyncEventEmitter;
-use rgsm_core::config::{cloud_namespace_generation, get_config};
+use rgsm_core::config::get_config;
 use tauri::Manager;
 
 use log::{error, info, warn};
@@ -66,7 +66,7 @@ impl SyncEventEmitter for TauriSyncEmitter {
 
 pub fn run() -> anyhow::Result<()> {
     info!("{}", t!("home.hello_world"));
-    let config_status = config_check()?;
+    config_check()?;
 
     // 将 panic 信息记录到日志中
     std::panic::set_hook(Box::new(|panic_info| {
@@ -238,26 +238,10 @@ pub fn run() -> anyhow::Result<()> {
             let config = get_config().expect("Failed to load config while building hooks");
             let snapshot_sync_runtime = snapshot_sync::SnapshotSyncRuntimeState::default();
             app.manage(snapshot_sync_runtime.clone());
-            let pipeline =
-                hooks::build_builtin_pipeline(app.handle(), cloud_sync_manager.clone(), &config);
+            let pipeline = hooks::build_builtin_pipeline(app.handle(), &config);
             app.manage(hooks::HookPipelineState::new(pipeline));
 
-            let startup_cloud_sync_manager = cloud_sync_manager.clone();
             app.manage(cloud_sync_manager);
-            if config_status.config_migrated {
-                let migrated_config = config.clone();
-                let generation =
-                    cloud_namespace_generation().expect("Failed to load Cloud Library generation");
-                tauri::async_runtime::spawn(async move {
-                    startup_cloud_sync_manager
-                        .enqueue_config_upload_if_enabled(
-                            &migrated_config,
-                            generation,
-                            "config_migration",
-                        )
-                        .await;
-                });
-            }
             snapshot_sync::setup(app.handle().clone(), snapshot_sync_runtime);
 
             sound::setup(app).expect("Cannot setup sound manager");

--- a/apps/rgsm-tui/src/app.rs
+++ b/apps/rgsm-tui/src/app.rs
@@ -105,19 +105,6 @@ impl App {
         self.should_quit
     }
 
-    pub async fn enqueue_config_migration_sync(&self) -> Result<()> {
-        if !self.settings.auto_enqueue_cloud_on_change {
-            return Ok(());
-        }
-
-        let config = rgsm_core::config::get_config()?;
-        let generation = rgsm_core::config::cloud_namespace_generation()?;
-        self.cloud_sync_manager
-            .enqueue_config_upload_if_enabled(&config, generation, "config_migration")
-            .await;
-        Ok(())
-    }
-
     pub fn selected_game(&self) -> Option<rgsm_core::backup::Game> {
         let indices = self.visible_game_indices();
         indices

--- a/apps/rgsm-tui/src/hooks.rs
+++ b/apps/rgsm-tui/src/hooks.rs
@@ -2,12 +2,11 @@ use std::sync::{Arc, Mutex};
 
 use rgsm_core::backup::{RestoreNotificationLevel, RestoreNotifier};
 use rgsm_core::cloud_sync::{
-    Backend, CloudSyncError, CloudSyncStatus, CloudSyncTaskManager, SyncEventEmitter,
+    CloudSyncError, CloudSyncStatus, CloudSyncTaskManager, SyncEventEmitter,
 };
 use rgsm_core::config::Config;
 use rgsm_core::hooks::{
-    ArchiveHashHook, ArchiveVerifyHook, CloudSyncEnqueueHook, HookPipeline, LifecycleHook,
-    PreRestoreBackupHook, SyncJobQueue,
+    ArchiveHashHook, ArchiveVerifyHook, HookPipeline, LifecycleHook, PreRestoreBackupHook,
 };
 
 use crate::logging::SessionLog;
@@ -70,8 +69,8 @@ impl SyncEventEmitter for TuiSyncEmitter {
 
 pub fn build_pipeline(
     config: &Config,
-    settings: &TuiSettings,
-    cloud_sync_manager: Arc<CloudSyncTaskManager>,
+    _settings: &TuiSettings,
+    _cloud_sync_manager: Arc<CloudSyncTaskManager>,
 ) -> Arc<HookPipeline> {
     let mut hooks: Vec<Box<dyn LifecycleHook>> = Vec::new();
     if config.settings.extra_backup_when_apply {
@@ -83,11 +82,55 @@ pub fn build_pipeline(
     if config.settings.verify_archive_before_apply {
         hooks.push(Box::new(ArchiveVerifyHook));
     }
-    if settings.auto_enqueue_cloud_on_change
-        && !matches!(config.settings.cloud_settings.backend, Backend::Disabled)
-    {
-        let sync_queue: Arc<dyn SyncJobQueue> = cloud_sync_manager;
-        hooks.push(Box::new(CloudSyncEnqueueHook::new(sync_queue)));
-    }
     Arc::new(HookPipeline::new(hooks))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use rgsm_core::cloud_sync::{Backend, CloudSyncTaskManager};
+    use rgsm_core::hooks::{ConfigSavedCtx, HookSource};
+
+    use super::*;
+
+    struct RecordingEmitter {
+        emissions: Arc<AtomicUsize>,
+    }
+
+    impl SyncEventEmitter for RecordingEmitter {
+        fn emit_status(&self, _status: &CloudSyncStatus) {
+            self.emissions.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn emit_error(&self, _error: &CloudSyncError) {}
+    }
+
+    #[tokio::test]
+    async fn legacy_tui_pipeline_does_not_enqueue_automatic_writes() {
+        let emissions = Arc::new(AtomicUsize::new(0));
+        let manager = CloudSyncTaskManager::new(Arc::new(RecordingEmitter {
+            emissions: Arc::clone(&emissions),
+        }));
+        let mut config = Config::default();
+        config.settings.cloud_settings.backend = Backend::WebDAV {
+            endpoint: "https://example.invalid/dav".into(),
+            username: "user".into(),
+            password: "pass".into(),
+        };
+        let settings = TuiSettings {
+            auto_enqueue_cloud_on_change: true,
+            ..TuiSettings::default()
+        };
+        let pipeline = build_pipeline(&config, &settings, manager);
+
+        pipeline
+            .fire_config_saved(&ConfigSavedCtx {
+                config,
+                source: HookSource::UserManual,
+            })
+            .await;
+
+        assert_eq!(emissions.load(Ordering::Relaxed), 0);
+    }
 }

--- a/apps/rgsm-tui/src/main.rs
+++ b/apps/rgsm-tui/src/main.rs
@@ -38,8 +38,7 @@ async fn main() -> Result<()> {
     rgsm_core::app_dirs::set_app_data_dir_override(data_dir.clone())
         .context("failed to set RGSM TUI profile directory")?;
 
-    let config_status =
-        rgsm_core::config::config_check().context("failed to initialize RGSM config")?;
+    rgsm_core::config::config_check().context("failed to initialize RGSM config")?;
     if let Some(source) = &options.import_gui_config {
         let report = profile_import::import_gui_profile(source, &data_dir)
             .context("failed to import GUI profile")?;
@@ -61,11 +60,6 @@ async fn main() -> Result<()> {
     let mut app = App::new(data_dir, settings)
         .await
         .context("failed to initialize TUI state")?;
-    if config_status.config_migrated {
-        app.enqueue_config_migration_sync()
-            .await
-            .context("failed to enqueue migrated config cloud sync")?;
-    }
     let mut terminal = TerminalGuard::enter().context("failed to enter terminal UI")?;
 
     while !app.should_quit() {

--- a/crates/rgsm-core/src/cloud_sync/task_manager.rs
+++ b/crates/rgsm-core/src/cloud_sync/task_manager.rs
@@ -20,7 +20,7 @@ use super::sync_state::{
 use crate::backup::GameSnapshots;
 use crate::cloud_sync::transfer::CloudTransfer;
 use crate::cloud_sync::{Backend, session_from_backend, upload_config, upload_game_snapshots};
-use crate::config::{CloudNamespaceGeneration, get_config};
+use crate::config::get_config;
 use crate::hooks::SyncJobQueue;
 use crate::preclude::*;
 
@@ -223,27 +223,6 @@ impl CloudSyncTaskManager {
         self.notify.notify_one();
         self.emit_full_status(Some("Queued cloud sync job".to_string()))
             .await;
-    }
-
-    pub async fn enqueue_config_upload_if_enabled(
-        &self,
-        config: &crate::config::Config,
-        generation: CloudNamespaceGeneration,
-        context: impl Into<String>,
-    ) {
-        if generation != CloudNamespaceGeneration::LegacyV1 {
-            return;
-        }
-        let backend = match &config.settings.cloud_settings.backend {
-            Backend::Disabled => return,
-            backend => backend.clone(),
-        };
-
-        self.enqueue(CloudSyncJob::UploadConfig {
-            backend,
-            context: context.into(),
-        })
-        .await;
     }
 
     pub async fn cancel_all(&self) -> CancelCloudSyncResult {
@@ -769,76 +748,6 @@ mod tests {
 
     fn manager() -> Arc<CloudSyncTaskManager> {
         CloudSyncTaskManager::new(Arc::new(NoopEmitter))
-    }
-
-    #[tokio::test]
-    async fn config_upload_enqueue_skips_disabled_backend() {
-        let manager = manager();
-        let config = crate::config::Config::default();
-
-        manager
-            .enqueue_config_upload_if_enabled(
-                &config,
-                CloudNamespaceGeneration::LegacyV1,
-                "config_migration",
-            )
-            .await;
-
-        let state = manager.state.lock().await;
-        assert!(state.queue.is_empty());
-    }
-
-    #[tokio::test]
-    async fn config_upload_enqueue_uses_config_backend() {
-        let manager = manager();
-        let mut config = crate::config::Config::default();
-        config.settings.cloud_settings.backend = Backend::WebDAV {
-            endpoint: "https://example.invalid/dav".to_string(),
-            username: "user".to_string(),
-            password: "pass".to_string(),
-        };
-
-        manager
-            .enqueue_config_upload_if_enabled(
-                &config,
-                CloudNamespaceGeneration::LegacyV1,
-                "config_migration",
-            )
-            .await;
-
-        let state = manager.state.lock().await;
-        assert_eq!(state.queue.len(), 1);
-        match &state.queue[0].job {
-            CloudSyncJob::UploadConfig {
-                backend: Backend::WebDAV { endpoint, .. },
-                context,
-            } => {
-                assert_eq!(endpoint, "https://example.invalid/dav");
-                assert_eq!(context, "config_migration");
-            }
-            other => panic!("expected config upload job, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn config_upload_enqueue_skips_v2_generation() {
-        let manager = manager();
-        let mut config = crate::config::Config::default();
-        config.settings.cloud_settings.backend = Backend::WebDAV {
-            endpoint: "https://example.invalid/dav".to_string(),
-            username: "user".to_string(),
-            password: "pass".to_string(),
-        };
-
-        manager
-            .enqueue_config_upload_if_enabled(
-                &config,
-                CloudNamespaceGeneration::V2,
-                "config_migration",
-            )
-            .await;
-
-        assert!(manager.state.lock().await.queue.is_empty());
     }
 
     #[tokio::test]

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -232,7 +232,8 @@ pub fn replace_config_local(config: &Config) -> Result<(), ConfigError> {
 /// Replace the config file with a new config struct
 pub async fn set_config(config: &Config) -> Result<(), ConfigError> {
     set_config_local(config)?;
-    // Cloud sync upload is now handled by the hook pipeline (CloudSyncEnqueueHook).
+    // Remote publication is generation-specific. Legacy V1 saves remain local until the
+    // configured cloud root has been inspected and the Cloud Library is explicitly activated.
     Ok(())
 }
 


### PR DESCRIPTION
Prevents a new or migrated installation from overwriting an existing cloud configuration before the remote root has been inspected.

- pauses Legacy V1 automatic cloud-write hooks until explicit create, join, or cutover activates the V2 Cloud Library
- removes startup uploads of migrated V1 configuration from GUI and TUI
- preserves the V2 snapshot-sync hook rebuilt after activation
- adds regression coverage proving a configured legacy backend cannot enqueue a write on config save

Root cause: saving backend or device configuration rebuilt the Legacy V1 hook pipeline and immediately fired `config_saved`, allowing local configuration to upload before `CloudLibrarySetup` classified the remote root.

Relevant verification: workspace Clippy with warnings denied, 401 core tests, 29 TUI tests, configuration-upgrade compatibility tests, persistent Fs V2 tests, and frontend format/lint/typecheck.

closes #360.