### PR TITLE
test(cloud): cover Fs synchronization safety

### DIFF
--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -4,7 +4,7 @@ use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-use super::DELETION_REGISTRY_PATH;
+use super::{CLOUD_ARCHIVES_PREFIX, DELETION_REGISTRY_PATH};
 use crate::device::DeviceId;
 
 pub const DELETION_REGISTRY_SCHEMA_VERSION: u32 = 1;
@@ -83,6 +83,27 @@ impl DeletionRegistryRepository {
             return Err(DeletionRegistryError::GameDeleted(game_id.to_string()));
         }
         Ok(())
+    }
+
+    /// Verify that a Device can write a Game and converge stale Archives when
+    /// its durable deletion marker already exists.
+    pub async fn ensure_active_and_converge_game_archives(
+        &self,
+        device_id: &str,
+        game_id: &str,
+    ) -> Result<(), DeletionRegistryError> {
+        let registry = self.load().await?;
+        if registry.deleted_profiles.contains_key(device_id) {
+            return Err(DeletionRegistryError::ProfileDeleted(device_id.to_string()));
+        }
+        if !registry.deleted_games.contains_key(game_id) {
+            return Ok(());
+        }
+        self.operator
+            .delete_with(&format!("{CLOUD_ARCHIVES_PREFIX}{game_id}/"))
+            .recursive(true)
+            .await?;
+        Err(DeletionRegistryError::GameDeleted(game_id.to_string()))
     }
 
     pub async fn mark_profile_deleted(

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
@@ -107,6 +107,7 @@ impl SnapshotSyncCoordinator {
         cancellation: &CancellationToken,
         materialize_remote: bool,
     ) -> Result<SnapshotReconciliationOutcome, SnapshotSyncError> {
+        self.ensure_active_or_converge_deleted_game(game_id).await?;
         let mut manifest = self.repository().load().await?;
         let order = publication_order(&manifest, game_id, local, local_baseline)?;
         let mut outcome = SnapshotReconciliationOutcome::default();
@@ -269,9 +270,7 @@ impl SnapshotSyncCoordinator {
         snapshot: &Snapshot,
         inherited_revision: Option<u64>,
     ) -> Result<(), SnapshotSyncError> {
-        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
-            .ensure_active(&self.current_device_id, game_id)
-            .await?;
+        self.ensure_active_or_converge_deleted_game(game_id).await?;
         let local_path = self.local_path(game_id, snapshot);
         let integrity = if local_path.is_file() {
             let path = local_path.clone();
@@ -284,6 +283,7 @@ impl SnapshotSyncCoordinator {
             None
         };
         let game_id = game_id.to_string();
+        let cleanup_game_id = game_id.clone();
         let snapshot = snapshot.clone();
         let current_device_id = self.current_device_id.clone();
         self.repository()
@@ -322,6 +322,8 @@ impl SnapshotSyncCoordinator {
                 Ok(())
             })
             .await?;
+        self.ensure_active_or_converge_deleted_game(&cleanup_game_id)
+            .await?;
         Ok(())
     }
 
@@ -333,9 +335,7 @@ impl SnapshotSyncCoordinator {
         let Some(head) = local.head_for_device(&self.current_device_id).cloned() else {
             return Ok(());
         };
-        DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
-            .ensure_active(&self.current_device_id, game_id)
-            .await?;
+        self.ensure_active_or_converge_deleted_game(game_id).await?;
         let manifest = self.repository().load().await?;
         let Some(game) = manifest.games.get(game_id) else {
             return Ok(());
@@ -346,6 +346,7 @@ impl SnapshotSyncCoordinator {
             return Ok(());
         }
         let game_id = game_id.to_string();
+        let cleanup_game_id = game_id.clone();
         let current_device_id = self.current_device_id.clone();
         self.repository()
             .mutate(move |manifest| {
@@ -360,7 +361,36 @@ impl SnapshotSyncCoordinator {
                 Ok(())
             })
             .await?;
+        self.ensure_active_or_converge_deleted_game(&cleanup_game_id)
+            .await?;
         Ok(())
+    }
+
+    async fn ensure_active_or_converge_deleted_game(
+        &self,
+        game_id: &str,
+    ) -> Result<(), SnapshotSyncError> {
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts);
+        match registry
+            .ensure_active_and_converge_game_archives(&self.current_device_id, game_id)
+            .await
+        {
+            Ok(()) => Ok(()),
+            Err(DeletionRegistryError::GameDeleted(_)) => {
+                let deleted_game_id = game_id.to_string();
+                let manifest_game_id = deleted_game_id.clone();
+                self.repository()
+                    .mutate(move |manifest| {
+                        manifest.games.remove(&manifest_game_id);
+                        Ok(())
+                    })
+                    .await?;
+                Err(SnapshotSyncError::DeletionRegistry(
+                    DeletionRegistryError::GameDeleted(deleted_game_id),
+                ))
+            }
+            Err(error) => Err(error.into()),
+        }
     }
 
     fn repository(&self) -> CloudManifestRepository<super::OpenDalManifestTransport> {

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -22,6 +22,92 @@ pub(crate) fn lock_config_test_file() -> MutexGuard<'static, ()> {
     CONFIG_FILE_TEST_LOCK.blocking_lock()
 }
 
+#[cfg(test)]
+pub(crate) struct ConfigTestStateGuard {
+    config_path: PathBuf,
+    original_config: Option<Vec<u8>>,
+    owner_backups: Vec<(PathBuf, Option<PathBuf>)>,
+    _backup_root: temp_dir::TempDir,
+}
+
+#[cfg(test)]
+impl ConfigTestStateGuard {
+    pub(crate) fn replace_with(config: &Config) -> Result<Self, std::io::Error> {
+        let config_path = resolve_app_path("GameSaveManager.config.json");
+        let original_config = fs::read(&config_path).ok();
+        let owner_paths = [
+            crate::config::owner_store::OWNER_DIRECTORY_NAME,
+            crate::config::owner_store::OWNER_STAGING_DIRECTORY_NAME,
+            crate::config::owner_store::OWNER_ROLLBACK_DIRECTORY_NAME,
+        ]
+        .into_iter()
+        .map(resolve_app_path)
+        .collect::<Vec<_>>();
+        let backup_root = temp_dir::TempDir::new()?;
+        let owner_backups = owner_paths
+            .iter()
+            .enumerate()
+            .map(|(index, owner_path)| {
+                if !owner_path.exists() {
+                    return Ok((owner_path.clone(), None));
+                }
+                let backup_path = backup_root.path().join(index.to_string());
+                copy_test_directory(owner_path, &backup_path)?;
+                Ok((owner_path.clone(), Some(backup_path)))
+            })
+            .collect::<Result<Vec<_>, std::io::Error>>()?;
+        for owner_path in &owner_paths {
+            let _ = fs::remove_dir_all(owner_path);
+        }
+        if let Some(parent) = config_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(
+            &config_path,
+            serde_json::to_vec_pretty(config).map_err(std::io::Error::other)?,
+        )?;
+
+        Ok(Self {
+            config_path,
+            original_config,
+            owner_backups,
+            _backup_root: backup_root,
+        })
+    }
+}
+
+#[cfg(test)]
+impl Drop for ConfigTestStateGuard {
+    fn drop(&mut self) {
+        for (owner_path, backup_path) in &self.owner_backups {
+            let _ = fs::remove_dir_all(owner_path);
+            if let Some(backup_path) = backup_path {
+                let _ = copy_test_directory(backup_path, owner_path);
+            }
+        }
+        if let Some(contents) = &self.original_config {
+            let _ = fs::write(&self.config_path, contents);
+        } else {
+            let _ = fs::remove_file(&self.config_path);
+        }
+    }
+}
+
+#[cfg(test)]
+fn copy_test_directory(source: &Path, target: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let target_path = target.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_test_directory(&entry.path(), &target_path)?;
+        } else {
+            fs::copy(entry.path(), target_path)?;
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ConfigCheckOutcome {
     pub config_migrated: bool,

--- a/crates/rgsm-core/src/services/game_deletion.rs
+++ b/crates/rgsm-core/src/services/game_deletion.rs
@@ -143,3 +143,320 @@ async fn cloud_prefix_has_entries(
     let mut lister = operator.lister(prefix).await?;
     Ok(lister.try_next().await?.is_some())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use crate::backup::{ArchiveFormat, CreatedBy, Game, GameSnapshots, Snapshot, archive_path};
+    use crate::cloud_sync::v2::{
+        CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudManifestRepository,
+        DeletionRegistryRepository, DeviceProfileRepository, SharedGameDeletionError,
+        SharedLibraryRepository, SnapshotSyncCoordinator, cloud_archive_path,
+    };
+    use crate::cloud_sync::{Backend, CloudSettings, CloudSyncSessionConfig};
+    use crate::config::{
+        CloudNamespaceGeneration, Config, ConfigTestStateGuard, ConfigurationOwners, SharedLibrary,
+        activate_cloud_namespace_v2, cloud_bootstrap_inputs, get_config, set_config_local,
+    };
+    use crate::device::get_current_device_id;
+    use crate::hooks::HookPipeline;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+
+    async fn assert_active_cloud_game(
+        config: &Config,
+        local_archive: &Path,
+        cloud_archive: &str,
+        second_device_id: &str,
+    ) {
+        assert!(
+            get_config()
+                .expect("effective configuration should reload")
+                .games
+                .iter()
+                .any(|game| game.storage_key == "example-game")
+        );
+        let (_, active_profile, _) =
+            cloud_bootstrap_inputs().expect("active local profile should reload");
+        assert!(active_profile.games.contains_key("example-game"));
+        assert_eq!(
+            std::fs::read(local_archive).expect("local archive should remain readable"),
+            b"service deletion archive bytes"
+        );
+
+        let operator = CloudSyncSessionConfig::from(&config.settings.cloud_settings)
+            .get_op()
+            .expect("fresh Fs operator should initialize");
+        assert!(
+            SharedLibraryRepository::new(operator.clone(), 2)
+                .load()
+                .await
+                .expect("Shared Library should reload")
+                .games
+                .iter()
+                .any(|game| game.storage_key == "example-game")
+        );
+        let profiles = DeviceProfileRepository::new(operator.clone(), 2)
+            .list()
+            .await
+            .expect("Device Profiles should reload");
+        assert!(
+            profiles
+                .iter()
+                .find(|profile| profile.device.id == second_device_id)
+                .expect("second Device Profile should remain")
+                .games
+                .contains_key("example-game")
+        );
+        assert!(
+            CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 2)
+                .load()
+                .await
+                .expect("Cloud Manifest should reload")
+                .games
+                .contains_key("example-game")
+        );
+        assert!(
+            operator
+                .exists(cloud_archive)
+                .await
+                .expect("cloud archive should remain")
+        );
+        assert!(
+            !DeletionRegistryRepository::new(operator, 2)
+                .load()
+                .await
+                .expect("Deletion Registry should reload")
+                .deleted_games
+                .contains_key("example-game")
+        );
+    }
+
+    async fn assert_deleted_cloud_game(config: &Config, local_root: &Path, cloud_archive: &str) {
+        assert!(
+            get_config()
+                .expect("effective configuration should reload")
+                .games
+                .iter()
+                .all(|game| game.storage_key != "example-game")
+        );
+        let (_, active_profile, _) =
+            cloud_bootstrap_inputs().expect("active local profile should reload");
+        assert!(!active_profile.games.contains_key("example-game"));
+        assert!(!local_root.join("example-game").exists());
+
+        let operator = CloudSyncSessionConfig::from(&config.settings.cloud_settings)
+            .get_op()
+            .expect("fresh Fs operator should initialize");
+        assert!(
+            SharedLibraryRepository::new(operator.clone(), 2)
+                .load()
+                .await
+                .expect("Shared Library should reload")
+                .games
+                .iter()
+                .all(|game| game.storage_key != "example-game")
+        );
+        assert!(
+            DeviceProfileRepository::new(operator.clone(), 2)
+                .list()
+                .await
+                .expect("Device Profiles should reload")
+                .iter()
+                .all(|profile| !profile.games.contains_key("example-game"))
+        );
+        assert!(
+            !CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 2)
+                .load()
+                .await
+                .expect("Cloud Manifest should reload")
+                .games
+                .contains_key("example-game")
+        );
+        assert!(
+            !operator
+                .exists(cloud_archive)
+                .await
+                .expect("cloud archive absence should be observable")
+        );
+        assert!(
+            DeletionRegistryRepository::new(operator, 2)
+                .load()
+                .await
+                .expect("Deletion Registry should reload")
+                .deleted_games
+                .contains_key("example-game")
+        );
+    }
+
+    #[test]
+    fn permanently_delete_cloud_game() {
+        let _config_lock = crate::config::lock_config_test_file();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("test runtime should initialize");
+        runtime.block_on(async {
+            const GAME_ID: &str = "example-game";
+            const GAME_NAME: &str = "Example Game";
+            const SNAPSHOT_ID: &str = "snapshot-a";
+            const ARCHIVE_BYTES: &[u8] = b"service deletion archive bytes";
+
+            let _ = crate::app_dirs::get_app_data_dir();
+            let cloud_root = temp_dir::TempDir::new().expect("temporary Fs root should initialize");
+            let local_root =
+                temp_dir::TempDir::new().expect("temporary local archive root should initialize");
+            let current_device_id = get_current_device_id();
+            let mut config = Config {
+                backup_path: local_root.path().to_string_lossy().into_owned(),
+                games: vec![Game {
+                    name: GAME_NAME.to_string(),
+                    storage_key: GAME_ID.to_string(),
+                    save_paths: Vec::new(),
+                    game_paths: Default::default(),
+                    next_save_unit_id: 0,
+                    cloud_sync_enabled: true,
+                    auto_backup: None,
+                    ludusavi_meta: None,
+                    device_bindings: Default::default(),
+                }],
+                ..Config::default()
+            };
+            config.settings.cloud_settings = CloudSettings {
+                backend: Backend::Fs,
+                root_path: cloud_root.path().to_string_lossy().into_owned(),
+                max_concurrency: 2,
+                ..CloudSettings::default()
+            };
+            let _config_state =
+                ConfigTestStateGuard::replace_with(&config).expect("config state should isolate");
+            set_config_local(&config).expect("effective V2 configuration should persist");
+            let (library, profile, _) =
+                cloud_bootstrap_inputs().expect("persisted configuration should load");
+            activate_cloud_namespace_v2(&library, &profile)
+                .expect("configuration should activate the V2 namespace");
+            assert_eq!(
+                crate::config::cloud_namespace_generation()
+                    .expect("namespace generation should load"),
+                CloudNamespaceGeneration::V2
+            );
+
+            let operator = CloudSyncSessionConfig::from(&config.settings.cloud_settings)
+                .get_op()
+                .expect("Fs operator should initialize");
+            let empty_library = SharedLibrary {
+                schema_version: library.schema_version,
+                games: Vec::new(),
+            };
+            CloudLibraryBootstrap::new(operator.clone(), 2)
+                .create_empty(&empty_library, &profile)
+                .await
+                .expect("empty Cloud Namespace should bootstrap");
+            SharedLibraryRepository::new(operator.clone(), 2)
+                .compare_replace(&empty_library, &library)
+                .await
+                .expect("Shared Game should publish");
+            DeviceProfileRepository::new(operator.clone(), 2)
+                .publish(current_device_id, &profile)
+                .await
+                .expect("acting Device Profile should publish");
+            let second_device_id = "device-b".to_string();
+            let mut second_profile = ConfigurationOwners::from_legacy(&config, &second_device_id)
+                .device_profiles
+                .remove(&second_device_id)
+                .expect("second Device Profile should initialize");
+            second_profile.local_archive_root = Some(
+                local_root
+                    .path()
+                    .join("device-b")
+                    .to_string_lossy()
+                    .into_owned(),
+            );
+            DeviceProfileRepository::new(operator.clone(), 2)
+                .publish(&second_device_id, &second_profile)
+                .await
+                .expect("second Device Profile should publish");
+
+            let snapshot = Snapshot {
+                date: SNAPSHOT_ID.to_string(),
+                describe: "service deletion snapshot".to_string(),
+                path: format!("{SNAPSHOT_ID}.zip"),
+                archive_format: ArchiveFormat::Zip,
+                size: ARCHIVE_BYTES.len() as u64,
+                parent: None,
+                archive_hash: None,
+                device_id: Some(current_device_id.clone()),
+                created_by: CreatedBy::Manual,
+            };
+            let local_archive = archive_path(
+                &local_root.path().join(GAME_ID),
+                SNAPSHOT_ID,
+                ArchiveFormat::Zip,
+            );
+            std::fs::create_dir_all(
+                local_archive
+                    .parent()
+                    .expect("archive path should have parent"),
+            )
+            .expect("archive directory should initialize");
+            std::fs::write(&local_archive, ARCHIVE_BYTES).expect("archive bytes should persist");
+            let mut snapshots = GameSnapshots::new(GAME_NAME);
+            snapshots.backups = vec![snapshot.clone()];
+            snapshots.set_head_for_device(current_device_id.clone(), Some(SNAPSHOT_ID.to_string()));
+            SnapshotSyncCoordinator::new(
+                operator.clone(),
+                local_root.path().to_path_buf(),
+                current_device_id.clone(),
+                local_root.path().join("materialization-progress.json"),
+                2,
+            )
+            .reconcile_game(
+                GAME_ID,
+                &snapshots,
+                0,
+                &Default::default(),
+                &CancellationToken::new(),
+            )
+            .await
+            .expect("verified archive should populate the Cloud Manifest");
+            let cloud_archive = cloud_archive_path(GAME_ID, SNAPSHOT_ID, ArchiveFormat::Zip)
+                .expect("cloud archive path should be valid");
+            assert!(
+                operator
+                    .exists(&cloud_archive)
+                    .await
+                    .expect("cloud archive should exist")
+            );
+
+            let service = ServiceContext::new(Arc::new(HookPipeline::new(vec![])));
+            let unconfirmed = service
+                .permanently_delete_cloud_game(GAME_ID, false)
+                .await
+                .expect_err("permanent deletion should require confirmation");
+            assert!(matches!(
+                unconfirmed,
+                CloudLibraryServiceError::SharedGameDeletion(
+                    SharedGameDeletionError::ConfirmationRequired
+                )
+            ));
+            assert_active_cloud_game(&config, &local_archive, &cloud_archive, &second_device_id)
+                .await;
+
+            service
+                .permanently_delete_cloud_game(GAME_ID, true)
+                .await
+                .expect("confirmed deletion should converge every owner");
+
+            assert_deleted_cloud_game(&config, local_root.path(), &cloud_archive).await;
+
+            service
+                .permanently_delete_cloud_game(GAME_ID, true)
+                .await
+                .expect("repeated confirmed deletion should converge idempotently");
+            assert_deleted_cloud_game(&config, local_root.path(), &cloud_archive).await;
+        });
+    }
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs.rs
@@ -1,8 +1,14 @@
+#[path = "cloud_sync_v2_fs/conflicts.rs"]
+mod conflicts;
 #[path = "cloud_sync_v2_fs/destructive.rs"]
 mod destructive;
+#[path = "cloud_sync_v2_fs/integrity.rs"]
+mod integrity;
 #[path = "cloud_sync_v2_fs/interleaving.rs"]
 mod interleaving;
 #[path = "cloud_sync_v2_fs/normal_path.rs"]
 mod normal_path;
+#[path = "cloud_sync_v2_fs/recovery.rs"]
+mod recovery;
 #[path = "cloud_sync_v2_fs/support.rs"]
 mod support;

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/TEST_MATRIX.md
@@ -20,9 +20,9 @@ operation-level failures and retry mechanics.
 | Retention deletes only expired automatic Snapshots and keeps the live branch | `retention_removes_only_expired_automatic_snapshot_and_keeps_live_branch` | Covered |
 | Device Profile removal preserves other Heads and shared Archive state | `profile_removal_preserves_other_device_head_and_blocks_stale_republication` | Covered |
 | A durable Profile marker blocks stale republication | `profile_removal_preserves_other_device_head_and_blocks_stale_republication` | Covered |
-| Conflict review and resolution | Follow-up | Deferred |
-| Shared Game deletion through its application-service boundary | Follow-up | Deferred |
-| Corrupt, missing, partial, and resurrected remote objects | Follow-up | Deferred |
-| Interrupted publication/deletion and restart recovery | Follow-up | Deferred |
+| Conflict review and resolution | `conflict_review_reports_divergent_device_positions`, `keep_local_publishes_complete_lineage_and_preserves_remote_position`, `accept_remote_materializes_selected_archive_and_moves_only_current_device_position`, `keep_local_rejects_stale_review_without_persisted_change`, `accept_remote_rejects_unavailable_candidate_without_persisted_change` | Covered |
+| Shared Game deletion through its application-service boundary | `permanently_delete_cloud_game` | Covered |
+| Corrupt, missing, partial, and resurrected remote objects | `missing_cloud_archive_fails_without_replacing_local_archive`, `truncated_cloud_archive_fails_without_replacing_local_archive`, `corrupt_cloud_archive_fails_without_replacing_local_archive`, `deleted_game_archive_recreation_cannot_restore_game_state` | Covered |
+| Interrupted publication/deletion and restart recovery | `materialize_all_stops_at_damaged_archive_and_resumes_after_repair`, `game_deletion_recovers_after_marker_written`, `game_deletion_recovers_after_local_archives_removed`, `game_deletion_recovers_after_cloud_archives_removed`, `game_deletion_recovers_after_shared_metadata_cleanup_begins` | Covered |
 | Cross-process Cloud Manifest conditional writes | Missing provider CAS contract | Blocked |
 | S3 and WebDAV compatibility | Issues #480 and #481 | Out of scope |

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/conflicts.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/conflicts.rs
@@ -1,0 +1,458 @@
+use opendal::ErrorKind;
+use rgsm_core::cloud_sync::v2::{
+    AcceptRemoteProgressError, CLOUD_MANIFEST_PATH, CloudManifestRepository,
+    KeepLocalProgressError, ManifestError, MaterializationError, ProgressRelation, SnapshotState,
+    V2ConflictInspector, V2ConflictResolver, V2RemoteProgressResolver,
+};
+use rgsm_core::preclude::BackendError;
+
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, bootstrap_game, cloud_archive, load_manifest,
+    reconcile_game, snapshot,
+};
+
+const GAME_ID: &str = "example-game";
+const GAME_NAME: &str = "Example Game";
+const PARENT_ID: &str = "parent";
+const LOCAL_HEAD_ID: &str = "device-a-head";
+const REMOTE_HEAD_ID: &str = "device-b-head";
+const PARENT_BYTES: &[u8] = b"shared parent archive";
+const LOCAL_BYTES: &[u8] = b"device A descendant archive";
+const REMOTE_BYTES: &[u8] = b"device B descendant archive";
+
+struct DivergedHistories {
+    cloud: FsCloudFixture,
+    device_a: DeviceFixture,
+    device_b: DeviceFixture,
+    parent: rgsm_core::backup::Snapshot,
+    local_head: rgsm_core::backup::Snapshot,
+    remote_head: rgsm_core::backup::Snapshot,
+    local_a: rgsm_core::backup::GameSnapshots,
+}
+
+async fn divergent_histories() -> DivergedHistories {
+    let cloud = FsCloudFixture::new();
+    let device_a = DeviceFixture::new("device-a");
+    let device_b = DeviceFixture::new("device-b");
+    bootstrap_game(&cloud, &device_a, Some(&device_b), GAME_ID, GAME_NAME).await;
+
+    let parent = snapshot(PARENT_ID, None, &device_a.id, PARENT_BYTES.len());
+    device_a.write_archive(GAME_ID, &parent, PARENT_BYTES);
+    let parent_only = device_a.snapshots(GAME_NAME, vec![parent.clone()], PARENT_ID);
+    reconcile_game(&cloud, &device_a, GAME_ID, &parent_only).await;
+
+    let local_head = snapshot(
+        LOCAL_HEAD_ID,
+        Some(PARENT_ID),
+        &device_a.id,
+        LOCAL_BYTES.len(),
+    );
+    device_a.write_archive(GAME_ID, &local_head, LOCAL_BYTES);
+    let local_a = device_a.snapshots(
+        GAME_NAME,
+        vec![parent.clone(), local_head.clone()],
+        LOCAL_HEAD_ID,
+    );
+    reconcile_game(&cloud, &device_a, GAME_ID, &local_a).await;
+
+    let remote_head = snapshot(
+        REMOTE_HEAD_ID,
+        Some(PARENT_ID),
+        &device_b.id,
+        REMOTE_BYTES.len(),
+    );
+    device_b.write_archive(GAME_ID, &remote_head, REMOTE_BYTES);
+    let local_b = device_b.snapshots(
+        GAME_NAME,
+        vec![parent.clone(), remote_head.clone()],
+        REMOTE_HEAD_ID,
+    );
+    reconcile_game(&cloud, &device_b, GAME_ID, &local_b).await;
+
+    DivergedHistories {
+        cloud,
+        device_a,
+        device_b,
+        parent,
+        local_head,
+        remote_head,
+        local_a,
+    }
+}
+
+async fn local_only_divergence() -> DivergedHistories {
+    let cloud = FsCloudFixture::new();
+    let device_a = DeviceFixture::new("device-a");
+    let device_b = DeviceFixture::new("device-b");
+    bootstrap_game(&cloud, &device_a, Some(&device_b), GAME_ID, GAME_NAME).await;
+
+    let parent = snapshot(PARENT_ID, None, &device_a.id, PARENT_BYTES.len());
+    device_a.write_archive(GAME_ID, &parent, PARENT_BYTES);
+    let parent_only = device_a.snapshots(GAME_NAME, vec![parent.clone()], PARENT_ID);
+    reconcile_game(&cloud, &device_a, GAME_ID, &parent_only).await;
+
+    let remote_head = snapshot(
+        REMOTE_HEAD_ID,
+        Some(PARENT_ID),
+        &device_b.id,
+        REMOTE_BYTES.len(),
+    );
+    device_b.write_archive(GAME_ID, &remote_head, REMOTE_BYTES);
+    let local_b = device_b.snapshots(
+        GAME_NAME,
+        vec![parent.clone(), remote_head.clone()],
+        REMOTE_HEAD_ID,
+    );
+    reconcile_game(&cloud, &device_b, GAME_ID, &local_b).await;
+
+    let local_head = snapshot(
+        LOCAL_HEAD_ID,
+        Some(PARENT_ID),
+        &device_a.id,
+        LOCAL_BYTES.len(),
+    );
+    device_a.write_archive(GAME_ID, &local_head, LOCAL_BYTES);
+    let local_a = device_a.snapshots(
+        GAME_NAME,
+        vec![parent.clone(), local_head.clone()],
+        LOCAL_HEAD_ID,
+    );
+
+    DivergedHistories {
+        cloud,
+        device_a,
+        device_b,
+        parent,
+        local_head,
+        remote_head,
+        local_a,
+    }
+}
+
+fn inspector(histories: &DivergedHistories) -> V2ConflictInspector {
+    V2ConflictInspector::new(
+        histories.cloud.new_operator(),
+        histories.device_a.archive_root.clone(),
+        histories.device_a.id.clone(),
+        MAX_ATTEMPTS,
+    )
+}
+
+#[tokio::test]
+async fn conflict_review_reports_divergent_device_positions() {
+    let histories = divergent_histories().await;
+
+    let review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("divergent positions should be reviewable");
+
+    assert!(review.requires_choice);
+    assert_eq!(
+        review
+            .local
+            .as_ref()
+            .map(|local| local.snapshot_id.as_str()),
+        Some(LOCAL_HEAD_ID)
+    );
+    assert_eq!(review.candidates.len(), 2);
+
+    let local = review
+        .candidates
+        .iter()
+        .find(|candidate| candidate.snapshot_id == LOCAL_HEAD_ID)
+        .expect("device A head should be advertised");
+    assert_eq!(local.devices, vec![histories.device_a.id.clone()]);
+    assert_eq!(local.relation, ProgressRelation::Same);
+    assert!(local.local_available);
+    assert!(local.cloud_available);
+
+    let remote = review
+        .candidates
+        .iter()
+        .find(|candidate| candidate.snapshot_id == REMOTE_HEAD_ID)
+        .expect("device B head should be advertised");
+    assert_eq!(remote.devices, vec![histories.device_b.id.clone()]);
+    assert_eq!(remote.relation, ProgressRelation::DifferentProgress);
+    assert_eq!(remote.common_ancestor.as_deref(), Some(PARENT_ID));
+    assert!(!remote.local_available);
+    assert!(remote.cloud_available);
+}
+
+#[tokio::test]
+async fn keep_local_publishes_complete_lineage_and_preserves_remote_position() {
+    let histories = local_only_divergence().await;
+    let review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("divergent positions should be reviewable");
+
+    let before = load_manifest(&histories.cloud).await;
+    assert!(
+        !before.games[GAME_ID].snapshots.contains_key(LOCAL_HEAD_ID),
+        "the selected local Snapshot must be unpublished before resolution"
+    );
+    assert!(
+        !histories
+            .cloud
+            .new_operator()
+            .exists(&cloud_archive(GAME_ID, &histories.local_head))
+            .await
+            .expect("cloud archive absence should be observable"),
+        "the selected local Archive must be unpublished before resolution"
+    );
+
+    let outcome = V2ConflictResolver::new(
+        histories.cloud.new_operator(),
+        histories.device_a.archive_root.clone(),
+        histories.device_a.id.clone(),
+        histories.device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .keep_local(
+        GAME_ID,
+        review.manifest_revision,
+        LOCAL_HEAD_ID,
+        &histories.local_a,
+    )
+    .await
+    .expect("keeping local progress should publish its lineage");
+
+    let manifest = load_manifest(&histories.cloud).await;
+    let game = manifest
+        .games
+        .get(GAME_ID)
+        .expect("game should remain in manifest");
+    assert_eq!(outcome.prepared_snapshots, 2);
+    assert_eq!(outcome.uploaded_archives, 1);
+    assert!(outcome.manifest_revision > review.manifest_revision);
+    assert_eq!(
+        game.device_heads
+            .get(&histories.device_a.id)
+            .map(String::as_str),
+        Some(LOCAL_HEAD_ID)
+    );
+    assert_eq!(
+        game.device_heads
+            .get(&histories.device_b.id)
+            .map(String::as_str),
+        Some(REMOTE_HEAD_ID)
+    );
+    for (snapshot, expected) in [
+        (&histories.parent, PARENT_BYTES),
+        (&histories.local_head, LOCAL_BYTES),
+    ] {
+        let node = game
+            .snapshots
+            .get(&snapshot.date)
+            .expect("lineage node should persist");
+        assert!(matches!(
+            &node.state,
+            SnapshotState::Live(live) if live.cloud_archive_verified
+        ));
+        assert_eq!(
+            histories
+                .cloud
+                .new_operator()
+                .read(&cloud_archive(GAME_ID, snapshot))
+                .await
+                .expect("published archive should be readable")
+                .to_vec(),
+            expected
+        );
+    }
+    assert_eq!(
+        histories
+            .cloud
+            .new_operator()
+            .read(&cloud_archive(GAME_ID, &histories.remote_head))
+            .await
+            .expect("remote device archive should remain readable")
+            .to_vec(),
+        REMOTE_BYTES
+    );
+}
+
+#[tokio::test]
+async fn accept_remote_materializes_selected_archive_and_moves_only_current_device_position() {
+    let histories = divergent_histories().await;
+    let review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("divergent positions should be reviewable");
+
+    let resolver = V2RemoteProgressResolver::new(
+        histories.cloud.new_operator(),
+        histories.device_a.archive_root.clone(),
+        histories.device_a.id.clone(),
+        histories.device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    );
+    let prepared = resolver
+        .prepare(
+            GAME_ID,
+            review.manifest_revision,
+            Some(LOCAL_HEAD_ID),
+            REMOTE_HEAD_ID,
+            &histories.local_a,
+        )
+        .await
+        .expect("advertised remote progress should materialize");
+    assert_eq!(prepared.selected_snapshot_id, REMOTE_HEAD_ID);
+    assert_eq!(
+        prepared
+            .lineage
+            .last()
+            .map(|snapshot| snapshot.date.as_str()),
+        Some(REMOTE_HEAD_ID)
+    );
+    let revision = resolver
+        .commit_current_device_head(GAME_ID, REMOTE_HEAD_ID)
+        .await
+        .expect("materialized remote progress should become device A head");
+
+    assert_eq!(
+        std::fs::read(
+            histories
+                .device_a
+                .archive_path(GAME_ID, &histories.remote_head)
+        )
+        .expect("selected archive should materialize locally"),
+        REMOTE_BYTES
+    );
+    let manifest = load_manifest(&histories.cloud).await;
+    let game = manifest
+        .games
+        .get(GAME_ID)
+        .expect("game should remain in manifest");
+    assert_eq!(manifest.revision, revision);
+    assert!(manifest.revision > review.manifest_revision);
+    assert_eq!(
+        game.device_heads
+            .get(&histories.device_a.id)
+            .map(String::as_str),
+        Some(REMOTE_HEAD_ID)
+    );
+    assert_eq!(
+        game.device_heads
+            .get(&histories.device_b.id)
+            .map(String::as_str),
+        Some(REMOTE_HEAD_ID)
+    );
+}
+
+#[tokio::test]
+async fn keep_local_rejects_stale_review_without_persisted_change() {
+    let histories = divergent_histories().await;
+    let review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("divergent positions should be reviewable");
+    CloudManifestRepository::new(
+        histories.cloud.new_operator(),
+        CLOUD_MANIFEST_PATH,
+        MAX_ATTEMPTS,
+    )
+    .mutate(|_| Ok::<_, ManifestError>(()))
+    .await
+    .expect("independent manifest change should advance the revision");
+    let before = load_manifest(&histories.cloud).await;
+
+    let error = V2ConflictResolver::new(
+        histories.cloud.new_operator(),
+        histories.device_a.archive_root.clone(),
+        histories.device_a.id.clone(),
+        histories.device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .keep_local(
+        GAME_ID,
+        review.manifest_revision,
+        LOCAL_HEAD_ID,
+        &histories.local_a,
+    )
+    .await
+    .expect_err("stale review must not persist a replacement");
+
+    assert!(matches!(error, KeepLocalProgressError::StaleReview { .. }));
+    assert_eq!(load_manifest(&histories.cloud).await, before);
+    assert_eq!(
+        std::fs::read(
+            histories
+                .device_a
+                .archive_path(GAME_ID, &histories.local_head)
+        )
+        .expect("existing local archive should remain unchanged"),
+        LOCAL_BYTES
+    );
+}
+
+#[tokio::test]
+async fn accept_remote_rejects_unavailable_candidate_without_persisted_change() {
+    let histories = divergent_histories().await;
+    let review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("divergent positions should be reviewable");
+    histories
+        .cloud
+        .new_operator()
+        .delete(&cloud_archive(GAME_ID, &histories.remote_head))
+        .await
+        .expect("remote archive should be removable through the Fs operator");
+    let before = load_manifest(&histories.cloud).await;
+
+    let result = V2RemoteProgressResolver::new(
+        histories.cloud.new_operator(),
+        histories.device_a.archive_root.clone(),
+        histories.device_a.id.clone(),
+        histories.device_a.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .prepare(
+        GAME_ID,
+        review.manifest_revision,
+        Some(LOCAL_HEAD_ID),
+        REMOTE_HEAD_ID,
+        &histories.local_a,
+    )
+    .await;
+    let Err(error) = result else {
+        panic!("missing remote archive must not replace a local archive");
+    };
+
+    assert!(matches!(
+        error,
+        AcceptRemoteProgressError::Materialization(MaterializationError::Backend(
+            BackendError::Cloud(error)
+        )) if error.kind() == ErrorKind::NotFound
+    ));
+    assert_eq!(load_manifest(&histories.cloud).await, before);
+    assert!(
+        !histories
+            .device_a
+            .archive_path(GAME_ID, &histories.remote_head)
+            .exists()
+    );
+    let fresh_review = inspector(&histories)
+        .review(GAME_ID, &histories.local_a)
+        .await
+        .expect("manifest remains reviewable after download failure");
+    assert!(
+        !fresh_review
+            .candidates
+            .iter()
+            .find(|candidate| candidate.snapshot_id == REMOTE_HEAD_ID)
+            .expect("advertised candidate should remain visible")
+            .local_available
+    );
+    assert_eq!(
+        std::fs::read(
+            histories
+                .device_a
+                .archive_path(GAME_ID, &histories.local_head)
+        )
+        .expect("existing local archive should remain unchanged"),
+        LOCAL_BYTES
+    );
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/integrity.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/integrity.rs
@@ -1,0 +1,244 @@
+use opendal::ErrorKind;
+use rgsm_core::cloud_sync::v2::{
+    ArchiveIntegrityError, CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifest,
+    CloudManifestRepository, DeletionRegistryRepository, DeviceProfileRepository,
+    MaterializationError, SharedGameDeletion, SharedLibraryRepository, SnapshotSyncCoordinator,
+};
+use rgsm_core::preclude::BackendError;
+use tokio_util::sync::CancellationToken;
+
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, bootstrap_game, cloud_archive, load_manifest,
+    reconcile_game, snapshot,
+};
+
+const GAME_ID: &str = "example-game";
+const GAME_NAME: &str = "Example Game";
+const SNAPSHOT_ID: &str = "snapshot-a";
+const ARCHIVE_BYTES: &[u8] = b"verified cloud archive";
+const EXISTING_BYTES: &[u8] = b"preexisting receiver archive";
+
+async fn published_snapshot() -> (
+    FsCloudFixture,
+    DeviceFixture,
+    DeviceFixture,
+    rgsm_core::backup::Snapshot,
+) {
+    let cloud = FsCloudFixture::new();
+    let source = DeviceFixture::new("device-a");
+    let receiver = DeviceFixture::new("device-b");
+    bootstrap_game(&cloud, &source, Some(&receiver), GAME_ID, GAME_NAME).await;
+
+    let snapshot = snapshot(SNAPSHOT_ID, None, &source.id, ARCHIVE_BYTES.len());
+    source.write_archive(GAME_ID, &snapshot, ARCHIVE_BYTES);
+    let snapshots = source.snapshots(GAME_NAME, vec![snapshot.clone()], SNAPSHOT_ID);
+    reconcile_game(&cloud, &source, GAME_ID, &snapshots).await;
+    (cloud, source, receiver, snapshot)
+}
+
+fn assert_no_download_staging_file(device: &DeviceFixture) {
+    let staging = device.progress_path.with_extension("staging");
+    if staging.exists() {
+        assert!(
+            std::fs::read_dir(staging)
+                .expect("staging directory should be readable")
+                .next()
+                .is_none(),
+            "failed downloads must remove their temporary archive"
+        );
+    }
+}
+
+async fn assert_damaged_download_preserves_local_archive(
+    cloud: &FsCloudFixture,
+    receiver: &DeviceFixture,
+    snapshot: &rgsm_core::backup::Snapshot,
+) -> MaterializationError {
+    let target = receiver.write_archive(GAME_ID, snapshot, EXISTING_BYTES);
+    let before = load_manifest(cloud).await;
+
+    let error = CloudArchiveMaterializer::new(
+        cloud.new_operator(),
+        receiver.archive_root.clone(),
+        receiver.id.clone(),
+        receiver.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .download(GAME_ID, SNAPSHOT_ID)
+    .await
+    .expect_err("damaged cloud archives must fail materialization");
+
+    assert_eq!(
+        std::fs::read(target).expect("preexisting archive should remain readable"),
+        EXISTING_BYTES
+    );
+    assert_no_download_staging_file(receiver);
+    let after = load_manifest(cloud).await;
+    assert_eq!(after, before);
+    assert!(
+        !after.games[GAME_ID]
+            .local_archives
+            .get(&receiver.id)
+            .is_some_and(|snapshots| snapshots.contains(SNAPSHOT_ID))
+    );
+    error
+}
+
+#[tokio::test]
+async fn missing_cloud_archive_fails_without_replacing_local_archive() {
+    let (cloud, _, receiver, snapshot) = published_snapshot().await;
+    cloud
+        .new_operator()
+        .delete(&cloud_archive(GAME_ID, &snapshot))
+        .await
+        .expect("verified cloud archive should be removable through the Fs operator");
+
+    let error = assert_damaged_download_preserves_local_archive(&cloud, &receiver, &snapshot).await;
+    assert!(matches!(
+        error,
+        MaterializationError::Backend(BackendError::Cloud(error))
+            if error.kind() == ErrorKind::NotFound
+    ));
+}
+
+#[tokio::test]
+async fn truncated_cloud_archive_fails_without_replacing_local_archive() {
+    let (cloud, _, receiver, snapshot) = published_snapshot().await;
+    let remote = cloud_archive(GAME_ID, &snapshot);
+    let remote_path = cloud.root().join(&remote);
+    let archive = std::fs::OpenOptions::new()
+        .write(true)
+        .open(&remote_path)
+        .expect("Fs cloud archive should be directly truncatable");
+    archive
+        .set_len(1)
+        .expect("Fs cloud archive should truncate through the production root");
+
+    let error = assert_damaged_download_preserves_local_archive(&cloud, &receiver, &snapshot).await;
+    assert!(matches!(
+        error,
+        MaterializationError::Integrity(ArchiveIntegrityError::Mismatch { .. })
+    ));
+}
+#[tokio::test]
+async fn corrupt_cloud_archive_fails_without_replacing_local_archive() {
+    let (cloud, _, receiver, snapshot) = published_snapshot().await;
+    let corruption = vec![b'x'; ARCHIVE_BYTES.len()];
+    cloud
+        .new_operator()
+        .write(&cloud_archive(GAME_ID, &snapshot), corruption)
+        .await
+        .expect("Fs cloud archive should be overwritable through the production operator");
+
+    let error = assert_damaged_download_preserves_local_archive(&cloud, &receiver, &snapshot).await;
+    assert!(matches!(
+        error,
+        MaterializationError::Integrity(ArchiveIntegrityError::Mismatch { .. })
+    ));
+}
+
+#[tokio::test]
+async fn deleted_game_archive_recreation_cannot_restore_game_state() {
+    let (cloud, source, stale_device, snapshot) = published_snapshot().await;
+    stale_device.write_archive(GAME_ID, &snapshot, ARCHIVE_BYTES);
+    let stale_game = load_manifest(&cloud).await.games[GAME_ID].clone();
+
+    SharedGameDeletion::new(
+        cloud.new_operator(),
+        source.archive_root.clone(),
+        source.id.clone(),
+        MAX_ATTEMPTS,
+    )
+    .delete(GAME_ID, GAME_NAME, true)
+    .await
+    .expect("permanent deletion should remove the populated Game");
+
+    let remote = cloud_archive(GAME_ID, &snapshot);
+    cloud
+        .new_operator()
+        .write(&remote, ARCHIVE_BYTES)
+        .await
+        .expect("stale archive object should be recreatable in the Fs root");
+    assert!(
+        cloud
+            .new_operator()
+            .exists(&remote)
+            .await
+            .expect("recreated archive should exist")
+    );
+    let mut resurrected_manifest = CloudManifest::default();
+    resurrected_manifest
+        .games
+        .insert(GAME_ID.to_string(), stale_game);
+    cloud
+        .new_operator()
+        .write(
+            CLOUD_MANIFEST_PATH,
+            serde_json::to_vec_pretty(&resurrected_manifest)
+                .expect("resurrected Cloud Manifest should serialize"),
+        )
+        .await
+        .expect("stale manifest write after marker validation should be reproducible");
+
+    let stale_snapshots = stale_device.snapshots(GAME_NAME, vec![snapshot.clone()], SNAPSHOT_ID);
+    assert!(
+        SnapshotSyncCoordinator::new(
+            cloud.new_operator(),
+            stale_device.archive_root.clone(),
+            stale_device.id.clone(),
+            stale_device.progress_path.clone(),
+            MAX_ATTEMPTS,
+        )
+        .reconcile_game(
+            GAME_ID,
+            &stale_snapshots,
+            0,
+            &Default::default(),
+            &CancellationToken::new(),
+        )
+        .await
+        .is_err()
+    );
+
+    assert!(
+        DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("deletion registry should reload")
+            .deleted_games
+            .contains_key(GAME_ID)
+    );
+    assert!(
+        SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Shared Library should reload")
+            .games
+            .iter()
+            .all(|game| game.storage_key != GAME_ID)
+    );
+    assert!(
+        DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .list()
+            .await
+            .expect("Device Profiles should reload")
+            .iter()
+            .all(|profile| !profile.games.contains_key(GAME_ID))
+    );
+    assert!(
+        !CloudManifestRepository::new(cloud.new_operator(), CLOUD_MANIFEST_PATH, MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Cloud Manifest should reload")
+            .games
+            .contains_key(GAME_ID)
+    );
+    assert!(
+        !cloud
+            .new_operator()
+            .exists(&remote)
+            .await
+            .expect("recreated archive should be removed"),
+        "the durable deletion marker must dominate stale archive publication"
+    );
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/recovery.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/recovery.rs
@@ -1,0 +1,262 @@
+use rgsm_core::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifestRepository,
+    DeletionRegistryRepository, DeviceProfileRepository, SharedGameDeletion,
+    SharedLibraryRepository,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, bootstrap_game, cloud_archive, read_progress,
+    reconcile_game, snapshot,
+};
+
+const GAME_ID: &str = "example-game";
+const GAME_NAME: &str = "Example Game";
+const SNAPSHOT_ID: &str = "snapshot-a";
+const ARCHIVE_BYTES: &[u8] = b"recovery archive bytes";
+
+async fn populated_game() -> (
+    FsCloudFixture,
+    DeviceFixture,
+    DeviceFixture,
+    rgsm_core::backup::Snapshot,
+) {
+    let cloud = FsCloudFixture::new();
+    let device_a = DeviceFixture::new("device-a");
+    let device_b = DeviceFixture::new("device-b");
+    bootstrap_game(&cloud, &device_a, Some(&device_b), GAME_ID, GAME_NAME).await;
+
+    let snapshot = snapshot(SNAPSHOT_ID, None, &device_a.id, ARCHIVE_BYTES.len());
+    device_a.write_archive(GAME_ID, &snapshot, ARCHIVE_BYTES);
+    let snapshots = device_a.snapshots(GAME_NAME, vec![snapshot.clone()], SNAPSHOT_ID);
+    reconcile_game(&cloud, &device_a, GAME_ID, &snapshots).await;
+    (cloud, device_a, device_b, snapshot)
+}
+
+async fn assert_deleted(
+    cloud: &FsCloudFixture,
+    device: &DeviceFixture,
+    snapshot: &rgsm_core::backup::Snapshot,
+) {
+    assert!(
+        DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Deletion Registry should reload")
+            .deleted_games
+            .contains_key(GAME_ID)
+    );
+    assert!(!device.archive_root.join(GAME_ID).exists());
+    assert!(
+        !cloud
+            .new_operator()
+            .exists(&cloud_archive(GAME_ID, snapshot))
+            .await
+            .expect("cloud archive absence should be observable")
+    );
+    assert!(
+        SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Shared Library should reload")
+            .games
+            .iter()
+            .all(|game| game.storage_key != GAME_ID)
+    );
+    assert!(
+        DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .list()
+            .await
+            .expect("Device Profiles should reload")
+            .iter()
+            .all(|profile| !profile.games.contains_key(GAME_ID))
+    );
+    assert!(
+        !CloudManifestRepository::new(cloud.new_operator(), CLOUD_MANIFEST_PATH, MAX_ATTEMPTS)
+            .load()
+            .await
+            .expect("Cloud Manifest should reload")
+            .games
+            .contains_key(GAME_ID)
+    );
+}
+
+async fn retry_deletion_after(
+    cloud: &FsCloudFixture,
+    device: &DeviceFixture,
+    snapshot: &rgsm_core::backup::Snapshot,
+) {
+    SharedGameDeletion::new(
+        cloud.new_operator(),
+        device.archive_root.clone(),
+        device.id.clone(),
+        MAX_ATTEMPTS,
+    )
+    .delete(GAME_ID, GAME_NAME, true)
+    .await
+    .expect("retry should converge the durable partial deletion state");
+    assert_deleted(cloud, device, snapshot).await;
+}
+
+#[tokio::test]
+async fn materialize_all_stops_at_damaged_archive_and_resumes_after_repair() {
+    let cloud = FsCloudFixture::new();
+    let source = DeviceFixture::new("device-a");
+    let receiver = DeviceFixture::new("device-b");
+    bootstrap_game(&cloud, &source, Some(&receiver), GAME_ID, GAME_NAME).await;
+
+    let first = snapshot("snapshot-1", None, &source.id, b"first bytes".len());
+    let middle = snapshot(
+        "snapshot-2",
+        Some("snapshot-1"),
+        &source.id,
+        b"middle bytes".len(),
+    );
+    let last = snapshot(
+        "snapshot-3",
+        Some("snapshot-2"),
+        &source.id,
+        b"last bytes".len(),
+    );
+    source.write_archive(GAME_ID, &first, b"first bytes");
+    source.write_archive(GAME_ID, &middle, b"middle bytes");
+    source.write_archive(GAME_ID, &last, b"last bytes");
+    let snapshots = source.snapshots(
+        GAME_NAME,
+        vec![first.clone(), middle.clone(), last.clone()],
+        "snapshot-3",
+    );
+    reconcile_game(&cloud, &source, GAME_ID, &snapshots).await;
+
+    cloud
+        .new_operator()
+        .write(&cloud_archive(GAME_ID, &middle), b"x".to_vec())
+        .await
+        .expect("middle Fs archive should be damageable");
+    let materializer = CloudArchiveMaterializer::new(
+        cloud.new_operator(),
+        receiver.archive_root.clone(),
+        receiver.id.clone(),
+        receiver.progress_path.clone(),
+        MAX_ATTEMPTS,
+    );
+    assert!(
+        materializer
+            .materialize_all(&CancellationToken::new())
+            .await
+            .is_err()
+    );
+
+    assert_eq!(
+        std::fs::read(receiver.archive_path(GAME_ID, &first))
+            .expect("first archive should remain committed"),
+        b"first bytes"
+    );
+    assert!(!receiver.archive_path(GAME_ID, &middle).exists());
+    assert!(!receiver.archive_path(GAME_ID, &last).exists());
+    let progress = read_progress(&receiver);
+    assert_eq!(progress["remaining"].as_array().map(Vec::len), Some(2));
+    assert_eq!(
+        progress["remaining"][0]["snapshot_id"].as_str(),
+        Some("snapshot-2")
+    );
+
+    cloud
+        .new_operator()
+        .write(&cloud_archive(GAME_ID, &middle), b"middle bytes".to_vec())
+        .await
+        .expect("middle Fs archive should be repairable");
+    let resumed = CloudArchiveMaterializer::new(
+        cloud.new_operator(),
+        receiver.archive_root.clone(),
+        receiver.id.clone(),
+        receiver.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .resume_pending(&CancellationToken::new())
+    .await
+    .expect("fresh materializer should resume the durable plan")
+    .expect("damaged batch should leave a pending plan");
+    assert_eq!(resumed.downloaded, 2);
+    assert_eq!(
+        std::fs::read(receiver.archive_path(GAME_ID, &middle))
+            .expect("repaired middle archive should materialize"),
+        b"middle bytes"
+    );
+    assert_eq!(
+        std::fs::read(receiver.archive_path(GAME_ID, &last))
+            .expect("later archive should materialize after repair"),
+        b"last bytes"
+    );
+    assert!(!receiver.progress_path.exists());
+}
+
+#[tokio::test]
+async fn game_deletion_recovers_after_marker_written() {
+    let (cloud, device_a, _, snapshot) = populated_game().await;
+    DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .mark_game_deleted(GAME_ID, GAME_NAME, &device_a.id)
+        .await
+        .expect("durable deletion marker should persist");
+
+    retry_deletion_after(&cloud, &device_a, &snapshot).await;
+}
+
+#[tokio::test]
+async fn game_deletion_recovers_after_local_archives_removed() {
+    let (cloud, device_a, _, snapshot) = populated_game().await;
+    DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .mark_game_deleted(GAME_ID, GAME_NAME, &device_a.id)
+        .await
+        .expect("durable deletion marker should persist");
+    std::fs::remove_dir_all(device_a.archive_root.join(GAME_ID))
+        .expect("local game archive directory should be removable");
+
+    retry_deletion_after(&cloud, &device_a, &snapshot).await;
+}
+
+#[tokio::test]
+async fn game_deletion_recovers_after_cloud_archives_removed() {
+    let (cloud, device_a, _, snapshot) = populated_game().await;
+    DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .mark_game_deleted(GAME_ID, GAME_NAME, &device_a.id)
+        .await
+        .expect("durable deletion marker should persist");
+    std::fs::remove_dir_all(device_a.archive_root.join(GAME_ID))
+        .expect("local game archive directory should be removable");
+    cloud
+        .new_operator()
+        .delete_with(&format!("v2/archives/{GAME_ID}/"))
+        .recursive(true)
+        .await
+        .expect("cloud archive prefix should be removable through the Fs operator");
+
+    retry_deletion_after(&cloud, &device_a, &snapshot).await;
+}
+
+#[tokio::test]
+async fn game_deletion_recovers_after_shared_metadata_cleanup_begins() {
+    let (cloud, device_a, _, snapshot) = populated_game().await;
+    DeletionRegistryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .mark_game_deleted(GAME_ID, GAME_NAME, &device_a.id)
+        .await
+        .expect("durable deletion marker should persist");
+    std::fs::remove_dir_all(device_a.archive_root.join(GAME_ID))
+        .expect("local game archive directory should be removable");
+    cloud
+        .new_operator()
+        .delete_with(&format!("v2/archives/{GAME_ID}/"))
+        .recursive(true)
+        .await
+        .expect("cloud archive prefix should be removable through the Fs operator");
+    let repository = SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS);
+    let expected = repository.load().await.expect("Shared Library should load");
+    let mut accepted = expected.clone();
+    accepted.games.retain(|game| game.storage_key != GAME_ID);
+    repository
+        .compare_replace(&expected, &accepted)
+        .await
+        .expect("shared metadata cleanup should persist before interruption");
+
+    retry_deletion_after(&cloud, &device_a, &snapshot).await;
+}

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
@@ -3,11 +3,16 @@ use std::path::{Path, PathBuf};
 
 use opendal::Operator;
 use rgsm_core::backup::{ArchiveFormat, CreatedBy, Game, GameSnapshots, Snapshot, archive_path};
+use rgsm_core::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudManifest, CloudManifestRepository,
+    DeviceProfileRepository, SharedLibraryRepository, SnapshotSyncCoordinator, cloud_archive_path,
+};
 use rgsm_core::cloud_sync::{Backend, CloudSyncSessionConfig};
 use rgsm_core::config::{
     Config, ConfigurationOwners, DeviceProfile, SharedLibrary, V2_CONFIG_SCHEMA_VERSION,
 };
 use rgsm_core::device::DeviceId;
+use tokio_util::sync::CancellationToken;
 
 pub const MAX_ATTEMPTS: usize = 2;
 
@@ -118,6 +123,89 @@ impl DeviceFixture {
         snapshots.set_head_for_device(self.id.clone(), Some(head.to_string()));
         snapshots
     }
+
+    pub fn archive_path(&self, game_id: &str, snapshot: &Snapshot) -> PathBuf {
+        archive_path(
+            &self.archive_root.join(game_id),
+            &snapshot.date,
+            snapshot.archive_format,
+        )
+    }
+}
+
+pub async fn bootstrap_game(
+    cloud: &FsCloudFixture,
+    device_a: &DeviceFixture,
+    device_b: Option<&DeviceFixture>,
+    game_id: &str,
+    game_name: &str,
+) {
+    let (empty_library, empty_profile) = device_a.empty_library_and_profile();
+    CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .create_empty(&empty_library, &empty_profile)
+        .await
+        .expect("empty Fs root should bootstrap");
+
+    let (library, profile_a) = device_a.library_and_profile_with_game(game_id, game_name);
+    SharedLibraryRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .compare_replace(&empty_library, &library)
+        .await
+        .expect("Shared Library should publish");
+    DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+        .publish(&device_a.id, &profile_a)
+        .await
+        .expect("device A profile should publish");
+
+    if let Some(device_b) = device_b {
+        let (_, profile_b) = device_b.library_and_profile_with_game(game_id, game_name);
+        DeviceProfileRepository::new(cloud.new_operator(), MAX_ATTEMPTS)
+            .publish(&device_b.id, &profile_b)
+            .await
+            .expect("device B profile should publish");
+    }
+}
+
+pub async fn reconcile_game(
+    cloud: &FsCloudFixture,
+    device: &DeviceFixture,
+    game_id: &str,
+    snapshots: &GameSnapshots,
+) {
+    SnapshotSyncCoordinator::new(
+        cloud.new_operator(),
+        device.archive_root.clone(),
+        device.id.clone(),
+        device.progress_path.clone(),
+        MAX_ATTEMPTS,
+    )
+    .reconcile_game(
+        game_id,
+        snapshots,
+        0,
+        &no_baseline(),
+        &CancellationToken::new(),
+    )
+    .await
+    .expect("Snapshot reconciliation should succeed");
+}
+
+pub async fn load_manifest(cloud: &FsCloudFixture) -> CloudManifest {
+    CloudManifestRepository::new(cloud.new_operator(), CLOUD_MANIFEST_PATH, MAX_ATTEMPTS)
+        .load()
+        .await
+        .expect("Cloud Manifest should load through a fresh Operator")
+}
+
+pub fn cloud_archive(game_id: &str, snapshot: &Snapshot) -> String {
+    cloud_archive_path(game_id, &snapshot.date, snapshot.archive_format)
+        .expect("cloud archive path should be valid")
+}
+
+pub fn read_progress(device: &DeviceFixture) -> serde_json::Value {
+    serde_json::from_slice(
+        &std::fs::read(&device.progress_path).expect("materialization progress should persist"),
+    )
+    .expect("materialization progress should be valid JSON")
 }
 
 pub fn snapshot(id: &str, parent: Option<&str>, device_id: &str, size: usize) -> Snapshot {


### PR DESCRIPTION
## Testing
- `cargo test -p rgsm-core --test cloud_sync_v2_fs`
- `cargo test -p rgsm-core services::game_deletion::tests::permanently_delete_cloud_game --lib -- --exact`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`