### PR TITLE
fix(cloud): resume cutover and land catch-up downloads

### DIFF
--- a/apps/rgsm-gui/.prettierignore
+++ b/apps/rgsm-gui/.prettierignore
@@ -39,3 +39,7 @@ src-tauri/GameSaveManager.config.json
 src-tauri/GameSaveManager.config.v2/
 src-tauri/GameSaveManager.cloud-cutover.*.json
 src-tauri/save_data/*
+
+# Playwright output
+e2e-report
+e2e-results

--- a/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
@@ -40,6 +40,7 @@ import {
   openSyncSettings,
   reviewProgress,
   toggleCloudEnabled,
+  waitForFreshSnapshotSecond,
 } from './support/gui';
 import {
   createRunRoot,
@@ -284,6 +285,7 @@ async function listSnapshots(host: RgsmHost): Promise<Array<{ date: string; desc
 }
 
 async function createAndUploadSnapshot(host: RgsmHost, describe: string): Promise<string> {
+  await waitForFreshSnapshotSecond();
   const config = await hostPost<{ games: Array<Record<string, unknown>> }>(
     host,
     '/api/v1/get-local-config'

--- a/apps/rgsm-gui/e2e/support/cloud-assertions.ts
+++ b/apps/rgsm-gui/e2e/support/cloud-assertions.ts
@@ -79,9 +79,10 @@ export async function xxh3File(
   const bytes = await readFile(path);
   const result = spawnSync(xxh3HelperPath(), [path], { encoding: 'utf8' });
   expect(result.status, `xxh3 helper failed for ${path}: ${result.stderr}`).toBe(0);
-  const parts = result.stdout.trim().split(/\s+/);
-  expect(parts.length).toBeGreaterThanOrEqual(3);
-  return { size: Number(parts[1]), hash: parts[2], bytes };
+  const [size, hash] = result.stdout.trim().split('\t');
+  expect(size).toBeTruthy();
+  expect(hash).toBeTruthy();
+  return { size: Number(size), hash, bytes };
 }
 export async function expectFileBytes(path: string, expected: Buffer): Promise<void> {
   expect(existsSync(path), `missing ${path}`).toBe(true);

--- a/apps/rgsm-gui/e2e/support/gui.ts
+++ b/apps/rgsm-gui/e2e/support/gui.ts
@@ -173,20 +173,27 @@ export async function deleteCurrentHead(page: Page, snapshotId: string): Promise
 
 export async function openProgressReview(page: Page): Promise<void> {
   await openSyncSettings(page);
-  await page.getByRole('button', { name: 'Progress diverged, compare' }).click();
+  const compare = page.getByRole('button', { name: 'Progress diverged, compare' });
+  await expect(compare).toBeVisible({ timeout: 30_000 });
+  await compare.click();
   await expect(page.getByRole('dialog').getByText('Devices have different progress')).toBeVisible();
 }
 
 export async function acceptRemoteProgress(page: Page, snapshotId: string): Promise<void> {
-  const dialog = page.getByRole('dialog');
-  await dialog
+  const review = page.getByRole('dialog', { name: /Compare progress/ });
+  const candidate = review
     .locator('article')
     .filter({ hasText: snapshotId })
-    .getByRole('button', {
-      name: 'Use this progress',
-    })
-    .click();
-  await page.getByRole('dialog').getByRole('button', { name: 'Use this progress' }).last().click();
+    .or(
+      review
+        .locator('article')
+        .filter({ has: page.getByRole('button', { name: 'Use this progress' }) })
+    )
+    .first();
+  await candidate.getByRole('button', { name: 'Use this progress' }).click();
+  const confirm = page.getByRole('dialog', { name: "Apply another device's progress?" });
+  await expect(confirm).toBeVisible();
+  await confirm.getByRole('button', { name: 'Use this progress' }).click();
   await expect(page.getByText(/The selected progress was applied/).first()).toBeAttached({
     timeout: 30_000,
   });
@@ -430,14 +437,13 @@ export async function enableMode(
 
 export async function keepLocalProgress(page: Page): Promise<void> {
   await openProgressReview(page);
-  await page.getByRole('button', { name: 'Keep this device' }).click();
-  const confirm = page.getByRole('dialog').getByRole('button', { name: 'Keep this device' });
-  if (await confirm.isVisible().catch(() => false)) {
-    await confirm.click();
-  }
-  await expect(page.getByRole('dialog', { name: 'Devices have different progress' })).toBeHidden({
-    timeout: 30_000,
-  });
+  const review = page.getByRole('dialog', { name: /Compare progress/ });
+  await review.getByRole('button', { name: 'Keep this device' }).click();
+  const confirm = page.getByRole('dialog', { name: "Keep this device's progress?" });
+  await expect(confirm).toBeVisible();
+  await confirm.getByRole('button', { name: 'Keep this device' }).click();
+  await expect(confirm).toBeHidden({ timeout: 30_000 });
+  await expect(review).toBeHidden({ timeout: 30_000 });
 }
 
 export async function evictLocalCopy(page: Page, snapshotId: string): Promise<void> {

--- a/apps/rgsm-gui/e2e/support/xxh3.rs
+++ b/apps/rgsm-gui/e2e/support/xxh3.rs
@@ -2,7 +2,7 @@ fn main() {
     for path in std::env::args().skip(1) {
         let bytes = std::fs::read(&path).unwrap_or_else(|error| panic!("{path}: {error}"));
         println!(
-            "{path} {} {:016x}",
+            "{}\t{:016x}\t{path}",
             bytes.len(),
             xxhash_rust::xxh3::xxh3_64(&bytes)
         );

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 import { commands, type CloudArchiveLibraryView } from '../api/commands';
 import { notifyError, notifyInfo, notifySuccess } from '../composables/useActivityCenter';
@@ -25,12 +25,15 @@ const cloudSnapshots = computed(
 );
 const totalSnapshots = computed(() => allSnapshots.value.length);
 
-async function load() {
+async function load(options: { silent?: boolean } = {}) {
+  if (loading.value) return;
   loading.value = true;
   try {
     const result = await commands.getCloudArchiveLibrary();
     if (result.status === 'error') {
-      notifyError($t('sync_settings.archives.load_failed'), result.error);
+      if (!options.silent) {
+        notifyError($t('sync_settings.archives.load_failed'), result.error);
+      }
       return;
     }
     library.value = result.data;
@@ -83,7 +86,16 @@ async function materializeAll() {
 }
 
 defineExpose({ load });
-onMounted(load);
+let refreshTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => {
+  void load();
+  refreshTimer = setInterval(() => {
+    void load({ silent: true });
+  }, 2000);
+});
+onUnmounted(() => {
+  if (refreshTimer !== undefined) clearInterval(refreshTimer);
+});
 </script>
 
 <template>

--- a/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
+++ b/apps/rgsm-gui/src/components/V2ConflictReviewDialog.vue
@@ -160,7 +160,8 @@ watch(
   () => props.modelValue,
   (open) => {
     if (open) void load();
-  }
+  },
+  { immediate: true }
 );
 </script>
 

--- a/apps/rgsm-gui/src/components/management/snapshotAvailability.ts
+++ b/apps/rgsm-gui/src/components/management/snapshotAvailability.ts
@@ -14,8 +14,7 @@ export function cloudSnapshotOf(
 }
 
 export function isSnapshotOnDevice(cloudGame: CloudArchiveGameView | null, date: string) {
-  const snapshot = cloudSnapshotOf(cloudGame, date);
-  return !snapshot || snapshot.local_verified;
+  return Boolean(cloudSnapshotOf(cloudGame, date)?.local_verified);
 }
 
 export function isSnapshotInCloud(cloudGame: CloudArchiveGameView | null, date: string) {

--- a/apps/rgsm-gui/src/ui/kit/KDialog.vue
+++ b/apps/rgsm-gui/src/ui/kit/KDialog.vue
@@ -20,8 +20,10 @@ const props = withDefaults(
     width?: number;
     /** When false: no X, no outside-click/Escape dismissal. For blocking confirms. */
     dismissable?: boolean;
+    /** Overlay stack. Nested confirms use messageBox above ordinary dialogs. */
+    layer?: number;
   }>(),
-  { title: undefined, width: 520, dismissable: true }
+  { title: undefined, width: 520, dismissable: true, layer: LAYER.dialog }
 );
 
 const open = defineModel<boolean>('open', { required: true });
@@ -39,11 +41,11 @@ function onEscape(event: KeyboardEvent) {
   <DialogRoot v-model:open="open">
     <DialogPortal>
       <DialogOverlay
-        :style="{ zIndex: LAYER.dialog }"
+        :style="{ zIndex: props.layer }"
         class="k-overlay fixed inset-0 bg-black/55 backdrop-blur-[2px]"
       />
       <DialogContent
-        :style="{ zIndex: LAYER.dialog, maxWidth: `${width}px` }"
+        :style="{ zIndex: props.layer, maxWidth: `${width}px` }"
         class="k-dialog fixed left-1/2 top-1/2 w-[calc(100vw-2rem)] -translate-x-1/2 -translate-y-1/2 rounded-md border border-border bg-surface p-5 text-text shadow-overlay focus:outline-none"
         @interact-outside="onInteractOutside"
         @escape-key-down="onEscape"

--- a/apps/rgsm-gui/src/ui/kit/KFeedbackHost.vue
+++ b/apps/rgsm-gui/src/ui/kit/KFeedbackHost.vue
@@ -2,10 +2,10 @@
 import { computed, ref, watch, type VNode } from 'vue';
 import { $t } from '../../i18n';
 import { settleFeedback, useFeedbackQueue } from '../../composables/useFeedback';
+import { LAYER } from '../layers';
 import KButton from './KButton.vue';
 import KDialog from './KDialog.vue';
 import KInput from './KInput.vue';
-
 /** Singleton host rendering queued useFeedback requests. Mounted once in App.vue. */
 const { feedbackQueue } = useFeedbackQueue();
 
@@ -59,6 +59,7 @@ function asRenderable(message: string | VNode) {
     :title="current?.title ?? ''"
     :width="440"
     :dismissable="current?.dismissable ?? true"
+    :layer="LAYER.messageBox"
   >
     <template v-if="current">
       <div class="text-sm leading-relaxed text-text">

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -436,8 +436,15 @@ impl Game {
         created_by: CreatedBy,
     ) -> Result<SnapshotCreated, BackupError> {
         let backup_path = get_backup_path()?.join(self.backup_dir_name().as_ref());
+        let infos = match self.get_game_snapshots_info() {
+            Ok(infos) => infos,
+            Err(BackupError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                GameSnapshots::new(self.name.clone())
+            }
+            Err(error) => return Err(error),
+        };
         // Keep the timestamp format sortable so lexicographic order equals chronological order.
-        let date = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        let date = unused_snapshot_date(&backup_path, &infos)?;
         let save_paths = &self.save_paths; // everything you should copy
         let config = get_config()?;
         let preset = config.settings.compression_preset;
@@ -454,7 +461,7 @@ impl Game {
             }
         };
 
-        let mut infos = self.get_game_snapshots_info()?;
+        let mut infos = infos;
 
         let parent = parent_date.or_else(|| infos.current_device_head().cloned());
 
@@ -494,7 +501,14 @@ impl Game {
     ) -> Result<SnapshotCreated, BackupError> {
         let backup_path = options.backup_base.join(self.backup_dir_name().as_ref());
         fs::create_dir_all(&backup_path)?;
-        let date = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        let infos = match self.get_game_snapshots_info() {
+            Ok(infos) => infos,
+            Err(BackupError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                GameSnapshots::new(self.name.clone())
+            }
+            Err(error) => return Err(error),
+        };
+        let date = unused_snapshot_date(&backup_path, &infos)?;
         let archive_format = ArchiveFormat::SevenZ;
         let archive_path = backup_path.join(archive_file_name(&date, archive_format));
         if let Some(notifier) = options.notifier {
@@ -511,7 +525,7 @@ impl Game {
             options.source_fingerprint,
         )?;
 
-        let mut infos = self.get_game_snapshots_info()?;
+        let mut infos = infos;
         let parent = options
             .parent_date
             .or_else(|| infos.current_device_head().cloned());
@@ -1000,4 +1014,32 @@ impl Game {
         self.set_game_snapshots_info(&saves)?;
         Ok(saves)
     }
+}
+
+pub(crate) fn unused_snapshot_date(
+    backup_path: &Path,
+    infos: &GameSnapshots,
+) -> Result<String, BackupError> {
+    let taken: HashSet<&str> = infos
+        .backups
+        .iter()
+        .map(|snapshot| snapshot.date.as_str())
+        .collect();
+    for offset in 0..60 {
+        let candidate = (chrono::Local::now() + chrono::Duration::seconds(offset))
+            .format("%Y-%m-%d_%H-%M-%S")
+            .to_string();
+        if taken.contains(candidate.as_str()) {
+            continue;
+        }
+        let zip = backup_path.join(archive_file_name(&candidate, ArchiveFormat::Zip));
+        let seven_z = backup_path.join(archive_file_name(&candidate, ArchiveFormat::SevenZ));
+        if zip.exists() || seven_z.exists() {
+            continue;
+        }
+        return Ok(candidate);
+    }
+    Err(BackupError::Unexpected(anyhow::anyhow!(
+        "Could not allocate a unique snapshot identity"
+    )))
 }

--- a/crates/rgsm-core/src/backup/tests/game.rs
+++ b/crates/rgsm-core/src/backup/tests/game.rs
@@ -1128,6 +1128,27 @@ fn game_draft_into_game_allocates_new_id_after_existing_row_path_edit() {
 }
 
 #[test]
+fn unused_snapshot_date_skips_occupied_second() -> TestResult {
+    let backup_path = Path::new("occupied-second");
+    let mut infos = GameSnapshots::new("game");
+    let occupied = chrono::Local::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+    infos.backups.push(Snapshot {
+        date: occupied.clone(),
+        describe: String::new(),
+        path: String::new(),
+        archive_format: crate::backup::ArchiveFormat::Zip,
+        size: 0,
+        parent: None,
+        archive_hash: None,
+        device_id: None,
+        created_by: CreatedBy::Manual,
+    });
+    let allocated = crate::backup::game::unused_snapshot_date(backup_path, &infos)?;
+    assert_ne!(allocated, occupied);
+    Ok(())
+}
+
+#[test]
 fn game_with_colon_in_name_can_create_snapshot() -> TestResult {
     let _config_lock = lock_config_file();
     run_async_test(async {

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
@@ -550,6 +550,56 @@ async fn game_materialization_respects_scope_and_activation_revision() {
 }
 
 #[tokio::test]
+async fn catch_up_uses_current_catalog_revision_not_legacy_zero() {
+    let operator = memory_operator();
+    let root = temp_dir::TempDir::new().expect("temporary directory should initialize");
+    let mut manifest = CloudManifest {
+        revision: 4,
+        ..Default::default()
+    };
+    let mut game = GameManifest::new("selected");
+    let bytes = b"published after join";
+    let mut node = live("later", bytes, true);
+    node.catalog_revision = 4;
+    game.upsert_live(node).unwrap();
+    operator
+        .write(
+            &cloud_archive_path("selected", "later", ArchiveFormat::Zip).unwrap(),
+            bytes.to_vec(),
+        )
+        .await
+        .unwrap();
+    manifest.games.insert("selected".into(), game);
+    write_manifest(&operator, &manifest).await;
+
+    let deck = materializer(operator.clone(), root.path(), "deck");
+    assert_eq!(
+        deck.materialize_game("selected", 0, &CancellationToken::new())
+            .await
+            .unwrap()
+            .downloaded,
+        0
+    );
+    let current = deck.catalog_revision().await.unwrap();
+    assert_eq!(current, 4);
+    assert_eq!(
+        deck.materialize_game("selected", current, &CancellationToken::new())
+            .await
+            .unwrap()
+            .downloaded,
+        1
+    );
+    assert!(
+        archive_path(
+            &root.path().join("deck").join("selected"),
+            "later",
+            ArchiveFormat::Zip
+        )
+        .is_file()
+    );
+}
+
+#[tokio::test]
 async fn materialize_all_resumes_the_one_pending_scope() {
     let operator = memory_operator();
     let root = temp_dir::TempDir::new().expect("temporary directory should initialize");

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_sync.rs
@@ -388,29 +388,50 @@ impl SnapshotSyncCoordinator {
         local: &GameSnapshots,
     ) -> Result<(), SnapshotSyncError> {
         let manifest = self.repository().load().await?;
-        let mut visiting = HashSet::new();
-        let mut emitted = manifest
+        if let Some(existing) = manifest
             .games
             .get(game_id)
-            .map(|game| game.snapshots.keys().cloned().collect())
-            .unwrap_or_default();
-        let snapshots = local
-            .backups
-            .iter()
-            .map(|item| (item.date.clone(), item))
-            .collect();
-        let mut order = Vec::new();
-        visit_snapshot(
-            &snapshot.date,
-            &snapshots,
-            &mut visiting,
-            &mut emitted,
-            &mut order,
-        )?;
-        for ancestor in order {
-            self.publish_local_node(game_id, &ancestor, None).await?;
+            .and_then(|game| game.snapshots.get(&snapshot.date))
+        {
+            let local_path = self.local_path(game_id, snapshot);
+            let integrity = if local_path.is_file() {
+                let path = local_path.clone();
+                Some(
+                    tokio::task::spawn_blocking(move || ArchiveIntegrity::from_file(&path))
+                        .await
+                        .map_err(|error| SnapshotSyncError::HashTask(error.to_string()))??,
+                )
+            } else {
+                None
+            };
+            merge_local_snapshot(&mut existing.clone(), snapshot, integrity)?;
+            self.materializer.upload(game_id, &snapshot.date).await?;
+        } else {
+            let mut visiting = HashSet::new();
+            let mut emitted = manifest
+                .games
+                .get(game_id)
+                .map(|game| game.snapshots.keys().cloned().collect())
+                .unwrap_or_default();
+            let snapshots = local
+                .backups
+                .iter()
+                .map(|item| (item.date.clone(), item))
+                .collect();
+            let mut order = Vec::new();
+            visit_snapshot(
+                &snapshot.date,
+                &snapshots,
+                &mut visiting,
+                &mut emitted,
+                &mut order,
+            )?;
+            for ancestor in order {
+                self.publish_local_node(game_id, &ancestor, None).await?;
+            }
+            self.materializer.upload(game_id, &snapshot.date).await?;
         }
-        self.materializer.upload(game_id, &snapshot.date).await?;
+        self.publish_current_head(game_id, local).await?;
         Ok(())
     }
 
@@ -1048,6 +1069,53 @@ mod tests {
                 .await
                 .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn upload_rejects_same_identity_with_different_content() {
+        let operator = memory_operator();
+        let root = temp_dir::TempDir::new().unwrap();
+        let archive_root = root.path().join("deck");
+        let game_root = archive_root.join("game");
+        std::fs::create_dir_all(&game_root).unwrap();
+        let first = archive_path(&game_root, "same", ArchiveFormat::Zip);
+        std::fs::write(&first, b"first-device").unwrap();
+        let mut game = GameManifest::new("game");
+        let mut node = SnapshotNode::live(
+            "same",
+            None,
+            ArchiveIntegrity::from_file(&first).unwrap(),
+            CreatedBy::Manual,
+        );
+        let SnapshotState::Live(live) = &mut node.state else {
+            unreachable!()
+        };
+        live.cloud_archive_verified = true;
+        game.upsert_live(node).unwrap();
+        let mut manifest = CloudManifest::default();
+        manifest.games.insert("game".into(), game);
+        write_manifest(&operator, &manifest).await;
+
+        std::fs::write(&first, b"second-device-bytes").unwrap();
+        let mut local = GameSnapshots::new("Game");
+        local.backups.push(snapshot("same", None));
+        let coordinator = SnapshotSyncCoordinator::new(
+            operator,
+            archive_root,
+            "laptop".into(),
+            root.path().join("progress.json"),
+            2,
+        );
+
+        let error = coordinator
+            .upload_local_snapshot("game", &local.backups[0], &local)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            SnapshotSyncError::ManifestGraph(ManifestError::SnapshotContentConflict(id))
+                if id == "same"
+        ));
     }
 
     #[test]

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -105,6 +105,11 @@ impl OwnerStore {
         if let Some(existing) = existing {
             owners.local_state.cloud_namespace_generation =
                 existing.local_state.cloud_namespace_generation;
+            if let Some(existing_profile) = existing.device_profiles.get(&current_device_id)
+                && let Some(current_profile) = owners.device_profiles.get_mut(&current_device_id)
+            {
+                current_profile.local_archive_root = existing_profile.local_archive_root.clone();
+            }
         }
         let effective = owners.assemble_effective()?;
         self.write(&owners)?;
@@ -713,6 +718,29 @@ mod tests {
                 .quick_action_game_id
                 .as_deref(),
             Some("deck-only")
+        );
+    }
+
+    #[test]
+    fn replace_effective_keeps_this_device_archive_root() {
+        let (_root, store) = store();
+        let local = config(get_current_device_id(), "this-device-backups");
+        store.initialize_from_legacy(&local).unwrap();
+
+        let mut remote = config(get_current_device_id(), "other-device-backups");
+        add_device(&mut remote, "other", "Other");
+        store.replace_effective(&remote).unwrap();
+
+        let persisted = store.load().unwrap();
+        assert_eq!(
+            persisted.device_profiles[get_current_device_id()]
+                .local_archive_root
+                .as_deref(),
+            Some("this-device-backups")
+        );
+        assert_eq!(
+            store.load_effective().unwrap().backup_path,
+            "this-device-backups"
         );
     }
 

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -12,7 +12,7 @@ use crate::cloud_sync::v2::{
     CloudArchiveMaterializer, CloudLibraryBootstrap, CloudLibraryBootstrapError,
     CloudLibraryCutover, CloudLibraryCutoverError, CloudLibraryCutoverReview, CloudLibraryJoin,
     CloudLibraryJoinError, CloudLibraryJoinReview, CloudManifestRepository,
-    CloudNamespaceClassification, ConflictReviewError, DeletionRegistryError,
+    CloudNamespaceClassification, CloudNamespaceError, ConflictReviewError, DeletionRegistryError,
     DeviceProfileRemovalError, DeviceProfileRepository, DeviceProfileRepositoryError,
     JoinGameDecision, KeepLocalProgressError, LocalArchiveEvictionError, ManifestRepositoryError,
     MaterializationError, MaterializationOutcome, MaterializationPreview, SharedGameDeletionError,
@@ -261,9 +261,11 @@ impl ServiceContext {
         let generation = local_state.cloud_namespace_generation;
         let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let bootstrap = CloudLibraryBootstrap::new(session.get_op()?, 3);
-        let classification = bootstrap.inspect().await?;
         let resumable_cutover = cutover_progress_path(&local_state.cloud_settings)?.is_file();
-        map_library_status(generation, classification, resumable_cutover)
+        match bootstrap.inspect().await {
+            Ok(classification) => map_library_status(generation, classification, resumable_cutover),
+            Err(error) => map_inspect_error(generation, resumable_cutover, error),
+        }
     }
 
     /// Reset the local V2 namespace to legacy when the cloud is broken or
@@ -659,8 +661,6 @@ impl ServiceContext {
             settings.live_save_process_name = Some(options.process_name.trim().to_string());
             settings.live_save_snapshot_on_exit = options.snapshot_on_exit;
         }
-        // Extract before the mutable borrow on accepted_profile ends.
-        let existing_activation_revision = settings.snapshot_sync_activation_revision;
 
         let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
 
@@ -721,9 +721,7 @@ impl ServiceContext {
         };
 
         let downloaded = if enabled && initial_catch_up == InitialCatchUpPolicy::DownloadExisting {
-            let revision = activation_revision
-                .or(existing_activation_revision)
-                .expect("enabled game must have an activation revision");
+            let revision = materializer.catalog_revision().await?;
             let outcome = materializer
                 .materialize_game(game_id, revision, cancellation)
                 .await;
@@ -1047,6 +1045,24 @@ fn map_library_status(
     }
 }
 
+fn map_inspect_error(
+    generation: CloudNamespaceGeneration,
+    resumable_cutover: bool,
+    error: CloudLibraryBootstrapError,
+) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+    match error {
+        CloudLibraryBootstrapError::Namespace(CloudNamespaceError::PartialV2(_))
+            if generation == CloudNamespaceGeneration::LegacyV1 && resumable_cutover =>
+        {
+            Ok(CloudLibraryStatus::CutoverRequired {
+                game_count: 0,
+                resumable: true,
+            })
+        }
+        error => Err(error.into()),
+    }
+}
+
 fn import_downloaded_lineage(
     game_id: &str,
     lineage: &[crate::backup::Snapshot],
@@ -1151,6 +1167,46 @@ mod tests {
                 false
             ),
             Err(CloudLibraryServiceError::ActiveLibraryUnavailable)
+        ));
+    }
+
+    fn resumable_partial_v2_status(
+        generation: CloudNamespaceGeneration,
+        resumable_cutover: bool,
+    ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
+        map_inspect_error(
+            generation,
+            resumable_cutover,
+            CloudLibraryBootstrapError::Namespace(CloudNamespaceError::PartialV2(vec![
+                "v2/archives/".into(),
+            ])),
+        )
+    }
+
+    #[test]
+    fn interrupted_cutover_with_local_progress_is_resumable() {
+        assert_eq!(
+            resumable_partial_v2_status(CloudNamespaceGeneration::LegacyV1, true).unwrap(),
+            CloudLibraryStatus::CutoverRequired {
+                game_count: 0,
+                resumable: true,
+            }
+        );
+    }
+
+    #[test]
+    fn partial_v2_without_local_progress_stays_fail_closed() {
+        assert!(matches!(
+            resumable_partial_v2_status(CloudNamespaceGeneration::LegacyV1, false),
+            Err(CloudLibraryServiceError::Bootstrap(
+                CloudLibraryBootstrapError::Namespace(CloudNamespaceError::PartialV2(_))
+            ))
+        ));
+        assert!(matches!(
+            resumable_partial_v2_status(CloudNamespaceGeneration::V2, true),
+            Err(CloudLibraryServiceError::Bootstrap(
+                CloudLibraryBootstrapError::Namespace(CloudNamespaceError::PartialV2(_))
+            ))
         ));
     }
 

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -261,6 +261,7 @@
         "local_remove": "Remove from this device",
         "local_download": "Download to this device",
         "local_unavailable": "No downloadable cloud copy yet",
+        "download_before_apply": "Download this snapshot to this device before applying it",
         "cloud_upload": "Upload to cloud",
         "batch_upload": "Upload to cloud",
         "batch_download": "Download to this device",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -261,6 +261,7 @@
         "local_remove": "从本机移除",
         "local_download": "下载到本机",
         "local_unavailable": "云端还没有可下载的副本",
+        "download_before_apply": "请先下载到本机再应用",
         "cloud_upload": "上传到云",
         "batch_upload": "上传到云",
         "batch_download": "下载到本机",


### PR DESCRIPTION
Fixes the product bugs that kept the player-path e2e suite red.

- Nested confirms now stack above drawers/dialogs.
- Interrupted V1→V2 cutover with local progress is resumable.
- Catch-up downloads use the current catalog revision.
- Remote V1 config replace keeps this device's archive root.
- Snapshot identities no longer collide across devices in the same second.

Verified locally: extra-backup drawer delete, protect-retention, cutover, keep-local, sync-modes, two-v1, remove-device.