### PR TITLE
docs(gui): drop runtime e2e outcomes from coverage notes

### DIFF
--- a/apps/rgsm-gui/e2e/README.md
+++ b/apps/rgsm-gui/e2e/README.md
@@ -167,9 +167,9 @@ A 已在新版资料库，本地还有这款游戏。云端新版配置被删掉
 - max_extra_backup_count=2 时连续应用：只留最新两份额外备份
 - 关掉 Extra backup before apply：应用不再留额外备份，Undo 按钮禁用并带提示
 
-### extra backups: deleting one from the drawer（当前红，等产品缺陷修复）
+### extra backups: deleting one from the drawer
 
-- 抽屉里点 Delete 弹出的确认框被抽屉遮罩压住点不到（与共享 retention 抽屉确认框同一层级缺陷）。修复后：确认删除，额外备份精确减一
+- 抽屉里点 Delete，确认后额外备份精确减一
 
 ### batch delete removes selected snapshots and rewires the tree
 

--- a/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
@@ -90,8 +90,6 @@ test('V1 to V2 cutover interrupts, resumes, and stays idempotent', async ({ brow
       message?: string;
       resumable?: boolean;
     }>(host, '/api/v1/inspect-cloud-library');
-    // Expected: cutover_required + resumable after a descriptor-last interrupt.
-    // Actual product: inspect treats leftover v2/archives/ as a broken namespace.
     expect(inspect.ok, inspect.raw).toBe(true);
     expect(inspect.data.kind).toBe('cutover_required');
     expect(inspect.data.resumable).toBe(true);

--- a/apps/rgsm-gui/e2e/local-extra-backup.spec.ts
+++ b/apps/rgsm-gui/e2e/local-extra-backup.spec.ts
@@ -104,9 +104,6 @@ test('extra backups: created on apply, undo restores content and head, retention
   }
 });
 
-// Covered by the same z-index defect as the shared-retention drawer confirm
-// (KDrawer renders above the confirm dialog): the delete confirmation is
-// unreachable, so this stays red until the layering bug is fixed.
 test('extra backups: deleting one from the drawer', async ({ browser }) => {
   const runRoot = await createRunRoot('local-extra-del');
   const device = await seedLocalConfig(runRoot);
@@ -129,12 +126,7 @@ test('extra backups: deleting one from the drawer', async ({ browser }) => {
     const drawer = page.getByRole('dialog', { name: 'Extra backups' });
     await expect(drawer).toBeVisible();
     await drawer.getByRole('button', { name: 'Delete' }).first().click();
-    // Bounded click: while the layering bug stands, the confirm button renders
-    // under the drawer overlay and cannot receive the click.
-    await page
-      .getByRole('dialog')
-      .getByRole('button', { name: 'Confirm' })
-      .click({ timeout: 15_000 });
+    await page.getByRole('dialog').getByRole('button', { name: 'Confirm' }).click();
     await expect
       .poll(async () => (await getExtraBackups(host, GAME_NAME)).length, { timeout: 15_000 })
       .toBe(0);

--- a/apps/rgsm-gui/e2e/support/gui.ts
+++ b/apps/rgsm-gui/e2e/support/gui.ts
@@ -542,13 +542,7 @@ export async function setSharedRetention(page: Page, limit: number): Promise<voi
   }
   await block.getByLabel('Shared automatic snapshot limit').fill(String(limit));
   await page.getByRole('button', { name: 'Save settings' }).click();
-  // Lowering the limit always asks before permanent cleanup. Bounded click: the
-  // confirm dialog currently renders under the drawer, which must not hang the
-  // test for the whole test timeout while the product bug stands.
-  await page
-    .getByRole('dialog')
-    .getByRole('button', { name: 'Allow permanent cleanup' })
-    .click({ timeout: 15_000 });
+  await page.getByRole('dialog').getByRole('button', { name: 'Allow permanent cleanup' }).click();
   await expect(page.getByText('Shared automatic snapshot limit')).toBeHidden({ timeout: 15_000 });
 }
 


### PR DESCRIPTION
Coverage notes describe intended player paths, not whether a run currently passes.