### PR TITLE
fix(gui): :bug: stack confirm dialogs above drawers

### DIFF
--- a/apps/rgsm-gui/src/ui/kit/KDrawer.vue
+++ b/apps/rgsm-gui/src/ui/kit/KDrawer.vue
@@ -44,11 +44,11 @@ function onEscape(event: KeyboardEvent) {
   <DialogRoot v-model:open="open">
     <DialogPortal>
       <DialogOverlay
-        :style="{ zIndex: LAYER.dialog }"
+        :style="{ zIndex: LAYER.drawer }"
         class="k-overlay fixed inset-0 bg-black/55 backdrop-blur-[2px]"
       />
       <DialogContent
-        :style="{ zIndex: LAYER.dialog, width: widthStyle }"
+        :style="{ zIndex: LAYER.drawer, width: widthStyle }"
         class="k-drawer fixed right-0 top-0 flex h-full max-w-[calc(100vw-2rem)] flex-col border-l border-border bg-surface text-text shadow-overlay focus:outline-none"
         @interact-outside="onInteractOutside"
         @escape-key-down="onEscape"

--- a/apps/rgsm-gui/src/ui/layers.ts
+++ b/apps/rgsm-gui/src/ui/layers.ts
@@ -11,7 +11,7 @@ export const LAYER = {
   // Path variable autocomplete dropdown — must sit above normal content but below drawers.
   PATH_AUTOCOMPLETE: 2050,
 
-  // Element Plus poppers/dialogs typically sit around 2xxx. Keep semantic room above.
+  // Drawers sit below dialogs so confirm/prompt boxes remain clickable.
   drawer: 3000,
   dialog: 3100,
   messageBox: 3200,


### PR DESCRIPTION
KDrawer uses LAYER.drawer so confirms stay clickable.