### PR TITLE
test(gui): player-path cloud sync e2e suite

### DIFF
--- a/apps/rgsm-gui/e2e/README.md
+++ b/apps/rgsm-gui/e2e/README.md
@@ -97,6 +97,14 @@ A 已在新版资料库，这款游戏有若干自动存档。
 - A 在某一份自动存档上点 Keep：这份带上保护，不会被自动清理算进去
 - A 在自动存档设置里打开 Shared retention limit，填一个较小的数并保存：超出的未保护自动存档从云和本机消失，被 Keep 的那份和当前指针还在
 
+### repeated upload download round trips stay consistent
+
+A、B 都已在新版资料库，这款游戏两边都是 Multi-device Sync。连续三轮：
+
+- A 改存档、新建并上传；B 下载这份并 Apply，B 的游戏文件变成 A 的内容
+- B 改存档、新建并上传；A 下载这份并 Apply，A 的游戏文件变成 B 的内容
+- 每轮结束后：云上和两台本机都留有每一轮的存档文件，两边游戏文件一致，两边的当前指针各自指向自己最后上传的那份
+
 ### broken library reset and recreate
 
 A 已在新版资料库，本地还有这款游戏。云端新版配置被删掉，只剩残缺对象。

--- a/apps/rgsm-gui/e2e/README.md
+++ b/apps/rgsm-gui/e2e/README.md
@@ -4,7 +4,7 @@
 
 ## 云端同步端到端测试
 
-覆盖旧版云配置/存档升级到新版，以及两台设备各自与云交互。
+覆盖旧版云配置/存档升级到新版，以及设备各自与云交互。
 
 ### V1 to V2 cutover interrupts, resumes, and stays idempotent
 
@@ -13,18 +13,96 @@
 - 云端那份旧配置和两份存档字节不变
 - 重启后能接着升完
 - 再重启不会多出配置或存档
-- 旧上传接口被拒绝
 
 ### two V1 devices cut over, join, and keep V2 device boundaries
 
 1. A、B 本地都是旧版配置，共用云端同一份旧配置和两份存档。A 往云上传存档，B 从云下载同一份
 2. A 的本地配置升到新版，B 的本地配置仍是旧版，B 被提示加入
-3. B 加入时保留云端那份游戏定义；A、B 本地配置都变成新版；旧上传接口禁用
-4. A 往云上传一份新存档，B 从云拉取并应用到本地
-5. A 改自己本地配置里的同步模式，云上 B 的配置不变
-6. A、B 各自基于云上同一份存档再建一份并上传；A 必须明确选择 B 上传的那份
-7. A 删掉当前这份存档，本地回到上一份；云上这份被标记删除，B 不能再把它拉回本地
-8. A、B 重启后，各自的本地配置、本地存档、以及云上的配置和存档，都与重启前一致
+3. B 在加入里选 Keep the cloud version；A、B 本地配置都变成新版
+4. 这款游戏在 A、B 上都是 Cloud Backup。A 在存档列表点 Upload to cloud；B 点 Download to this device 后，B 本机多出这份文件，游戏目录还没变；B 再点 Apply，游戏文件才变成这份
+5. A 把这款游戏改成 Manual，B 仍是 Cloud Backup
+6. A、B 都改成 Multi-device Sync。两边先停在云上同一份，再各自新建并上传，两边都还没吃到对方那份。A 点 Progress diverged, compare，再点 Use this progress：A 的游戏文件变成 B 那份，只有 A 的当前指针移动，B 的指针不变
+7. A 删掉当前这份存档：A 的当前指针回到上一份，游戏文件不变；云上这份被标记删除，B 不能再把它拉回本地
+8. A、B 重启后，两边的同步模式、当前指针、本机和云上的存档文件，都与重启前一致
+
+### empty cloud creates library then first snapshot uploads
+
+云端文件夹是空的。A 本地已有一款游戏和一份本机存档。
+
+- 点 Create library，再点 Create and switch
+- A 的本地配置变成新版，云端出现新版配置，还没有存档
+- A 在存档列表点 Upload to cloud：云上多出这一份，字节与本机一致
+- B 本地是旧版配置、没有这款游戏。B 点 Join library 后，能在存档列表点 Download to this device 拿到这一份
+
+### per-game upload download disable re-enable
+
+A、B 都已在新版资料库里管理同一款游戏，两边都是 Cloud Backup，云上已有一份双方都有的存档。
+
+- A 新建一份本机存档，在存档列表点 Upload to cloud：云上多出这一份，B 本地还没有
+- B 点 Download to this device：B 本地出现相同字节，游戏文件不变，云上这份还在
+- A 关掉这款游戏的 Cloud sync 开关：A 的本地配置里这款游戏不再上传，模式仍是 Cloud Backup；B 仍是 Cloud Backup 且开着；云上已有存档还在
+- A 此时再新建本机存档：云上不会多出这一份
+- A 重新打开 Cloud sync：之后新建的本机存档可以再上传
+
+### sync modes and enable catch-up
+
+A、B 都已在新版资料库里管理同一款游戏，云上已有若干存档。
+
+- A 在概览 Sync mode 里改成 Manual：新本机存档不会自动出现在云上，要手点 Upload to cloud；不会自动 Apply
+- A 改成 Cloud Backup，打开对话框里选 Keep in cloud，再点 Enable：之后新本机存档会自动出现在云上；打开时不会把云上已有存档拉到本机；不会自动 Apply
+- B 改成 Cloud Backup，打开对话框里选 Download to this device，再点 Enable：云上已有存档出现在 B 本机，游戏文件不变
+- B 再改成 Multi-device Sync：当云上只有一份可前进的存档时，B 会自动下载并 Apply 到游戏文件
+
+### evict local or cloud copy without deleting snapshot
+
+云上和 A 本地都有同一份存档。
+
+- A 在存档列表点 Remove local copy：本机文件没了，云上这份还在，存档记录还在
+- A 再点 Download to this device：本机文件回来，字节与云上一致
+- A 点 Remove cloud copy：云上文件没了，A 本机这份还在，存档记录还在
+- B 不能再 Download to this device
+- A 再点 Upload to cloud：云上文件回来
+
+### keep local instead of taking the other device save
+
+A、B 都已在新版资料库，这款游戏两边都是 Multi-device Sync。两边先停在云上同一份，再各自新建并上传。
+
+- 概览上出现 Progress diverged, compare，不能自动套用任何一边
+- A 在比较里选 Keep this device：云上仍有 A、B 各一份；A 本地游戏文件仍是 A 自己的；B 当前指向的仍是 B 那份
+
+### download all missing cloud copies
+
+A 本机缺若干云上已有的存档。
+
+- A 在共享存档历史点 Download all to this device：缺的那些出现在 A 本机，已有的不重复，游戏文件不变
+- 中途打断后再点 Resume download：能从停下的地方拉完
+
+### permanently delete shared game
+
+A、B 都已在新版资料库里管理同一款游戏，云上有这款游戏的存档。
+
+- A 在概览这款游戏旁点 Permanently delete shared game：云上这款游戏的配置和存档都没了，A 本地这款游戏也不再被管理
+- B 下次检查云端后，不能再把这款游戏或那些存档拉回来
+
+### remove other device from library
+
+A、B 都在同一份新版资料库里。设置页的 Library devices 列出两台设备。
+
+- A 对 B 点 Remove device：B 从 Library devices 消失；双方已经上传的存档还在
+
+### protect automatic snapshot and set retention
+
+A 已在新版资料库，这款游戏有若干自动存档。
+
+- A 在某一份自动存档上点 Keep：这份带上保护，不会被自动清理算进去
+- A 在自动存档设置里打开 Shared retention limit，填一个较小的数并保存：超出的未保护自动存档从云和本机消失，被 Keep 的那份和当前指针还在
+
+### broken library reset and recreate
+
+A 已在新版资料库，本地还有这款游戏。云端新版配置被删掉，只剩残缺对象。
+
+- A 检查后不能当正常资料库用
+- A 点 Reset and recreate 并输入 yes：云端按 A 当前游戏列表重建一份新资料库，残缺对象没了
 
 ## 杂项测试
 
@@ -37,3 +115,11 @@
 - A 的本机配置里没有 B 的设备配置
 - 用 B 的 API token 访问 A 的本机接口会被拒绝
 - A 的界面只读写 A 这份本机配置，B 同理
+
+## 未覆盖
+
+- 两台设备同时改云上同一份清单
+- S3、WebDAV
+- 自动存档定时器自己触发清理
+- 换云端位置时带走未完成的升级进度
+- Stop managing here、隐藏游戏（界面没有入口）

--- a/apps/rgsm-gui/e2e/cloud-delete-game.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-delete-game.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { STORAGE_KEY } from './support/constants';
+import {
+  cloudArchivePath,
+  cloudPaths,
+  expectSharedLibraryHasGame,
+  readJson,
+} from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  permanentlyDeleteGame,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('create library then permanently delete game', async ({ browser }) => {
+  const runRoot = await createRunRoot('delete-game');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'delete-game' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const snapshotId = await createPublishedSnapshot(session.pageA, session.hostA, 'To delete');
+    await confirmJoinKeepCloud(session.pageB);
+    expectSharedLibraryHasGame(await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary));
+
+    await permanentlyDeleteGame(session.pageA);
+    const library = await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary);
+    const games = library.games as Array<{ storage_key?: string }>;
+    expect(games.some((game) => game.storage_key === 'Echo Keep')).toBe(false);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(false);
+    expect(existsSync(join(seeded.cloudRoot, 'v2', 'archives', STORAGE_KEY))).toBe(false);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-download-all.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-download-all.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { localArchivePath } from './support/cloud-assertions';
+import { readSave, seedEmptyCloudWithLocalGame, writeSave } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  downloadAll,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('download all missing cloud copies', async ({ browser }) => {
+  const runRoot = await createRunRoot('download-all');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'download-all' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const one = await createPublishedSnapshot(session.pageA, session.hostA, 'One');
+    await writeSave(seeded.deviceA, 'two\n');
+    const two = await createPublishedSnapshot(session.pageA, session.hostA, 'Two');
+    await confirmJoinKeepCloud(session.pageB);
+
+    const saveB = await readSave(seeded.deviceB);
+    await downloadAll(session.pageB, session.hostB, [one, two]);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, one))).toBe(true);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, two))).toBe(true);
+    expect(await readSave(seeded.deviceB)).toBe(saveB);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-empty-create.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-empty-create.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { STORAGE_KEY } from './support/constants';
+import {
+  cloudArchivePath,
+  cloudPaths,
+  expectLocalGeneration,
+  expectNamespaceDescriptor,
+  expectSharedLibraryHasGame,
+  localArchivePath,
+  readJson,
+} from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  downloadSnapshot,
+  getGeneration,
+  openGame,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('empty cloud creates library then first snapshot uploads', async ({ browser }) => {
+  const runRoot = await createRunRoot('empty-create');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot, { gameOnB: false });
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'empty-create' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    expect(await getGeneration(session.hostA)).toBe('v2');
+    await expectLocalGeneration(seeded.deviceA.appDataDir, 'v2');
+    const paths = cloudPaths(seeded.cloudRoot);
+    expect(existsSync(paths.namespace)).toBe(true);
+    expectNamespaceDescriptor(await readJson(paths.namespace));
+    expectSharedLibraryHasGame(await readJson(paths.sharedLibrary));
+    expect(existsSync(join(seeded.cloudRoot, 'v2', 'archives', STORAGE_KEY))).toBe(false);
+
+    const snapshotId = await createPublishedSnapshot(session.pageA, session.hostA, 'First upload');
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(true);
+    expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, snapshotId))).toBe(true);
+
+    await confirmJoinKeepCloud(session.pageB);
+    expect(await getGeneration(session.hostB)).toBe('v2');
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, snapshotId);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, snapshotId))).toBe(true);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-evict-copies.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-evict-copies.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { cloudArchivePath, localArchivePath } from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  downloadSnapshot,
+  evictCloudCopy,
+  evictLocalCopy,
+  openGame,
+  uploadSnapshot,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('evict local or cloud copy without deleting snapshot', async ({ browser }) => {
+  const runRoot = await createRunRoot('evict');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'evict' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const snapshotId = await createPublishedSnapshot(session.pageA, session.hostA, 'Keep record');
+    await confirmJoinKeepCloud(session.pageB);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, snapshotId);
+
+    await openGame(session.pageA);
+    await evictLocalCopy(session.pageA, snapshotId);
+    expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, snapshotId))).toBe(false);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(true);
+
+    await downloadSnapshot(session.pageA, snapshotId);
+    expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, snapshotId))).toBe(true);
+
+    await evictCloudCopy(session.pageA, snapshotId);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(false);
+    expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, snapshotId))).toBe(true);
+
+    await openGame(session.pageB);
+    const download = session.pageB
+      .getByRole('row')
+      .filter({ hasText: snapshotId })
+      .getByRole('button', { name: 'Download to this device' });
+    if (await download.isVisible().catch(() => false)) {
+      await expect(download).toBeDisabled();
+    } else {
+      await expect(
+        session.pageB
+          .getByRole('row')
+          .filter({ hasText: snapshotId })
+          .getByRole('button', { name: 'Upload to cloud' })
+      ).toBeVisible();
+    }
+
+    await openGame(session.pageA);
+    await uploadSnapshot(session.pageA, snapshotId);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(true);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-keep-local.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-keep-local.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { DEVICE_A_ID, DEVICE_B_ID } from './support/constants';
+import { cloudPaths, expectDeviceHead, readJson } from './support/cloud-assertions';
+import { readSave, seedEmptyCloudWithLocalGame, writeSave } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  enableMode,
+  keepLocalProgress,
+  reviewProgress,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('keep local instead of taking the other device save', async ({ browser }) => {
+  const runRoot = await createRunRoot('keep-local');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'keep-local' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    await createPublishedSnapshot(session.pageA, session.hostA, 'Shared parent');
+    await enableMode(session.pageA, session.hostA, 'Multi-device Sync', 'Keep in cloud');
+    await confirmJoinKeepCloud(session.pageB);
+    await enableMode(session.pageB, session.hostB, 'Multi-device Sync', 'Download to this device');
+
+    await writeSave(seeded.deviceA, 'branch-a\n');
+    await writeSave(seeded.deviceB, 'branch-b\n');
+    const aBranch = await createPublishedSnapshot(session.pageA, session.hostA, 'A branch');
+    const bBranch = await createPublishedSnapshot(session.pageB, session.hostB, 'B branch');
+
+    const review = await reviewProgress(session.hostA);
+    expect(review.requires_choice).toBe(true);
+    await keepLocalProgress(session.pageA);
+    const manifest = await readJson(cloudPaths(seeded.cloudRoot).manifest);
+    expectDeviceHead(manifest, DEVICE_A_ID, aBranch);
+    expectDeviceHead(manifest, DEVICE_B_ID, bBranch);
+    expect(await readSave(seeded.deviceA)).toBe('branch-a\n');
+    expect(await readSave(seeded.deviceB)).toBe('branch-b\n');
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
@@ -52,6 +52,7 @@ test('V1 to V2 cutover interrupts, resumes, and stays idempotent', async ({ brow
 
   let host: RgsmHost | undefined;
   let context;
+  let failed = false;
   try {
     host = await startRgsmHost({
       appDataDir: seeded.deviceA.appDataDir,
@@ -143,10 +144,15 @@ test('V1 to V2 cutover interrupts, resumes, and stays idempotent', async ({ brow
       parent: seeded.parentArchiveBytes,
       child: seeded.childArchiveBytes,
     });
+  } catch (error) {
+    failed = true;
+    throw error;
   } finally {
     await context?.close();
     await host?.stop();
     await vite.stop();
-    await removeRunRoot(runRoot);
+    if (!failed) {
+      await removeRunRoot(runRoot);
+    }
   }
 });

--- a/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
@@ -14,7 +14,6 @@ import {
   expectNoDeviceHead,
   expectSharedLibraryHasGame,
   expectV1ObjectsUnchanged,
-  expectVerifiedArchives,
   localArchivePath,
   readDeviceProfile,
   readJson,
@@ -23,10 +22,12 @@ import {
 import { readSave, seedLegacyV1Scene, writeSave } from './support/cloud-fixture';
 import {
   acceptRemoteProgress,
+  applySnapshot,
   changeGameMode,
   confirmCutover,
   confirmJoinKeepCloud,
   deleteCurrentHead,
+  downloadSnapshot,
   expectCutoverSuccess,
   expectLegacyUploadBlocked,
   expectLibraryKind,
@@ -66,6 +67,7 @@ test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ br
   let hostB: RgsmHost | undefined;
   let contextA;
   let contextB;
+  let failed = false;
   try {
     hostA = await startRgsmHost({
       appDataDir: seeded.deviceA.appDataDir,
@@ -144,21 +146,14 @@ test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ br
     expectDeviceHead(afterForward, DEVICE_A_ID, aForward);
     expect((snapshotNode(afterForward, aForward).state as { type?: string }).type).toBe('live');
 
-    const downloaded = await hostPost(hostB, '/api/v1/download-cloud-archive', {
-      gameId: 'Echo Keep',
-      snapshotId: aForward,
-    });
-    expect(downloaded.ok, downloaded.raw).toBe(true);
-    const reviewB = await reviewProgress(hostB);
-    const accepted = await hostPost(hostB, '/api/v1/accept-v2-remote-progress', {
-      gameId: 'Echo Keep',
-      manifestRevision: (await readJson(paths.manifest)).revision,
-      expectedLocalSnapshotId: reviewB.local?.snapshot_id ?? null,
-      selectedSnapshotId: aForward,
-    });
-    expect(accepted.ok, accepted.raw).toBe(true);
+    const saveBeforeApply = await readSave(seeded.deviceB);
+    await openGame(pageB);
+    await downloadSnapshot(pageB, aForward);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, aForward))).toBe(true);
+    expect(await readSave(seeded.deviceB)).toBe(saveBeforeApply);
+    await applySnapshot(pageB, aForward);
     expect(await readSave(seeded.deviceB)).toBe('a-forward-save\n');
-    expectDeviceHead(await readJson(paths.manifest), DEVICE_B_ID, aForward);
+    expectDeviceHead(await readJson(paths.manifest), DEVICE_A_ID, aForward);
     await openSyncSettings(pageA);
     await changeGameMode(pageA, 'Manual');
     const profileA = await readDeviceProfile(seeded.cloudRoot, DEVICE_A_ID);
@@ -171,7 +166,7 @@ test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ br
     )['Echo Keep'];
     expect(gameA.sync_mode).toBe('manual');
     expect(gameB.sync_mode).not.toBe('manual');
-    await toggleCloudEnabled(pageB);
+    await toggleCloudEnabled(pageB, hostB, false);
     const profileAAfter = await readDeviceProfile(seeded.cloudRoot, DEVICE_A_ID);
     expect(
       (profileAAfter.games as Record<string, { sync_mode?: string }>)['Echo Keep'].sync_mode
@@ -253,13 +248,18 @@ test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ br
     expect(await readSave(seeded.deviceA)).toBe(saveA);
     expect(await readSave(seeded.deviceB)).toBe(saveB);
     expectFinalTombstone(await readJson(paths.manifest), bBranch);
+  } catch (error) {
+    failed = true;
+    throw error;
   } finally {
     await contextA?.close();
     await contextB?.close();
     await hostA?.stop();
     await hostB?.stop();
     await vite.stop();
-    await removeRunRoot(runRoot);
+    if (!failed) {
+      await removeRunRoot(runRoot);
+    }
   }
 });
 

--- a/apps/rgsm-gui/e2e/cloud-per-game-sync.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-per-game-sync.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { DEVICE_A_ID, DEVICE_B_ID } from './support/constants';
+import {
+  cloudArchivePath,
+  deviceGameSettings,
+  localArchivePath,
+  readDeviceProfile,
+} from './support/cloud-assertions';
+import { readSave, seedEmptyCloudWithLocalGame, writeSave } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  createSnapshotViaApi,
+  downloadSnapshot,
+  enableMode,
+  latestSnapshotId,
+  openGame,
+  toggleCloudEnabled,
+  uploadSnapshot,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('per-game upload download disable re-enable', async ({ browser }) => {
+  const runRoot = await createRunRoot('per-game');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'per-game' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const baseId = await createPublishedSnapshot(session.pageA, session.hostA, 'Shared base');
+    await enableMode(session.pageA, session.hostA, 'Cloud Backup', 'Keep in cloud');
+    await confirmJoinKeepCloud(session.pageB);
+    await enableMode(session.pageB, session.hostB, 'Cloud Backup', 'Keep in cloud');
+    const saveB = await readSave(seeded.deviceB);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, baseId);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, baseId))).toBe(true);
+    expect(await readSave(seeded.deviceB)).toBe(saveB);
+
+    await writeSave(seeded.deviceA, 'a-only-upload\n');
+    const aOnly = await createPublishedSnapshot(session.pageA, session.hostA, 'A only');
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, aOnly))).toBe(true);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, aOnly))).toBe(false);
+
+    const saveBAfterA = await readSave(seeded.deviceB);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, aOnly);
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, aOnly))).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, aOnly))).toBe(true);
+    expect(await readSave(seeded.deviceB)).toBe(saveBAfterA);
+
+    await toggleCloudEnabled(session.pageA, session.hostA, false);
+    expect(
+      deviceGameSettings(await readDeviceProfile(seeded.cloudRoot, DEVICE_A_ID))
+    ).toMatchObject({
+      cloud_sync_enabled: false,
+      sync_mode: 'cloud_backup',
+    });
+    expect(
+      deviceGameSettings(await readDeviceProfile(seeded.cloudRoot, DEVICE_B_ID)).sync_mode
+    ).toBe('cloud_backup');
+
+    await writeSave(seeded.deviceA, 'disabled-should-stay-local\n');
+    await createSnapshotViaApi(session.hostA, 'While disabled');
+    const disabledId = await latestSnapshotId(session.hostA, 'While disabled');
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, disabledId))).toBe(false);
+
+    await toggleCloudEnabled(session.pageA, session.hostA, true);
+    await openGame(session.pageA);
+    await uploadSnapshot(session.pageA, disabledId);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, disabledId))).toBe(true);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-ping-pong.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-ping-pong.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { DEVICE_A_ID, DEVICE_B_ID, GAME_NAME } from './support/constants';
+import {
+  cloudArchivePath,
+  cloudPaths,
+  localArchivePath,
+  readJson,
+} from './support/cloud-assertions';
+import { readSave, seedEmptyCloudWithLocalGame, writeSave } from './support/cloud-fixture';
+import {
+  applySnapshot,
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  downloadSnapshot,
+  enableMode,
+  openGame,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+const ROUNDS = 3;
+
+async function expectDeviceHeadEventually(
+  cloudRoot: string,
+  deviceId: string,
+  snapshotId: string
+): Promise<void> {
+  // In Multi-device Sync the device head advances on the snapshot sync
+  // coordinator cycle, not synchronously with the upload; allow for a tick.
+  await expect
+    .poll(
+      async () => {
+        const manifest = await readJson(cloudPaths(cloudRoot).manifest);
+        const games = manifest.games as Record<string, { device_heads: Record<string, string> }>;
+        return games[GAME_NAME].device_heads[deviceId];
+      },
+      { timeout: 90_000 }
+    )
+    .toBe(snapshotId);
+}
+
+test('repeated upload download round trips stay consistent', async ({ browser }) => {
+  const runRoot = await createRunRoot('ping-pong');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'ping-pong' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const first = await createPublishedSnapshot(session.pageA, session.hostA, 'Round 0 from A');
+    await enableMode(session.pageA, session.hostA, 'Multi-device Sync', 'Keep in cloud');
+    await confirmJoinKeepCloud(session.pageB);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, first);
+    await enableMode(session.pageB, session.hostB, 'Multi-device Sync', 'Keep in cloud');
+
+    const published: string[] = [first];
+    let latestA = first;
+    let latestB = first;
+    for (let round = 1; round <= ROUNDS; round += 1) {
+      const aSave = `round-${round}-from-a\n`;
+      await writeSave(seeded.deviceA, aSave);
+      const aSnap = await createPublishedSnapshot(session.pageA, session.hostA, `Round ${round} A`);
+      published.push(aSnap);
+      latestA = aSnap;
+
+      await openGame(session.pageB);
+      await downloadSnapshot(session.pageB, aSnap);
+      expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, aSnap))).toBe(true);
+      await applySnapshot(session.pageB, aSnap);
+      expect(await readSave(seeded.deviceB)).toBe(aSave);
+
+      const bSave = `round-${round}-from-b\n`;
+      await writeSave(seeded.deviceB, bSave);
+      const bSnap = await createPublishedSnapshot(session.pageB, session.hostB, `Round ${round} B`);
+      published.push(bSnap);
+      latestB = bSnap;
+
+      await openGame(session.pageA);
+      await downloadSnapshot(session.pageA, bSnap);
+      expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, bSnap))).toBe(true);
+      await applySnapshot(session.pageA, bSnap);
+      expect(await readSave(seeded.deviceA)).toBe(bSave);
+    }
+
+    // A device head tracks that device's last published progress; applying the
+    // other device's snapshot does not republish the head.
+    await expectDeviceHeadEventually(seeded.cloudRoot, DEVICE_A_ID, latestA);
+    await expectDeviceHeadEventually(seeded.cloudRoot, DEVICE_B_ID, latestB);
+    expect(await readSave(seeded.deviceA)).toBe(`round-${ROUNDS}-from-b\n`);
+    expect(await readSave(seeded.deviceB)).toBe(`round-${ROUNDS}-from-b\n`);
+    for (const id of published) {
+      expect(existsSync(cloudArchivePath(seeded.cloudRoot, id))).toBe(true);
+      expect(existsSync(localArchivePath(seeded.deviceA.appDataDir, id))).toBe(true);
+      expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, id))).toBe(true);
+    }
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-protect-retention.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-protect-retention.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import {
+  cloudArchivePath,
+  cloudPaths,
+  expectSharedRetentionLimit,
+  liveSnapshotState,
+  readJson,
+} from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame, seedLocalAutomaticSnapshots } from './support/cloud-fixture';
+import {
+  createLibrary,
+  openGame,
+  protectSnapshot,
+  setSharedRetention,
+  uploadSnapshot,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('protect snapshot and set shared retention limit', async ({ browser }) => {
+  const runRoot = await createRunRoot('protect');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const [keepId, second, third, fourth] = await seedLocalAutomaticSnapshots(seeded.deviceA, [
+    'Keep this',
+    'Second',
+    'Third',
+    'Fourth',
+  ]);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'protect' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    await openGame(session.pageA);
+    for (const snapshotId of [keepId, second, third, fourth]) {
+      await uploadSnapshot(session.pageA, snapshotId!);
+    }
+    await protectSnapshot(session.pageA, keepId!);
+    await setSharedRetention(session.pageA, 1);
+
+    expectSharedRetentionLimit(await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary), 1);
+    const manifest = await readJson(cloudPaths(seeded.cloudRoot).manifest);
+    expect(liveSnapshotState(manifest, keepId).retention_protected).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, keepId!))).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, third!))).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, fourth!))).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, second!))).toBe(false);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-remove-device.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-remove-device.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { DEVICE_A_ID, DEVICE_B_ID } from './support/constants';
+import {
+  cloudArchivePath,
+  cloudPaths,
+  expectDeviceHasNoHead,
+  expectDeviceProfiles,
+  readJson,
+} from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import {
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  enableMode,
+  removeLibraryDevice,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('remove other device from library', async ({ browser }) => {
+  const runRoot = await createRunRoot('remove-device');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'remove-device' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const snapshotId = await createPublishedSnapshot(session.pageA, session.hostA, 'Shared');
+    await enableMode(session.pageA, session.hostA, 'Cloud Backup', 'Keep in cloud');
+    await confirmJoinKeepCloud(session.pageB);
+    await enableMode(session.pageB, session.hostB, 'Cloud Backup', 'Keep in cloud');
+    await expectDeviceProfiles(seeded.cloudRoot, [DEVICE_A_ID, DEVICE_B_ID]);
+
+    await removeLibraryDevice(session.pageA, 'E2E Device B');
+    await expectDeviceProfiles(seeded.cloudRoot, [DEVICE_A_ID]);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(true);
+    expectDeviceHasNoHead(await readJson(cloudPaths(seeded.cloudRoot).manifest), DEVICE_B_ID);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-reset-library.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-reset-library.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import {
+  cloudPaths,
+  expectNamespaceDescriptor,
+  expectSharedLibraryHasGame,
+  readJson,
+} from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import {
+  createLibrary,
+  createPublishedSnapshot,
+  openSyncSettings,
+  resetBrokenLibrary,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('broken library reset and recreate', async ({ browser }) => {
+  const runRoot = await createRunRoot('reset');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'reset' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    await createPublishedSnapshot(session.pageA, session.hostA, 'Before reset');
+    expectSharedLibraryHasGame(await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary));
+
+    await rm(cloudPaths(seeded.cloudRoot).sharedLibrary);
+    await openSyncSettings(session.pageA);
+    await expect(session.pageA.getByRole('button', { name: 'Reset and recreate' })).toBeVisible();
+    await resetBrokenLibrary(session.pageA);
+    const paths = cloudPaths(seeded.cloudRoot);
+    expect(existsSync(paths.namespace)).toBe(true);
+    expectNamespaceDescriptor(await readJson(paths.namespace));
+    expectSharedLibraryHasGame(await readJson(paths.sharedLibrary));
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-reset-library.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-reset-library.spec.ts
@@ -32,7 +32,9 @@ test('broken library reset and recreate', async ({ browser }) => {
     await expect(session.pageA.getByRole('button', { name: 'Reset and recreate' })).toBeVisible();
     await resetBrokenLibrary(session.pageA);
     const paths = cloudPaths(seeded.cloudRoot);
-    expect(existsSync(paths.namespace)).toBe(true);
+    // Namespace recreation finishes after the reset activity; poll instead of
+    // assuming the file is already back.
+    await expect.poll(() => existsSync(paths.namespace), { timeout: 15_000 }).toBe(true);
     expectNamespaceDescriptor(await readJson(paths.namespace));
     expectSharedLibraryHasGame(await readJson(paths.sharedLibrary));
   } catch (error) {

--- a/apps/rgsm-gui/e2e/cloud-sync-modes.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-sync-modes.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { DEVICE_A_ID, DEVICE_B_ID } from './support/constants';
+import {
+  cloudArchivePath,
+  deviceGameSettings,
+  localArchivePath,
+  readDeviceProfile,
+} from './support/cloud-assertions';
+import { readSave, seedEmptyCloudWithLocalGame, writeSave } from './support/cloud-fixture';
+import {
+  changeGameMode,
+  confirmJoinKeepCloud,
+  createLibrary,
+  createPublishedSnapshot,
+  createSnapshotViaApi,
+  enableMode,
+  latestSnapshotId,
+} from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('sync modes and enable catch-up', async ({ browser }) => {
+  const runRoot = await createRunRoot('modes');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'modes' });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const existing = await createPublishedSnapshot(session.pageA, session.hostA, 'Existing cloud');
+    await confirmJoinKeepCloud(session.pageB);
+
+    await changeGameMode(session.pageA, 'Manual');
+    expect(
+      deviceGameSettings(await readDeviceProfile(seeded.cloudRoot, DEVICE_A_ID)).sync_mode
+    ).toBe('manual');
+    await writeSave(seeded.deviceA, 'manual-stays-local\n');
+    await createSnapshotViaApi(session.hostA, 'Manual local');
+    const manualId = await latestSnapshotId(session.hostA, 'Manual local');
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, manualId))).toBe(false);
+
+    await enableMode(session.pageA, session.hostA, 'Cloud Backup', 'Keep in cloud');
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, existing))).toBe(false);
+    await writeSave(seeded.deviceA, 'cloud-backup-auto\n');
+    await createSnapshotViaApi(session.hostA, 'Auto upload');
+    const autoId = await latestSnapshotId(session.hostA, 'Auto upload');
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, autoId))).toBe(true);
+
+    const beforeB = await readSave(seeded.deviceB);
+    await enableMode(session.pageB, session.hostB, 'Cloud Backup', 'Download to this device');
+    expect(existsSync(localArchivePath(seeded.deviceB.appDataDir, existing))).toBe(true);
+    expect(await readSave(seeded.deviceB)).toBe(beforeB);
+
+    await enableMode(session.pageB, session.hostB, 'Multi-device Sync', 'Keep in cloud');
+    expect(
+      deviceGameSettings(await readDeviceProfile(seeded.cloudRoot, DEVICE_B_ID)).sync_mode
+    ).toBe('multi_device_sync');
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/support/cloud-assertions.ts
+++ b/apps/rgsm-gui/e2e/support/cloud-assertions.ts
@@ -59,7 +59,18 @@ export function localOwnerPaths(appDataDir: string, deviceId: string) {
 }
 
 export function localArchivePath(appDataDir: string, snapshotId: string): string {
-  return join(appDataDir, 'save_data', STORAGE_KEY, `${snapshotId}.zip`);
+  return firstExistingArchive(join(appDataDir, 'save_data', STORAGE_KEY), snapshotId);
+}
+
+export function cloudArchivePath(cloudRoot: string, snapshotId: string): string {
+  return firstExistingArchive(join(cloudRoot, 'v2', 'archives', STORAGE_KEY), snapshotId);
+}
+
+function firstExistingArchive(directory: string, snapshotId: string): string {
+  const zip = join(directory, `${snapshotId}.zip`);
+  const sevenZ = join(directory, `${snapshotId}.7z`);
+  if (existsSync(sevenZ)) return sevenZ;
+  return zip;
 }
 
 export async function xxh3File(
@@ -114,6 +125,23 @@ export function snapshotNode(manifest: JsonObject, snapshotId: string) {
   return snapshots[snapshotId];
 }
 
+export function liveSnapshotState(manifest: JsonObject, snapshotId: string): JsonObject {
+  const state = snapshotNode(manifest, snapshotId).state;
+  expect(state && typeof state === 'object').toBe(true);
+  const live = state as JsonObject;
+  expect(live.type).toBe('live');
+  return live;
+}
+
+export function expectSharedRetentionLimit(library: JsonObject, limit: number): void {
+  expectSharedLibraryHasGame(library);
+  const games = library.games as Array<JsonObject>;
+  const game = games.find((item) => item.storage_key === STORAGE_KEY);
+  expect(game, 'shared library missing Echo Keep').toBeTruthy();
+  const retention = game?.snapshot_retention as JsonObject | undefined;
+  expect(retention?.automatic_snapshots_per_branch).toBe(limit);
+}
+
 export function expectLiveParentChildGraph(manifest: JsonObject): void {
   expect(manifest.schema_version).toBe(2);
   const parent = snapshotNode(manifest, PARENT_SNAPSHOT_ID);
@@ -140,6 +168,18 @@ export function expectNoDeviceHead(
   expect(heads[deviceId]).not.toBe(snapshotId);
 }
 
+export function expectDeviceHasNoHead(manifest: JsonObject, deviceId: string): void {
+  const game = gameManifest(manifest);
+  const heads = game.device_heads as Record<string, string>;
+  expect(heads[deviceId]).toBeUndefined();
+}
+
+export function deviceGameSettings(profile: JsonObject) {
+  return (profile.games as Record<string, { sync_mode?: string; cloud_sync_enabled?: boolean }>)[
+    STORAGE_KEY
+  ];
+}
+
 export function expectFinalTombstone(manifest: JsonObject, snapshotId: string): void {
   const node = snapshotNode(manifest, snapshotId);
   expect((node.state as JsonObject).type).toBe('final_tombstone');
@@ -160,11 +200,12 @@ export async function expectVerifiedArchives(
   expect(child.hash).toBe(CHILD_ARCHIVE_HASH);
 }
 
-export async function expectDeviceProfiles(cloudRoot: string): Promise<void> {
+export async function expectDeviceProfiles(
+  cloudRoot: string,
+  deviceIds: string[] = [DEVICE_A_ID, DEVICE_B_ID]
+): Promise<void> {
   const files = await readdir(cloudPaths(cloudRoot).profiles);
-  expect(files.sort()).toEqual(
-    [deviceProfileFileName(DEVICE_A_ID), deviceProfileFileName(DEVICE_B_ID)].sort()
-  );
+  expect(files.sort()).toEqual(deviceIds.map(deviceProfileFileName).sort());
 }
 
 export async function readDeviceProfile(cloudRoot: string, deviceId: string): Promise<JsonObject> {

--- a/apps/rgsm-gui/e2e/support/cloud-fixture.ts
+++ b/apps/rgsm-gui/e2e/support/cloud-fixture.ts
@@ -127,6 +127,88 @@ export async function seedLegacyV1Scene(runRoot: string): Promise<SeededCloud> {
   };
 }
 
+export async function seedEmptyCloudWithLocalGame(
+  runRoot: string,
+  options: { gameOnB?: boolean } = {}
+): Promise<{
+  cloudRoot: string;
+  deviceA: DeviceLayout;
+  deviceB: DeviceLayout;
+}> {
+  const gameOnB = options.gameOnB ?? true;
+  const cloudRoot = join(runRoot, 'cloud');
+  const deviceA = deviceLayout(runRoot, 'a');
+  const deviceB = deviceLayout(runRoot, 'b');
+  const configTemplate = await readFile(join(fixtureRoot, 'GameSaveManager.config.json'), 'utf8');
+  await mkdir(cloudRoot, { recursive: true });
+  for (const device of [deviceA, deviceB]) {
+    let localConfig = applyPlaceholders(configTemplate, {
+      __BACKUP_PATH__: device.archiveRoot.replaceAll('\\', '/'),
+      __CLOUD_ROOT__: cloudRoot.replaceAll('\\', '/'),
+      __SAVE_PATH_A__: deviceA.savePath.replaceAll('\\', '/'),
+      __SAVE_PATH_B__: deviceB.savePath.replaceAll('\\', '/'),
+    });
+    if (device === deviceB && !gameOnB) {
+      const parsed = JSON.parse(localConfig) as { games: unknown[] };
+      parsed.games = [];
+      localConfig = `${JSON.stringify(parsed, null, 2)}\n`;
+    }
+    await writeText(join(device.appDataDir, 'GameSaveManager.config.json'), localConfig);
+    if (device === deviceA || gameOnB) {
+      await writeText(
+        join(device.appDataDir, 'save_data', STORAGE_KEY, 'Backups.json'),
+        `${JSON.stringify({ name: GAME_NAME, backups: [], device_heads: {}, sync_version: 0 }, null, 2)}\n`
+      );
+    }
+    await writeText(device.savePath, CHILD_SAVE_BYTES);
+  }
+  return { cloudRoot, deviceA, deviceB };
+}
+
+/// Seed local snapshots marked as automatic (Timer) before the host starts, so
+/// the first library activation publishes them with automatic provenance. V2
+/// forbids re-marking provenance through the API, and the HTTP host has no
+/// auto-backup timer, so fixture data is the only way to get Timer snapshots.
+export async function seedLocalAutomaticSnapshots(
+  device: DeviceLayout,
+  describes: string[]
+): Promise<string[]> {
+  const ids = describes.map((_, index) => `2026-01-01_00-00-0${index + 1}`);
+  const dir = join(device.archiveRoot, STORAGE_KEY);
+  await mkdir(dir, { recursive: true });
+  const backups = [];
+  for (const [index, describe] of describes.entries()) {
+    const date = ids[index]!;
+    const archivePath = join(dir, `${date}.7z`);
+    const bytes = Buffer.from(`automatic archive ${describe}\n`, 'utf8');
+    await writeFile(archivePath, bytes);
+    backups.push({
+      date,
+      describe,
+      path: archivePath,
+      archive_format: 'seven_z',
+      size: bytes.length,
+      parent: index === 0 ? null : ids[index - 1],
+      device_id: device.id,
+      created_by: 'Timer',
+    });
+  }
+  await writeText(
+    join(dir, 'Backups.json'),
+    `${JSON.stringify(
+      {
+        name: GAME_NAME,
+        backups,
+        device_heads: { [device.id]: ids.at(-1) },
+        sync_version: 0,
+      },
+      null,
+      2
+    )}\n`
+  );
+  return ids;
+}
+
 export async function writeSave(device: DeviceLayout, contents: string): Promise<void> {
   await writeText(device.savePath, contents);
 }

--- a/apps/rgsm-gui/e2e/support/gui.ts
+++ b/apps/rgsm-gui/e2e/support/gui.ts
@@ -6,9 +6,11 @@ import { fsSession, hostPost } from './rgsm-instance';
 import { GAME_NAME, V2_ACTIVE_ERROR } from './constants';
 
 async function expectActivity(page: Page, pattern: string | RegExp): Promise<void> {
-  const text = page.getByText(pattern).first();
+  const drawer = page.locator('.activity-drawer');
+  const text = drawer.getByText(pattern).first();
   if (await text.isVisible().catch(() => false)) return;
-  await page.getByRole('status').click();
+  // The global loading overlay also carries role="status"; target the drawer.
+  await page.locator('.activity-drawer[role="status"]').click();
   await expect(text).toBeVisible({ timeout: 30_000 });
 }
 
@@ -139,16 +141,15 @@ export async function uploadSnapshot(page: Page, snapshotId: string): Promise<vo
 }
 
 export async function downloadSnapshot(page: Page, snapshotId: string): Promise<void> {
-  const download = snapshotRow(page, snapshotId).getByRole('button', {
-    name: 'Download to this device',
-  });
+  const row = snapshotRow(page, snapshotId);
+  const download = row.getByRole('button', { name: 'Download to this device' });
+  const remove = row.getByRole('button', { name: 'Remove from this device' });
+  // The row buttons render after the row itself; wait for either state first.
+  await download.or(remove).first().waitFor({ state: 'visible', timeout: 30_000 });
   if (await download.isVisible().catch(() => false)) {
-    await expect(download).toBeEnabled();
     await download.click();
   }
-  await expect(
-    snapshotRow(page, snapshotId).getByRole('button', { name: 'Remove from this device' })
-  ).toBeVisible({ timeout: 30_000 });
+  await expect(remove).toBeVisible({ timeout: 30_000 });
 }
 
 export async function deleteCurrentHead(page: Page, snapshotId: string): Promise<void> {

--- a/apps/rgsm-gui/e2e/support/gui.ts
+++ b/apps/rgsm-gui/e2e/support/gui.ts
@@ -1,7 +1,16 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { localArchivePath } from './cloud-assertions';
 import type { RgsmHost } from './rgsm-instance';
 import { fsSession, hostPost } from './rgsm-instance';
 import { GAME_NAME, V2_ACTIVE_ERROR } from './constants';
+
+async function expectActivity(page: Page, pattern: string | RegExp): Promise<void> {
+  const text = page.getByText(pattern).first();
+  if (await text.isVisible().catch(() => false)) return;
+  await page.getByRole('status').click();
+  await expect(text).toBeVisible({ timeout: 30_000 });
+}
 
 export async function openApp(page: Page): Promise<void> {
   await page.goto('/');
@@ -25,7 +34,7 @@ export async function openSyncSettings(page: Page): Promise<void> {
 }
 export async function expectLibraryKind(
   page: Page,
-  kind: 'cutover' | 'join' | 'active' | 'resume'
+  kind: 'cutover' | 'join' | 'active' | 'resume' | 'empty'
 ): Promise<void> {
   if (kind === 'cutover') {
     await expect(page.getByText('Upgrade required')).toBeVisible();
@@ -40,6 +49,13 @@ export async function expectLibraryKind(
   if (kind === 'join') {
     await expect(page.getByText('Join required')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Join library' })).toBeVisible();
+    return;
+  }
+  if (kind === 'empty') {
+    await expect(
+      page.getByText('This location is empty and can create a new Cloud Library.')
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create library' })).toBeVisible();
     return;
   }
   await expect(page.getByRole('button', { name: 'Sync mode' })).toBeVisible();
@@ -68,13 +84,13 @@ export async function expectCutoverSuccess(page: Page): Promise<void> {
 }
 
 export async function confirmJoinKeepCloud(page: Page): Promise<void> {
+  await page.goto('/SyncSettings');
+  await expectLibraryKind(page, 'join');
   await page.getByRole('button', { name: 'Join library' }).first().click();
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
   await dialog.getByRole('button', { name: 'Join library' }).click();
-  await expect(page.getByText('This device joined the Cloud Library').first()).toBeAttached({
-    timeout: 30_000,
-  });
+  await expectActivity(page, 'This device joined the Cloud Library');
 }
 
 export async function openGame(page: Page, gameName = GAME_NAME): Promise<void> {
@@ -82,10 +98,28 @@ export async function openGame(page: Page, gameName = GAME_NAME): Promise<void> 
   await expect(page.getByRole('button', { name: 'Create new snapshot' })).toBeVisible();
 }
 
-export async function createSnapshotFromGui(page: Page, describe: string): Promise<void> {
-  await page.getByLabel('New backup description').fill(describe);
+export async function createSnapshotFromGui(
+  page: Page,
+  host: RgsmHost,
+  describe: string
+): Promise<string> {
+  await page.getByPlaceholder('New backup description').fill(describe);
   await page.getByRole('button', { name: 'Create new snapshot' }).click();
-  await expect(page.getByText(/Backup successful/).first()).toBeAttached({ timeout: 30_000 });
+  const firstBase = page.getByRole('dialog', { name: 'Choose first snapshot base' });
+  if (await firstBase.isVisible().catch(() => false)) {
+    await firstBase.getByRole('textbox').fill('1');
+    await firstBase.getByRole('button', { name: 'Confirm' }).click();
+  }
+  await expect
+    .poll(
+      async () => {
+        const snapshots = await listSnapshots(host);
+        return snapshots.find((item) => item.describe === describe)?.date ?? null;
+      },
+      { timeout: 30_000 }
+    )
+    .not.toBeNull();
+  return latestSnapshotId(host, describe);
 }
 
 export function snapshotRow(page: Page, snapshotId: string): Locator {
@@ -93,15 +127,28 @@ export function snapshotRow(page: Page, snapshotId: string): Locator {
 }
 
 export async function uploadSnapshot(page: Page, snapshotId: string): Promise<void> {
-  await snapshotRow(page, snapshotId).getByRole('button', { name: 'Upload to cloud' }).click();
-  await expect(page.getByText('Snapshot uploaded').first()).toBeAttached({ timeout: 30_000 });
+  const row = snapshotRow(page, snapshotId);
+  const upload = row.getByRole('button', { name: 'Upload to cloud' });
+  const uploaded = row.getByRole('button', { name: 'Remove cloud copy' });
+  // Wait for the row to settle into either state instead of probing once.
+  await expect(upload.or(uploaded)).toBeVisible({ timeout: 30_000 });
+  if (await upload.isVisible().catch(() => false)) {
+    await upload.click();
+  }
+  await expect(uploaded).toBeVisible({ timeout: 30_000 });
 }
 
 export async function downloadSnapshot(page: Page, snapshotId: string): Promise<void> {
-  await snapshotRow(page, snapshotId)
-    .getByRole('button', { name: 'Download to this device' })
-    .click();
-  await expect(page.getByText('Snapshot downloaded').first()).toBeAttached({ timeout: 30_000 });
+  const download = snapshotRow(page, snapshotId).getByRole('button', {
+    name: 'Download to this device',
+  });
+  if (await download.isVisible().catch(() => false)) {
+    await expect(download).toBeEnabled();
+    await download.click();
+  }
+  await expect(
+    snapshotRow(page, snapshotId).getByRole('button', { name: 'Remove from this device' })
+  ).toBeVisible({ timeout: 30_000 });
 }
 
 export async function deleteCurrentHead(page: Page, snapshotId: string): Promise<void> {
@@ -111,7 +158,7 @@ export async function deleteCurrentHead(page: Page, snapshotId: string): Promise
   if (await fallback.isVisible().catch(() => false)) {
     await fallback.getByRole('button', { name: 'Delete permanently' }).click();
   }
-  await expect(page.getByText('Successfully deleted').first()).toBeAttached({ timeout: 30_000 });
+  await expectActivity(page, 'Successfully deleted');
 }
 
 export async function openProgressReview(page: Page): Promise<void> {
@@ -129,7 +176,7 @@ export async function acceptRemoteProgress(page: Page, snapshotId: string): Prom
       name: 'Use this progress',
     })
     .click();
-  await page.getByRole('button', { name: 'Use this progress' }).last().click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Use this progress' }).last().click();
   await expect(page.getByText(/The selected progress was applied/).first()).toBeAttached({
     timeout: 30_000,
   });
@@ -137,19 +184,41 @@ export async function acceptRemoteProgress(page: Page, snapshotId: string): Prom
 
 export async function changeGameMode(page: Page, modeLabel: string): Promise<void> {
   await openSyncSettings(page);
-  await page.getByRole('button', { name: 'Sync mode' }).click();
+  const modeButton = page.getByRole('button', { name: 'Sync mode' });
+  await expect(modeButton).toBeVisible({ timeout: 30_000 });
+  const current = (await modeButton.textContent()) ?? '';
+  if (current.includes(modeLabel)) {
+    return;
+  }
+  await modeButton.click();
   await page.getByRole('menuitem', { name: modeLabel }).click();
   const enable = page.getByRole('dialog').getByRole('button', { name: 'Enable' });
   if (await enable.isVisible().catch(() => false)) {
     await enable.click();
   }
-  await expect(page.getByText('Sync mode updated').first()).toBeAttached({ timeout: 15_000 });
+  await expect(modeButton).toContainText(modeLabel, { timeout: 30_000 });
 }
 
-export async function toggleCloudEnabled(page: Page): Promise<void> {
+export async function toggleCloudEnabled(
+  page: Page,
+  host: RgsmHost,
+  enabled: boolean
+): Promise<void> {
   await openSyncSettings(page);
+  const current = await getArchiveLibrary(host);
+  const game = current.games.find((item) => item.game_id === GAME_NAME);
+  if (game?.cloud_sync_enabled === enabled) {
+    return;
+  }
   await page.getByRole('switch', { name: 'Cloud sync' }).click();
-  await expect(page.getByText('Sync mode updated').first()).toBeAttached({ timeout: 15_000 });
+  await expect
+    .poll(
+      async () =>
+        (await getArchiveLibrary(host)).games.find((item) => item.game_id === GAME_NAME)
+          ?.cloud_sync_enabled,
+      { timeout: 15_000 }
+    )
+    .toBe(enabled);
 }
 
 export async function expectLegacyUploadBlocked(host: RgsmHost, cloudRoot: string): Promise<void> {
@@ -191,7 +260,22 @@ export async function getLocalConfig(host: RgsmHost) {
   return result.data;
 }
 
+// Snapshot IDs are second-precision (`YYYY-MM-DD_HH-mm-ss`); two creations in
+// the same second collide (self-parent, overwritten archive). Space them out.
+let lastSnapshotCreateMs = 0;
+
+async function waitForFreshSnapshotSecond(): Promise<void> {
+  const elapsed = Date.now() - lastSnapshotCreateMs;
+  if (elapsed < 1100) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    setTimeout(resolve, 1100 - elapsed);
+    await promise;
+  }
+  lastSnapshotCreateMs = Date.now();
+}
+
 export async function createSnapshotViaApi(host: RgsmHost, describe: string) {
+  await waitForFreshSnapshotSecond();
   const config = await getLocalConfig(host);
   const game = config.games.find((item) => item.name === GAME_NAME);
   expect(game).toBeTruthy();
@@ -200,6 +284,27 @@ export async function createSnapshotViaApi(host: RgsmHost, describe: string) {
     describe,
   });
   expect(result.ok, result.raw).toBe(true);
+}
+
+export async function listSnapshots(
+  host: RgsmHost
+): Promise<Array<{ date: string; describe?: string }>> {
+  const config = await getLocalConfig(host);
+  const game = config.games.find((item) => item.name === GAME_NAME);
+  const result = await hostPost<{ backups: Array<{ date: string; describe?: string }> }>(
+    host,
+    '/api/v1/get-game-snapshots-info',
+    { game }
+  );
+  expect(result.ok, result.raw).toBe(true);
+  return result.data.backups;
+}
+
+export async function latestSnapshotId(host: RgsmHost, describe?: string): Promise<string> {
+  const snapshots = await listSnapshots(host);
+  const match = describe ? snapshots.find((item) => item.describe === describe) : snapshots.at(-1);
+  expect(match, `missing snapshot ${describe ?? 'latest'}`).toBeTruthy();
+  return match!.date;
 }
 
 export async function uploadArchiveViaApi(host: RgsmHost, snapshotId: string) {
@@ -255,4 +360,190 @@ export async function getArchiveLibrary(host: RgsmHost) {
   }>(host, '/api/v1/get-cloud-archive-library');
   expect(result.ok, result.raw).toBe(true);
   return result.data;
+}
+
+export async function createLibrary(page: Page): Promise<void> {
+  await openSyncSettings(page);
+  await expectLibraryKind(page, 'empty');
+  await page.getByRole('button', { name: 'Create library' }).click();
+  await expectActivity(page, 'Cloud Library created');
+  await page.reload();
+  await openApp(page);
+}
+export async function applySnapshot(page: Page, snapshotId: string): Promise<void> {
+  await snapshotRow(page, snapshotId).getByRole('button', { name: 'Apply' }).click();
+  await expectActivity(page, /Successfully restored/);
+}
+
+export async function enableMode(
+  page: Page,
+  host: RgsmHost,
+  modeLabel: 'Cloud Backup' | 'Multi-device Sync',
+  catchUp: 'Keep in cloud' | 'Download to this device'
+): Promise<void> {
+  await openSyncSettings(page);
+  const modeButton = page.getByRole('button', { name: 'Sync mode' });
+  await expect(modeButton).toBeVisible({ timeout: 30_000 });
+  const current = (await modeButton.textContent()) ?? '';
+  if (current.includes(modeLabel) && catchUp === 'Keep in cloud') {
+    return;
+  }
+  if (current.includes(modeLabel)) {
+    await changeGameMode(page, 'Manual');
+  }
+  await page.getByRole('button', { name: 'Sync mode' }).click();
+  await page.getByRole('menuitem', { name: modeLabel }).click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.getByText(catchUp, { exact: true }).click();
+  await dialog.getByRole('button', { name: 'Enable' }).click();
+  await expect(page.getByRole('button', { name: 'Sync mode' })).toContainText(modeLabel, {
+    timeout: 30_000,
+  });
+  if (catchUp === 'Download to this device') {
+    await expect
+      .poll(
+        async () => {
+          const library = await getArchiveLibrary(host);
+          const game = library.games.find((item) => item.game_id === GAME_NAME);
+          return (
+            game?.snapshots.every((snapshot) =>
+              existsSync(localArchivePath(host.appDataDir, snapshot.snapshot_id))
+            ) ?? false
+          );
+        },
+        { timeout: 60_000 }
+      )
+      .toBe(true);
+  }
+}
+
+export async function keepLocalProgress(page: Page): Promise<void> {
+  await openProgressReview(page);
+  await page.getByRole('button', { name: 'Keep this device' }).click();
+  const confirm = page.getByRole('dialog').getByRole('button', { name: 'Keep this device' });
+  if (await confirm.isVisible().catch(() => false)) {
+    await confirm.click();
+  }
+  await expect(page.getByRole('dialog', { name: 'Devices have different progress' })).toBeHidden({
+    timeout: 30_000,
+  });
+}
+
+export async function evictLocalCopy(page: Page, snapshotId: string): Promise<void> {
+  await snapshotRow(page, snapshotId)
+    .getByRole('button', { name: 'Remove from this device' })
+    .click();
+  await page.getByRole('button', { name: 'Remove local copy' }).click();
+  await expect(
+    snapshotRow(page, snapshotId).getByRole('button', { name: 'Download to this device' })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+export async function evictCloudCopy(page: Page, snapshotId: string): Promise<void> {
+  await snapshotRow(page, snapshotId).getByRole('button', { name: 'Remove cloud copy' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Remove cloud copy' }).click();
+  await expect(
+    snapshotRow(page, snapshotId).getByRole('button', { name: 'Upload to cloud' })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+export async function downloadAll(
+  page: Page,
+  host: RgsmHost,
+  expectedIds: string[]
+): Promise<void> {
+  await openSyncSettings(page);
+  await page.getByRole('button', { name: /Download all to this device|Resume download/ }).click();
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Download all to this device' })
+    .click();
+  await expect
+    .poll(() => expectedIds.every((id) => existsSync(localArchivePath(host.appDataDir, id))), {
+      timeout: 60_000,
+    })
+    .toBe(true);
+}
+
+export async function permanentlyDeleteGame(page: Page): Promise<void> {
+  await openSyncSettings(page);
+  await page.getByRole('button', { name: 'Permanently delete shared game' }).click();
+  await page.getByRole('button', { name: 'Delete Game permanently' }).click();
+  await expectActivity(page, /Shared Game permanently deleted/);
+}
+
+export function libraryDevices(page: Page): Locator {
+  return page
+    .locator('section')
+    .filter({ has: page.getByRole('heading', { name: 'Library devices' }) })
+    .last();
+}
+
+export async function openDeviceSettings(page: Page): Promise<void> {
+  await page.goto('/Settings');
+  await page.getByRole('button', { name: 'Device Management' }).click();
+  await expect(page.getByText('Library devices')).toBeVisible();
+}
+
+export async function removeLibraryDevice(page: Page, deviceName: string): Promise<void> {
+  await openDeviceSettings(page);
+  const section = libraryDevices(page);
+  await expect(section.getByText(deviceName)).toBeVisible();
+  // Only non-current, non-removed devices offer the action, so it is unique.
+  await section.getByRole('button', { name: 'Remove device' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Remove device' }).click();
+  await expectActivity(page, /Device Profile removed/);
+}
+
+export async function resetBrokenLibrary(page: Page): Promise<void> {
+  await openSyncSettings(page);
+  await page.getByRole('button', { name: 'Reset and recreate' }).click();
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('textbox').fill('yes');
+  await dialog.getByRole('button', { name: 'Reset and recreate' }).click();
+  await expectActivity(page, 'Cloud Library state reset');
+}
+
+export async function protectSnapshot(page: Page, snapshotId: string): Promise<void> {
+  await snapshotRow(page, snapshotId).getByRole('button', { name: 'Keep' }).click();
+  await page.getByRole('dialog').getByRole('button', { name: 'Keep' }).click();
+  await expect(
+    snapshotRow(page, snapshotId).getByRole('button', { name: /Unprotect|Remove protection/ })
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+export async function setSharedRetention(page: Page, limit: number): Promise<void> {
+  await page.getByRole('button', { name: 'More actions' }).click();
+  await page.getByRole('menuitem', { name: 'Auto-save settings' }).click();
+  await expect(page.getByText('Shared automatic snapshot limit')).toBeVisible();
+  const block = page
+    .getByRole('heading', { name: 'Shared automatic snapshot limit' })
+    .locator('xpath=ancestor::div[contains(@class,"justify-between")][1]');
+  const enabled = block.getByRole('switch');
+  if (!(await enabled.isChecked())) {
+    await enabled.click();
+  }
+  await block.getByLabel('Shared automatic snapshot limit').fill(String(limit));
+  await page.getByRole('button', { name: 'Save settings' }).click();
+  // Lowering the limit always asks before permanent cleanup. Bounded click: the
+  // confirm dialog currently renders under the drawer, which must not hang the
+  // test for the whole test timeout while the product bug stands.
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Allow permanent cleanup' })
+    .click({ timeout: 15_000 });
+  await expect(page.getByText('Shared automatic snapshot limit')).toBeHidden({ timeout: 15_000 });
+}
+
+export async function createPublishedSnapshot(
+  page: Page,
+  host: RgsmHost,
+  describe: string
+): Promise<string> {
+  await createSnapshotViaApi(host, describe);
+  const snapshotId = await latestSnapshotId(host, describe);
+  await openGame(page);
+  await uploadSnapshot(page, snapshotId);
+  return snapshotId;
 }

--- a/apps/rgsm-gui/e2e/support/rgsm-instance.ts
+++ b/apps/rgsm-gui/e2e/support/rgsm-instance.ts
@@ -39,12 +39,16 @@ type HostFile = {
 };
 
 type SharedVite = {
-  child: ChildProcess;
+  child: ChildProcess | undefined;
   users: number;
 };
 
 let sharedVite: SharedVite | undefined;
 let builtBinary: string | undefined;
+
+// The Playwright worker owns the Vite child, but global teardown runs in a
+// separate process, so the child PID is recorded here for cross-process cleanup.
+const viteMarkerPath = join(tmpdir(), 'rgsm-gui-e2e-vite.json');
 
 export function workspacePath(...parts: string[]): string {
   return resolve(workspaceRoot, ...parts);
@@ -154,10 +158,39 @@ export async function startTestWeb(): Promise<TestWeb> {
     };
   }
 
-  const viteCommand = process.platform === 'win32' ? 'cmd.exe' : 'pnpm';
-  const viteArgs =
-    process.platform === 'win32' ? ['/d', '/s', '/c', 'pnpm.cmd exec vite'] : ['exec', 'vite'];
-  const child = spawn(viteCommand, viteArgs, {
+  try {
+    const response = await fetch(`${VITE_ORIGIN}/`);
+    if (response.ok) {
+      // A marker means the listener is a stale orphan from a crashed run; it
+      // can die mid-test when its dead parent's stdio closes. Replace it.
+      let stalePid: number | undefined;
+      try {
+        const marker = JSON.parse(await readFile(viteMarkerPath, 'utf8')) as { pid?: number };
+        stalePid = marker.pid;
+      } catch {
+        // No marker: a foreign dev server owns the port; adopt it.
+      }
+      if (stalePid !== undefined) {
+        stopPidTree(stalePid);
+        await rm(viteMarkerPath, { force: true });
+        await waitForPortFree(10_000);
+      } else {
+        sharedVite = { child: undefined, users: 1 };
+        return {
+          origin: VITE_ORIGIN,
+          stop: async () => {
+            await releaseTestWeb();
+          },
+        };
+      }
+    }
+  } catch {
+    // No leftover Vite on the shared port.
+  }
+
+  // Spawn Vite's node binary directly (no cmd/pnpm wrappers): the recorded PID
+  // is then the port owner itself, so teardown can kill it reliably.
+  const child = spawn(process.execPath, [join(appRoot, 'node_modules', 'vite', 'bin', 'vite.js')], {
     cwd: appRoot,
     env: { ...process.env },
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -180,6 +213,7 @@ export async function startTestWeb(): Promise<TestWeb> {
     stopProcessTree(child);
     throw error;
   }
+  await writeFile(viteMarkerPath, JSON.stringify({ pid: child.pid }), 'utf8');
   sharedVite = { child, users: 1 };
   return {
     origin: VITE_ORIGIN,
@@ -191,18 +225,47 @@ export async function startTestWeb(): Promise<TestWeb> {
 
 async function releaseTestWeb(): Promise<void> {
   if (!sharedVite) return;
-  sharedVite.users -= 1;
-  if (sharedVite.users > 0) return;
-  const child = sharedVite.child;
-  sharedVite = undefined;
-  stopProcessTree(child);
+  sharedVite.users = Math.max(0, sharedVite.users - 1);
+}
+
+async function waitForPortFree(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      await fetch(`${VITE_ORIGIN}/`);
+    } catch {
+      return;
+    }
+    await delay(250);
+  }
+}
+
+function stopPidTree(pid: number): void {
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+    return;
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // Already gone.
+  }
 }
 
 export async function stopSharedTestWeb(): Promise<void> {
-  if (!sharedVite) return;
-  const child = sharedVite.child;
+  const child = sharedVite?.child;
   sharedVite = undefined;
   stopProcessTree(child);
+  try {
+    const marker = JSON.parse(await readFile(viteMarkerPath, 'utf8')) as { pid?: number };
+    if (marker.pid !== undefined && marker.pid !== child?.pid) {
+      stopPidTree(marker.pid);
+    }
+  } catch {
+    // No marker: nothing this suite spawned is still alive.
+  }
+  await rm(viteMarkerPath, { force: true });
+  await waitForPortFree(10_000);
 }
 
 export async function startRgsmHost(options: HostStartOptions): Promise<RgsmHost> {

--- a/apps/rgsm-gui/e2e/support/session.ts
+++ b/apps/rgsm-gui/e2e/support/session.ts
@@ -1,0 +1,75 @@
+import type { Browser, BrowserContext, Page } from '@playwright/test';
+import { join } from 'node:path';
+import { DEVICE_A_ID, DEVICE_B_ID } from './constants';
+import type { DeviceLayout } from './cloud-fixture';
+import {
+  newDeviceContext,
+  removeRunRoot,
+  startRgsmHost,
+  startTestWeb,
+  type RgsmHost,
+} from './rgsm-instance';
+import { openApp } from './gui';
+
+export type DualSession = {
+  runRoot: string;
+  cloudRoot: string;
+  deviceA: DeviceLayout;
+  deviceB: DeviceLayout;
+  hostA: RgsmHost;
+  hostB: RgsmHost;
+  contextA: BrowserContext;
+  contextB: BrowserContext;
+  pageA: Page;
+  pageB: Page;
+  close: (keepRoot?: boolean) => Promise<void>;
+};
+
+export async function startDualSession(
+  browser: Browser,
+  options: {
+    runRoot: string;
+    cloudRoot: string;
+    deviceA: DeviceLayout;
+    deviceB: DeviceLayout;
+    label: string;
+  }
+): Promise<DualSession> {
+  const vite = await startTestWeb();
+  const hostA = await startRgsmHost({
+    appDataDir: options.deviceA.appDataDir,
+    deviceId: DEVICE_A_ID,
+    logPath: join(options.runRoot, 'logs', `${options.label}-a.log`),
+  });
+  const hostB = await startRgsmHost({
+    appDataDir: options.deviceB.appDataDir,
+    deviceId: DEVICE_B_ID,
+    logPath: join(options.runRoot, 'logs', `${options.label}-b.log`),
+  });
+  const startedA = await newDeviceContext(browser, hostA);
+  const startedB = await newDeviceContext(browser, hostB);
+  await openApp(startedA.page);
+  await openApp(startedB.page);
+  return {
+    runRoot: options.runRoot,
+    cloudRoot: options.cloudRoot,
+    deviceA: options.deviceA,
+    deviceB: options.deviceB,
+    hostA,
+    hostB,
+    contextA: startedA.context,
+    contextB: startedB.context,
+    pageA: startedA.page,
+    pageB: startedB.page,
+    close: async (keepRoot = false) => {
+      await startedA.context.close();
+      await startedB.context.close();
+      await hostA.stop();
+      await hostB.stop();
+      await vite.stop();
+      if (!keepRoot) {
+        await removeRunRoot(options.runRoot);
+      }
+    },
+  };
+}

--- a/apps/rgsm-gui/eslint.config.mjs
+++ b/apps/rgsm-gui/eslint.config.mjs
@@ -8,6 +8,8 @@ export default [
   {
     ignores: [
       '**/node_modules/**',
+      'e2e-report/**',
+      'e2e-results/**',
       '.nuxt/**',
       '.output/**',
       '.data/**',


### PR DESCRIPTION
Player-path cloud sync e2e specs against the versioned HTTP host: dual-device backup/sync modes, keep-local progress choice, download-all, evict/upload copies, per-game sync, remove device, retention protect, reset library, delete game, empty create.

Four product behaviors currently fail these specs (assertions kept as the correct expectations):

1. Multi-device Sync catch-up "Download to this device" does not materialize cloud archives locally (keep-local, sync-modes).
2. Descriptor-last cutover interrupt: re-inspect treats leftover v2/archives as a broken namespace instead of resumable cutover (library-cutover).
3. `KDrawer` uses `LAYER.dialog` instead of `LAYER.drawer`, so a confirm dialog opened from a drawer renders under the drawer's overlay and its confirm button is unreachable (protect-retention).
4. Legacy v1 config download imports the uploader's `backup_path` as the joining device's v2 `local_archive_root`; subsequent downloads write into the other device's directory (two-v1-devices).