### PR TITLE
feat(sync): bind devices to cloud library identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5012,6 +5012,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "utoipa",
+ "uuid",
  "whoami",
  "windows-sys 0.61.2",
  "winreg",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ temp-dir = "0.1.16"
 thiserror = "2.0.18"
 tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = { version = "0.7.18", features = ["full"] }
+uuid = { version = "1.24.0", features = ["v4"] }
 winreg = "0.55"
 zip = { version = "5.1.1", features = ["deflate", "bzip2", "zstd"] }
 sevenz-rust2 = { version = "=0.21.3", default-features = false, features = ["compress", "deflate", "util"] }

--- a/crates/rgsm-core/Cargo.toml
+++ b/crates/rgsm-core/Cargo.toml
@@ -50,6 +50,7 @@ specta.workspace = true
 rust-i18n.workspace = true
 keyvalues-serde = "0.2"
 utoipa = "5"
+uuid.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg.workspace = true

--- a/crates/rgsm-core/src/cloud_sync/backend.rs
+++ b/crates/rgsm-core/src/cloud_sync/backend.rs
@@ -113,7 +113,7 @@ fn endpoint_host_range(endpoint: &str) -> Option<(usize, usize)> {
     Some((start, start + host_len))
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type, utoipa::ToSchema)]
 #[serde(tag = "type")]
 pub enum Backend {
     Disabled,

--- a/crates/rgsm-core/src/cloud_sync/cloud_settings.rs
+++ b/crates/rgsm-core/src/cloud_sync/cloud_settings.rs
@@ -6,7 +6,7 @@ use crate::preclude::*;
 
 use super::Backend;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Type, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Type, utoipa::ToSchema)]
 pub struct CloudSettings {
     /// 同步间隔，单位分钟，为0则不自动同步
     #[serde(default = "default_value::default_zero")]

--- a/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/bootstrap.rs
@@ -61,6 +61,7 @@ impl<T: CloudLibraryTransport> CloudLibraryBootstrap<T> {
     /// namespace; it never advertises an incomplete library as supported.
     pub async fn create_empty(
         &self,
+        descriptor: &CloudNamespaceDescriptor,
         shared_library: &SharedLibrary,
         device_profile: &DeviceProfile,
     ) -> Result<(), CloudLibraryBootstrapError> {
@@ -74,11 +75,11 @@ impl<T: CloudLibraryTransport> CloudLibraryBootstrap<T> {
             }
         }
 
+        descriptor.validate()?;
         shared_library.validate()?;
         let manifest = CloudManifest::default();
         manifest.validate()?;
         let profile_path = device_profile_path(&device_profile.device.id);
-        let descriptor = CloudNamespaceDescriptor::default();
 
         self.write_verified(SHARED_LIBRARY_PATH, &pretty_bytes(shared_library)?)
             .await?;
@@ -91,15 +92,20 @@ impl<T: CloudLibraryTransport> CloudLibraryBootstrap<T> {
         .await?;
         self.write_verified(&profile_path, &pretty_bytes(device_profile)?)
             .await?;
-        self.write_verified(V2_NAMESPACE_DESCRIPTOR_PATH, &pretty_bytes(&descriptor)?)
+        self.write_verified(V2_NAMESPACE_DESCRIPTOR_PATH, &pretty_bytes(descriptor)?)
             .await?;
 
         match self.inspect().await? {
             CloudNamespaceClassification::SupportedV2 {
+                descriptor: stored_descriptor,
                 shared_library: stored,
                 manifest: stored_manifest,
-                ..
-            } if stored == *shared_library && stored_manifest == manifest => Ok(()),
+            } if stored_descriptor == *descriptor
+                && stored == *shared_library
+                && stored_manifest == manifest =>
+            {
+                Ok(())
+            }
             _ => Err(CloudLibraryBootstrapError::FinalVerificationMismatch),
         }
     }
@@ -224,8 +230,12 @@ mod tests {
         let transport = FakeTransport::default();
         let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
         let (shared, profile) = inputs();
+        let descriptor = CloudNamespaceDescriptor::default();
 
-        bootstrap.create_empty(&shared, &profile).await.unwrap();
+        bootstrap
+            .create_empty(&descriptor, &shared, &profile)
+            .await
+            .unwrap();
 
         let state = bootstrap.transport.state.lock().unwrap();
         assert_eq!(
@@ -247,9 +257,10 @@ mod tests {
             .insert("unrelated".into(), Vec::new());
         let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
         let (shared, profile) = inputs();
+        let descriptor = CloudNamespaceDescriptor::default();
 
         assert!(matches!(
-            bootstrap.create_empty(&shared, &profile).await,
+            bootstrap.create_empty(&descriptor, &shared, &profile).await,
             Err(CloudLibraryBootstrapError::Namespace(
                 CloudNamespaceError::UnrecognizedRoot(_)
             ))
@@ -263,9 +274,10 @@ mod tests {
         transport.state.lock().unwrap().corrupt_writes = true;
         let bootstrap = CloudLibraryBootstrap::with_transport(transport, 2);
         let (shared, profile) = inputs();
+        let descriptor = CloudNamespaceDescriptor::default();
 
         assert!(matches!(
-            bootstrap.create_empty(&shared, &profile).await,
+            bootstrap.create_empty(&descriptor, &shared, &profile).await,
             Err(CloudLibraryBootstrapError::WriteVerificationFailed { attempts: 2, .. })
         ));
         let state = bootstrap.transport.state.lock().unwrap();

--- a/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/cutover.rs
@@ -30,6 +30,7 @@ pub struct CloudLibraryCutoverReview {
 }
 #[derive(Debug)]
 pub struct CloudLibraryCutoverResult {
+    pub library_id: String,
     pub shared_library: SharedLibrary,
     pub device_profiles: HashMap<DeviceId, DeviceProfile>,
     pub snapshot_count: usize,
@@ -38,6 +39,7 @@ pub struct CloudLibraryCutoverResult {
 #[derive(Debug, Serialize, Deserialize)]
 struct CutoverPlan {
     schema_version: u32,
+    library_id: String,
     shared_library: SharedLibrary,
     device_profiles: HashMap<DeviceId, DeviceProfile>,
     games: Vec<FrozenGame>,
@@ -104,7 +106,7 @@ impl CloudLibraryCutover {
                 return Err(CloudLibraryCutoverError::UnexpectedPublishedNamespace);
             }
             let manifest = self.build_manifest(&plan)?;
-            self.verify_published(&plan.shared_library, &manifest)
+            self.verify_published(&plan.library_id, &plan.shared_library, &manifest)
                 .await?;
             return Ok(Self::result(plan));
         }
@@ -134,7 +136,7 @@ impl CloudLibraryCutover {
         }
         let manifest = self.build_manifest(&plan)?;
         self.publish(&plan, &manifest).await?;
-        self.verify_published(&plan.shared_library, &manifest)
+        self.verify_published(&plan.library_id, &plan.shared_library, &manifest)
             .await?;
         Ok(Self::result(plan))
     }
@@ -180,6 +182,7 @@ impl CloudLibraryCutover {
         }
         Ok(CutoverPlan {
             schema_version: CUTOVER_PROGRESS_SCHEMA_VERSION,
+            library_id: CloudNamespaceDescriptor::default().library_id,
             shared_library: owners.shared_library,
             device_profiles: owners.device_profiles,
             games,
@@ -211,6 +214,7 @@ impl CloudLibraryCutover {
             .filter(|result| matches!(result, CutoverArchiveResult::Unavailable))
             .count();
         CloudLibraryCutoverResult {
+            library_id: plan.library_id,
             shared_library: plan.shared_library,
             device_profiles: plan.device_profiles,
             snapshot_count: summary.snapshot_count,
@@ -374,7 +378,9 @@ impl CloudLibraryCutover {
         }
         self.write_verified(
             V2_NAMESPACE_DESCRIPTOR_PATH,
-            &serde_json::to_vec_pretty(&CloudNamespaceDescriptor::default())?,
+            &serde_json::to_vec_pretty(&CloudNamespaceDescriptor::with_library_id(
+                &plan.library_id,
+            ))?,
         )
         .await
     }
@@ -399,6 +405,7 @@ impl CloudLibraryCutover {
     }
     async fn verify_published(
         &self,
+        library_id: &str,
         library: &SharedLibrary,
         manifest: &CloudManifest,
     ) -> Result<(), CloudLibraryCutoverError> {
@@ -407,10 +414,15 @@ impl CloudLibraryCutover {
             .await?
         {
             CloudNamespaceClassification::SupportedV2 {
+                descriptor,
                 shared_library,
                 manifest: stored_manifest,
-                ..
-            } if shared_library == *library && stored_manifest == *manifest => Ok(()),
+            } if descriptor.library_id == library_id
+                && shared_library == *library
+                && stored_manifest == *manifest =>
+            {
+                Ok(())
+            }
             _ => Err(CloudLibraryCutoverError::FinalVerificationMismatch),
         }
     }

--- a/crates/rgsm-core/src/cloud_sync/v2/join.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join.rs
@@ -8,8 +8,8 @@ use tokio::sync::Mutex;
 
 use super::{
     CloudLibraryTransport, CloudNamespaceClassification, CloudNamespaceClassifier,
-    CloudNamespaceError, GameJoinClassification, OpenDalNamespaceTransport, SHARED_LIBRARY_PATH,
-    compare_join_libraries, device_profile_path,
+    CloudNamespaceDescriptor, CloudNamespaceError, GameJoinClassification,
+    OpenDalNamespaceTransport, SHARED_LIBRARY_PATH, compare_join_libraries, device_profile_path,
 };
 use crate::config::{DeviceProfile, OwnershipError, SharedGame, SharedLibrary};
 
@@ -30,6 +30,13 @@ pub struct CloudLibraryJoinItem {
     pub cloud_fingerprint: Option<String>,
     pub classification: GameJoinClassification,
     pub difference: GameDefinitionDifference,
+}
+
+#[derive(Debug)]
+pub struct CloudLibraryJoinResult {
+    pub library_id: String,
+    pub shared_library: SharedLibrary,
+    pub device_profile: DeviceProfile,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
@@ -82,7 +89,7 @@ impl<T: CloudLibraryTransport> CloudLibraryJoin<T> {
         &self,
         local: &SharedLibrary,
     ) -> Result<CloudLibraryJoinReview, CloudLibraryJoinError> {
-        let cloud = self.load_supported().await?;
+        let (_, cloud) = self.load_supported().await?;
         build_review(local, &cloud)
     }
 
@@ -92,12 +99,12 @@ impl<T: CloudLibraryTransport> CloudLibraryJoin<T> {
         local_profile: &DeviceProfile,
         decisions: &[JoinGameDecision],
         confirmed_replacements: bool,
-    ) -> Result<(SharedLibrary, DeviceProfile), CloudLibraryJoinError> {
+    ) -> Result<CloudLibraryJoinResult, CloudLibraryJoinError> {
         let _guard = JOIN_WRITER_LOCK.lock().await;
         validate_decisions(local, decisions, confirmed_replacements)?;
 
         for _ in 0..self.max_attempts {
-            let latest = self.load_supported().await?;
+            let (descriptor, latest) = self.load_supported().await?;
             let accepted = apply_decisions(local, latest, decisions)?;
             let expected = serde_json::to_vec_pretty(&accepted)?;
             if decisions
@@ -116,7 +123,11 @@ impl<T: CloudLibraryTransport> CloudLibraryJoin<T> {
             let profile_path = device_profile_path(&profile.device.id);
             let profile_bytes = serde_json::to_vec_pretty(&profile)?;
             self.write_verified(&profile_path, &profile_bytes).await?;
-            return Ok((accepted, profile));
+            return Ok(CloudLibraryJoinResult {
+                library_id: descriptor.library_id,
+                shared_library: accepted,
+                device_profile: profile,
+            });
         }
         Err(CloudLibraryJoinError::WriteVerificationFailed {
             path: SHARED_LIBRARY_PATH.to_string(),
@@ -124,12 +135,18 @@ impl<T: CloudLibraryTransport> CloudLibraryJoin<T> {
         })
     }
 
-    async fn load_supported(&self) -> Result<SharedLibrary, CloudLibraryJoinError> {
+    async fn load_supported(
+        &self,
+    ) -> Result<(CloudNamespaceDescriptor, SharedLibrary), CloudLibraryJoinError> {
         match CloudNamespaceClassifier::with_transport(self.transport.clone())
             .classify()
             .await?
         {
-            CloudNamespaceClassification::SupportedV2 { shared_library, .. } => Ok(shared_library),
+            CloudNamespaceClassification::SupportedV2 {
+                descriptor,
+                shared_library,
+                ..
+            } => Ok((descriptor, shared_library)),
             CloudNamespaceClassification::V1Only { .. } => {
                 Err(CloudLibraryJoinError::JoinUnavailable("legacy_v1"))
             }
@@ -325,6 +342,8 @@ mod tests {
         V2_CONFIG_SCHEMA_VERSION,
     };
 
+    const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+
     #[derive(Default)]
     struct FakeTransport {
         objects: StdMutex<BTreeMap<String, Vec<u8>>>,
@@ -394,7 +413,7 @@ mod tests {
         let mut objects = transport.objects.lock().unwrap();
         objects.insert(
             V2_NAMESPACE_DESCRIPTOR_PATH.into(),
-            serde_json::to_vec(&CloudNamespaceDescriptor::default()).unwrap(),
+            serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id(LIBRARY_ID)).unwrap(),
         );
         objects.insert(
             CLOUD_MANIFEST_PATH.into(),
@@ -495,10 +514,12 @@ mod tests {
             .collect::<Vec<_>>();
         let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
 
-        let (accepted, _) = join
+        let result = join
             .join(&local, &profile(&local), &decisions, true)
             .await
             .unwrap();
+        assert_eq!(result.library_id, LIBRARY_ID);
+        let accepted = result.shared_library;
 
         assert!(accepted.games.contains(&local_only));
         let accepted_replacement = accepted

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -50,8 +50,8 @@ pub use game_comparison::{
 pub use game_deletion::{SharedGameDeletion, SharedGameDeletionError, SharedGameDeletionOutcome};
 pub use integrity::{ArchiveIntegrity, ArchiveIntegrityError};
 pub use join::{
-    CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinItem, CloudLibraryJoinReview,
-    GameDefinitionDifference, JoinGameAction, JoinGameDecision,
+    CloudLibraryJoin, CloudLibraryJoinError, CloudLibraryJoinItem, CloudLibraryJoinResult,
+    CloudLibraryJoinReview, GameDefinitionDifference, JoinGameAction, JoinGameDecision,
 };
 pub use local_eviction::{
     CloudArchiveEviction, CloudArchiveEvictionError, LocalArchiveEviction,
@@ -68,6 +68,7 @@ pub use materialization::{
 pub use materialization_models::{
     CloudArchiveDeletionView, MaterializationOutcome, MaterializationPreview,
 };
+pub(crate) use namespace::CloudLibraryTarget;
 pub use namespace::{
     CLOUD_ARCHIVES_PREFIX, CLOUD_MANIFEST_PATH, CloudNamespaceClassification,
     CloudNamespaceClassifier, CloudNamespaceDescriptor, CloudNamespaceError,

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -5,6 +5,7 @@ use futures_util::TryStreamExt;
 use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use uuid::Uuid;
 
 use super::super::V1_CONFIG_PATH;
 #[cfg(test)]
@@ -46,13 +47,73 @@ pub fn cloud_archive_path(
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CloudNamespaceDescriptor {
     pub schema_version: u32,
+    pub library_id: String,
 }
 
 impl Default for CloudNamespaceDescriptor {
     fn default() -> Self {
         Self {
             schema_version: V2_NAMESPACE_SCHEMA_VERSION,
+            library_id: Uuid::new_v4().to_string(),
         }
+    }
+}
+
+impl CloudNamespaceDescriptor {
+    pub fn with_library_id(library_id: impl Into<String>) -> Self {
+        Self {
+            schema_version: V2_NAMESPACE_SCHEMA_VERSION,
+            library_id: library_id.into(),
+        }
+    }
+
+    pub(super) fn validate(&self) -> Result<(), CloudNamespaceError> {
+        if self.schema_version != V2_NAMESPACE_SCHEMA_VERSION {
+            return Err(CloudNamespaceError::UnsupportedSchema {
+                object: V2_NAMESPACE_DESCRIPTOR_PATH,
+                found: self.schema_version,
+            });
+        }
+        Uuid::parse_str(&self.library_id).map_err(|_| CloudNamespaceError::InvalidLibraryId)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct CloudLibraryTarget {
+    operator: Operator,
+    expected_library_id: String,
+}
+
+impl CloudLibraryTarget {
+    pub(crate) fn new(operator: Operator, expected_library_id: impl Into<String>) -> Self {
+        Self {
+            operator,
+            expected_library_id: expected_library_id.into(),
+        }
+    }
+
+    pub(crate) fn operator(&self) -> Operator {
+        self.operator.clone()
+    }
+
+    pub(crate) async fn verify(&self) -> Result<Operator, CloudNamespaceError> {
+        let bytes = match self.operator.read(V2_NAMESPACE_DESCRIPTOR_PATH).await {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                return Err(CloudNamespaceError::MissingRequiredObject(
+                    V2_NAMESPACE_DESCRIPTOR_PATH,
+                ));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let descriptor: CloudNamespaceDescriptor =
+            parse_json(V2_NAMESPACE_DESCRIPTOR_PATH, &bytes.to_vec())?;
+        descriptor.validate()?;
+        if descriptor.library_id != self.expected_library_id {
+            return Err(CloudNamespaceError::LibraryIdentityMismatch);
+        }
+        Ok(self.operator())
     }
 }
 
@@ -176,12 +237,7 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
     ) -> Result<CloudNamespaceClassification, CloudNamespaceError> {
         let descriptor: CloudNamespaceDescriptor =
             parse_json(V2_NAMESPACE_DESCRIPTOR_PATH, descriptor_bytes)?;
-        if descriptor.schema_version != V2_NAMESPACE_SCHEMA_VERSION {
-            return Err(CloudNamespaceError::UnsupportedSchema {
-                object: V2_NAMESPACE_DESCRIPTOR_PATH,
-                found: descriptor.schema_version,
-            });
-        }
+        descriptor.validate()?;
 
         let shared_bytes = self.required_object(SHARED_LIBRARY_PATH).await?;
         let shared_library: SharedLibrary = parse_json(SHARED_LIBRARY_PATH, &shared_bytes)?;
@@ -232,6 +288,12 @@ pub enum CloudNamespaceError {
     PartialV2(Vec<String>),
     #[error("Cloud root is non-empty but is not recognized: {0:?}")]
     UnrecognizedRoot(Vec<String>),
+    #[error("Cloud Library descriptor contains an invalid library ID")]
+    InvalidLibraryId,
+    #[error("The configured cloud location belongs to a different Cloud Library")]
+    LibraryIdentityMismatch,
+    #[error("The local V2 configuration is missing its Cloud Library ID")]
+    LocalLibraryIdMissing,
     #[error(transparent)]
     SharedLibrary(#[from] OwnershipError),
     #[error(transparent)]
@@ -362,6 +424,7 @@ mod tests {
             V2_NAMESPACE_DESCRIPTOR_PATH.into(),
             serde_json::to_vec(&CloudNamespaceDescriptor {
                 schema_version: V2_NAMESPACE_SCHEMA_VERSION + 1,
+                ..CloudNamespaceDescriptor::default()
             })
             .unwrap(),
         );
@@ -370,6 +433,18 @@ mod tests {
                 .classify()
                 .await,
             Err(CloudNamespaceError::UnsupportedSchema { .. })
+        ));
+
+        let mut invalid_identity = complete_v2();
+        invalid_identity.objects.insert(
+            V2_NAMESPACE_DESCRIPTOR_PATH.into(),
+            serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id("invalid")).unwrap(),
+        );
+        assert!(matches!(
+            CloudNamespaceClassifier::with_transport(invalid_identity)
+                .classify()
+                .await,
+            Err(CloudNamespaceError::InvalidLibraryId)
         ));
 
         let mut corrupt = complete_v2();
@@ -537,5 +612,29 @@ mod tests {
         let transport = OpenDalNamespaceTransport::new(operator);
 
         assert!(transport.list_sample("/", 10).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn target_accepts_only_the_bound_library_id() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let descriptor = CloudNamespaceDescriptor::default();
+        operator
+            .write(
+                V2_NAMESPACE_DESCRIPTOR_PATH,
+                serde_json::to_vec(&descriptor).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        CloudLibraryTarget::new(operator.clone(), &descriptor.library_id)
+            .verify()
+            .await
+            .unwrap();
+        assert!(matches!(
+            CloudLibraryTarget::new(operator, CloudNamespaceDescriptor::default().library_id,)
+                .verify()
+                .await,
+            Err(CloudNamespaceError::LibraryIdentityMismatch)
+        ));
     }
 }

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -105,6 +105,7 @@ impl OwnerStore {
         if let Some(existing) = existing {
             owners.local_state.cloud_namespace_generation =
                 existing.local_state.cloud_namespace_generation;
+            owners.local_state.cloud_library_id = existing.local_state.cloud_library_id;
             if let Some(existing_profile) = existing.device_profiles.get(&current_device_id)
                 && let Some(current_profile) = owners.device_profiles.get_mut(&current_device_id)
             {
@@ -157,6 +158,7 @@ impl OwnerStore {
         &self,
         expected_library: &SharedLibrary,
         expected_profile: &DeviceProfile,
+        library_id: &str,
     ) -> Result<(), OwnerStoreError> {
         let mut owners = self.load()?;
         let current_profile = owners
@@ -169,6 +171,7 @@ impl OwnerStore {
             return Err(OwnerStoreError::ActivationInputsChanged);
         }
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
     }
 
@@ -178,6 +181,7 @@ impl OwnerStore {
         expected_local_profile: &DeviceProfile,
         accepted_library: &SharedLibrary,
         accepted_profile: &DeviceProfile,
+        library_id: &str,
     ) -> Result<(), OwnerStoreError> {
         let mut owners = self.load()?;
         let current_device_id = owners.local_state.current_device_id.clone();
@@ -208,6 +212,7 @@ impl OwnerStore {
             .device_profiles
             .insert(current_device_id, accepted_profile.clone());
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
     }
 
@@ -217,6 +222,7 @@ impl OwnerStore {
         expected_local_profile: &DeviceProfile,
         accepted_library: &SharedLibrary,
         accepted_profiles: &HashMap<DeviceId, DeviceProfile>,
+        library_id: &str,
     ) -> Result<(), OwnerStoreError> {
         let mut owners = self.load()?;
         let current_device_id = owners.local_state.current_device_id.clone();
@@ -239,6 +245,7 @@ impl OwnerStore {
             .device_profiles
             .insert(current_device_id, accepted_current_profile);
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
     }
 
@@ -287,6 +294,7 @@ impl OwnerStore {
         expected_profile: &DeviceProfile,
         accepted_library: &SharedLibrary,
         accepted_profile: &DeviceProfile,
+        library_id: &str,
     ) -> Result<(), OwnerStoreError> {
         let mut owners = self.load()?;
         let current_device_id = owners.local_state.current_device_id.clone();
@@ -306,6 +314,7 @@ impl OwnerStore {
         owners
             .device_profiles
             .insert(current_device_id, accepted_profile.clone());
+        owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
     }
 
@@ -595,6 +604,8 @@ mod tests {
     use crate::backup::Game;
     use crate::device::Device;
 
+    const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+
     fn store() -> (temp_dir::TempDir, OwnerStore) {
         let root = temp_dir::TempDir::new().unwrap();
         let store = OwnerStore::new(root.path().to_path_buf());
@@ -784,6 +795,7 @@ mod tests {
         store.initialize_from_legacy(&input).unwrap();
         let mut owners = store.load().unwrap();
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        owners.local_state.cloud_library_id = Some(LIBRARY_ID.to_string());
         owners
             .device_profiles
             .get_mut("steam-deck")
@@ -809,15 +821,19 @@ mod tests {
         store.initialize_from_legacy(&input).unwrap();
         let owners = store.load().unwrap();
         let profile = &owners.device_profiles[get_current_device_id()];
-        store.activate_v2(&owners.shared_library, profile).unwrap();
+        store
+            .activate_v2(&owners.shared_library, profile, LIBRARY_ID)
+            .unwrap();
 
         store.merge_effective(&input).unwrap();
         store.replace_effective(&input).unwrap();
 
+        let active = store.load().unwrap().local_state;
         assert_eq!(
-            store.load().unwrap().local_state.cloud_namespace_generation,
+            active.cloud_namespace_generation,
             CloudNamespaceGeneration::V2
         );
+        assert_eq!(active.cloud_library_id.as_deref(), Some(LIBRARY_ID));
     }
 
     #[test]
@@ -836,6 +852,7 @@ mod tests {
                 &stale_profile,
                 &before.shared_library,
                 &before.device_profiles,
+                LIBRARY_ID,
             ),
             Err(OwnerStoreError::CutoverInputsChanged)
         ));
@@ -852,6 +869,7 @@ mod tests {
                 &expected_profile,
                 &before.shared_library,
                 &accepted_profiles,
+                LIBRARY_ID,
             )
             .unwrap();
         let active = store.load().unwrap();
@@ -862,6 +880,10 @@ mod tests {
         assert_eq!(
             active.local_state.cloud_namespace_generation,
             CloudNamespaceGeneration::V2
+        );
+        assert_eq!(
+            active.local_state.cloud_library_id.as_deref(),
+            Some(LIBRARY_ID)
         );
         assert_eq!(
             active.device_profiles[get_current_device_id()].device.name,
@@ -912,6 +934,7 @@ mod tests {
                 &reordered,
                 &before.shared_library,
                 &before.device_profiles,
+                LIBRARY_ID,
             )
             .unwrap();
     }
@@ -930,7 +953,7 @@ mod tests {
             Err(OwnerStoreError::ProfileInputsChanged)
         ));
         store
-            .activate_v2(&owners.shared_library, &expected)
+            .activate_v2(&owners.shared_library, &expected, LIBRARY_ID)
             .unwrap();
         store.replace_current_profile(&expected, &accepted).unwrap();
         assert_eq!(
@@ -967,7 +990,11 @@ mod tests {
             Err(OwnerStoreError::SharedLibraryInputsChanged)
         ));
         store
-            .activate_v2(&expected, &owners.device_profiles[get_current_device_id()])
+            .activate_v2(
+                &expected,
+                &owners.device_profiles[get_current_device_id()],
+                LIBRARY_ID,
+            )
             .unwrap();
         store.replace_shared_library(&expected, &accepted).unwrap();
         assert_eq!(

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -39,6 +39,8 @@ pub enum OwnershipError {
     DuplicateSharedSaveUnit { game_id: String, save_unit_id: u32 },
     #[error("Shared Game {0} has an invalid Snapshot retention limit")]
     InvalidSnapshotRetention(String),
+    #[error("An active V2 configuration must contain a Cloud Library ID")]
+    MissingCloudLibraryId,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type, utoipa::ToSchema)]
@@ -265,6 +267,8 @@ pub struct LocalState {
     pub cloud_settings: CloudSettings,
     #[serde(default)]
     pub cloud_namespace_generation: CloudNamespaceGeneration,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cloud_library_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type, utoipa::ToSchema)]
@@ -359,6 +363,7 @@ impl ConfigurationOwners {
                 interface: LocalInterfaceSettings::from(&config.settings),
                 cloud_settings: config.settings.cloud_settings.clone(),
                 cloud_namespace_generation: CloudNamespaceGeneration::LegacyV1,
+                cloud_library_id: None,
             },
         }
     }
@@ -367,6 +372,15 @@ impl ConfigurationOwners {
         validate_schema("Configuration Owners", self.schema_version)?;
         self.shared_library.validate()?;
         validate_schema("Local State", self.local_state.schema_version)?;
+        if self.local_state.cloud_namespace_generation == CloudNamespaceGeneration::V2
+            && self
+                .local_state
+                .cloud_library_id
+                .as_deref()
+                .is_none_or(str::is_empty)
+        {
+            return Err(OwnershipError::MissingCloudLibraryId);
+        }
 
         for (device_id, profile) in &self.device_profiles {
             validate_schema(
@@ -445,6 +459,7 @@ impl ConfigurationOwners {
         self.shared_library = incoming.shared_library;
         incoming.local_state.cloud_namespace_generation =
             self.local_state.cloud_namespace_generation;
+        incoming.local_state.cloud_library_id = self.local_state.cloud_library_id.clone();
         self.local_state = incoming.local_state;
         self.device_profiles.retain(|device_id, _| {
             device_id == &current_device_id || incoming_device_ids.contains(device_id)

--- a/crates/rgsm-core/src/config/utils.rs
+++ b/crates/rgsm-core/src/config/utils.rs
@@ -187,11 +187,12 @@ pub(crate) fn cloud_bootstrap_inputs()
 pub(crate) fn activate_cloud_namespace_v2(
     expected_library: &SharedLibrary,
     expected_profile: &DeviceProfile,
+    library_id: &str,
 ) -> Result<(), ConfigError> {
     let _guard = CONFIG_STORE_LOCK
         .lock()
         .map_err(|_| ConfigError::StoreLockPoisoned)?;
-    OwnerStore::runtime().activate_v2(expected_library, expected_profile)?;
+    OwnerStore::runtime().activate_v2(expected_library, expected_profile, library_id)?;
     Ok(())
 }
 
@@ -200,6 +201,7 @@ pub(crate) fn activate_joined_cloud_library(
     expected_local_profile: &DeviceProfile,
     accepted_library: &SharedLibrary,
     accepted_profile: &DeviceProfile,
+    library_id: &str,
 ) -> Result<(), ConfigError> {
     let _guard = CONFIG_STORE_LOCK
         .lock()
@@ -209,6 +211,7 @@ pub(crate) fn activate_joined_cloud_library(
         expected_local_profile,
         accepted_library,
         accepted_profile,
+        library_id,
     )?;
     Ok(())
 }
@@ -218,6 +221,7 @@ pub(crate) fn activate_cutover_cloud_library(
     expected_local_profile: &DeviceProfile,
     accepted_library: &SharedLibrary,
     accepted_profiles: &std::collections::HashMap<crate::device::DeviceId, DeviceProfile>,
+    library_id: &str,
 ) -> Result<(), ConfigError> {
     let _guard = CONFIG_STORE_LOCK
         .lock()
@@ -227,6 +231,7 @@ pub(crate) fn activate_cutover_cloud_library(
         expected_local_profile,
         accepted_library,
         accepted_profiles,
+        library_id,
     )?;
     Ok(())
 }
@@ -258,6 +263,7 @@ pub(crate) fn accept_remote_shared_library(
     expected_profile: &DeviceProfile,
     accepted_library: &SharedLibrary,
     accepted_profile: &DeviceProfile,
+    library_id: &str,
 ) -> Result<(), ConfigError> {
     let _guard = CONFIG_STORE_LOCK
         .lock()
@@ -267,6 +273,7 @@ pub(crate) fn accept_remote_shared_library(
         expected_profile,
         accepted_library,
         accepted_profile,
+        library_id,
     )?;
     Ok(())
 }

--- a/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
+++ b/crates/rgsm-core/src/hooks/v2_snapshot_sync_hook.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use super::{HookSource, LifecycleHook, SnapshotCreatedCtx};
-use crate::cloud_sync::v2::SnapshotSyncCoordinator;
+use crate::cloud_sync::v2::{CloudLibraryTarget, SnapshotSyncCoordinator};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SnapshotSyncTarget {
@@ -24,18 +24,21 @@ pub struct SnapshotSyncTarget {
 }
 
 pub struct V2SnapshotSyncHook {
+    target: CloudLibraryTarget,
     coordinator: SnapshotSyncCoordinator,
     targets: BTreeMap<String, SnapshotSyncTarget>,
     operation_lock: Arc<Mutex<()>>,
 }
 
 impl V2SnapshotSyncHook {
-    pub fn new(
+    pub(crate) fn new(
+        target: CloudLibraryTarget,
         coordinator: SnapshotSyncCoordinator,
         targets: BTreeMap<String, SnapshotSyncTarget>,
         operation_lock: Arc<Mutex<()>>,
     ) -> Self {
         Self {
+            target,
             coordinator,
             targets,
             operation_lock,
@@ -62,6 +65,7 @@ impl LifecycleHook for V2SnapshotSyncHook {
             return Ok(());
         };
         let _guard = self.operation_lock.lock().await;
+        self.target.verify().await?;
 
         // Multi-device Sync: publish records first, check divergence, then
         // transfer only when the fleet is not diverged. This prevents a stale

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -60,6 +60,8 @@ pub enum BackendError {
     #[error("Cloud operator error: {0:#?}")]
     OperatorCheck(String),
     #[error(transparent)]
+    CloudNamespace(#[from] crate::cloud_sync::v2::CloudNamespaceError),
+    #[error(transparent)]
     Unexpected(#[from] anyhow::Error),
 }
 impl From<opendal::Error> for BackendError {

--- a/crates/rgsm-core/src/services/cloud_archive.rs
+++ b/crates/rgsm-core/src/services/cloud_archive.rs
@@ -1,9 +1,8 @@
 use crate::backup::GameSnapshots;
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{CloudArchiveLibraryView, DeletionRegistryRepository};
 use crate::config::{cloud_bootstrap_inputs, get_config};
 
-use super::{CloudLibraryServiceError, ServiceContext};
+use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::bound_v2_operator};
 
 impl ServiceContext {
     pub async fn cloud_archive_library(
@@ -12,12 +11,9 @@ impl ServiceContext {
         super::game_deletion::converge_local_deleted_games().await?;
         super::retention::refresh_v2_snapshot_retention().await?;
         let (library, profile, local_state) = cloud_bootstrap_inputs()?;
-        let registry = DeletionRegistryRepository::new(
-            CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?,
-            3,
-        )
-        .load()
-        .await?;
+        let registry = DeletionRegistryRepository::new(bound_v2_operator(&local_state).await?, 3)
+            .load()
+            .await?;
         let game_names = library
             .games
             .iter()

--- a/crates/rgsm-core/src/services/cloud_library_target.rs
+++ b/crates/rgsm-core/src/services/cloud_library_target.rs
@@ -1,0 +1,80 @@
+use opendal::Operator;
+
+use crate::cloud_sync::CloudSyncSessionConfig;
+use crate::cloud_sync::v2::{CloudLibraryTarget, CloudNamespaceError};
+use crate::config::{CloudNamespaceGeneration, LocalState};
+use crate::preclude::BackendError;
+
+pub(crate) fn cloud_library_target(
+    local_state: &LocalState,
+) -> Result<CloudLibraryTarget, BackendError> {
+    if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
+        return Err(CloudNamespaceError::LocalLibraryIdMissing.into());
+    }
+    let library_id = local_state
+        .cloud_library_id
+        .as_deref()
+        .ok_or(CloudNamespaceError::LocalLibraryIdMissing)?;
+    let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+    Ok(CloudLibraryTarget::new(operator, library_id))
+}
+
+pub(crate) async fn bound_v2_operator(local_state: &LocalState) -> Result<Operator, BackendError> {
+    Ok(cloud_library_target(local_state)?.verify().await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_sync::v2::{CloudNamespaceDescriptor, V2_NAMESPACE_DESCRIPTOR_PATH};
+    use crate::cloud_sync::{Backend, CloudSettings};
+    use crate::config::{Config, ConfigurationOwners};
+
+    const LOCAL_LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const REMOTE_LIBRARY_ID: &str = "22222222-2222-4222-8222-222222222222";
+
+    #[tokio::test]
+    async fn bound_operator_rejects_a_different_cloud_library() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let device_id = "device".to_string();
+        let mut state =
+            ConfigurationOwners::from_legacy(&Config::default(), &device_id).local_state;
+        state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
+        state.cloud_library_id = Some(LOCAL_LIBRARY_ID.to_string());
+        state.cloud_settings = CloudSettings {
+            backend: Backend::Fs,
+            root_path: root.path().to_string_lossy().into_owned(),
+            ..CloudSettings::default()
+        };
+        let operator = CloudSyncSessionConfig::from(&state.cloud_settings)
+            .get_op()
+            .unwrap();
+        operator
+            .write(
+                V2_NAMESPACE_DESCRIPTOR_PATH,
+                serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id(
+                    REMOTE_LIBRARY_ID,
+                ))
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            bound_v2_operator(&state).await,
+            Err(BackendError::CloudNamespace(
+                CloudNamespaceError::LibraryIdentityMismatch
+            ))
+        ));
+
+        operator
+            .write(
+                V2_NAMESPACE_DESCRIPTOR_PATH,
+                serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id(LOCAL_LIBRARY_ID))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(bound_v2_operator(&state).await.is_ok());
+    }
+}

--- a/crates/rgsm-core/src/services/conflict_resolution.rs
+++ b/crates/rgsm-core/src/services/conflict_resolution.rs
@@ -3,7 +3,6 @@ use specta::Type;
 
 use crate::app_dirs::resolve_app_path;
 use crate::backup::{CapturePlanError, Game, GameSnapshots, Snapshot};
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
     KeepLocalProgressOutcome, V2ConflictResolver, V2RemoteProgressResolver,
 };
@@ -12,7 +11,7 @@ use crate::config::{
 };
 use crate::hooks::HookSource;
 
-use super::{CloudLibraryServiceError, ServiceContext};
+use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::bound_v2_operator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Type, utoipa::ToSchema)]
 pub struct AcceptRemoteProgressOutcome {
@@ -43,9 +42,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let outcome = V2ConflictResolver::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -81,9 +79,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let resolver = V2RemoteProgressResolver::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),

--- a/crates/rgsm-core/src/services/device_game_lifecycle.rs
+++ b/crates/rgsm-core/src/services/device_game_lifecycle.rs
@@ -2,13 +2,12 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::app_dirs::resolve_app_path;
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{CloudArchiveEviction, DeviceProfileRepository, LocalArchiveEviction};
 use crate::config::{
     CloudNamespaceGeneration, cloud_bootstrap_inputs, get_config, replace_current_device_profile,
 };
 
-use super::{CloudLibraryServiceError, ServiceContext};
+use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::bound_v2_operator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct DeviceGameStatus {
@@ -136,9 +135,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         Ok(LocalArchiveEviction::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             3,
@@ -158,10 +156,11 @@ impl ServiceContext {
         }
         self.converged_materializer().await?;
         let (_, _, local_state) = v2_inputs()?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-        Ok(CloudArchiveEviction::new(session.get_op()?, 3)
-            .evict(game_id, snapshot_id)
-            .await?)
+        Ok(
+            CloudArchiveEviction::new(bound_v2_operator(&local_state).await?, 3)
+                .evict(game_id, snapshot_id)
+                .await?,
+        )
     }
 }
 
@@ -185,8 +184,7 @@ async fn publish_profile(
     expected: &crate::config::DeviceProfile,
     accepted: &crate::config::DeviceProfile,
 ) -> Result<(), CloudLibraryServiceError> {
-    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-    DeviceProfileRepository::new(session.get_op()?, 3)
+    DeviceProfileRepository::new(bound_v2_operator(local_state).await?, 3)
         .publish(&local_state.current_device_id, accepted)
         .await?;
     replace_current_device_profile(expected, accepted)?;

--- a/crates/rgsm-core/src/services/game.rs
+++ b/crates/rgsm-core/src/services/game.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result, anyhow, bail};
 
 use crate::backup::{self, AutoBackupConfig, Game, GameDeviceBinding, GameDraft};
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
     CLOUD_MANIFEST_PATH, CloudManifestRepository, DeviceProfileRepository, SharedLibraryRepository,
 };
@@ -12,7 +11,7 @@ use crate::config::{
 };
 use crate::hooks::{GameAddedCtx, GameDeletedCtx, GameUpdatedCtx, HookSource};
 
-use super::ServiceContext;
+use super::{ServiceContext, cloud_library_target::bound_v2_operator};
 
 impl ServiceContext {
     pub async fn add_game(&self, game: &GameDraft, source: HookSource) -> Result<()> {
@@ -337,18 +336,19 @@ async fn publish_v2_game_change(expected: ExpectedV2GameChange) -> Result<()> {
     let (accepted_library, accepted_profile, accepted_state) = cloud_bootstrap_inputs()?;
     if accepted_state.cloud_namespace_generation != CloudNamespaceGeneration::V2
         || accepted_state.current_device_id != expected.local_state.current_device_id
+        || accepted_state.cloud_settings != expected.local_state.cloud_settings
+        || accepted_state.cloud_library_id != expected.local_state.cloud_library_id
     {
         bail!("Cloud Library ownership changed while the Game was being saved");
     }
 
-    let session = CloudSyncSessionConfig::from(&expected.local_state.cloud_settings);
-    let operator = session.get_op()?;
+    let operator = bound_v2_operator(&expected.local_state).await?;
     let shared = SharedLibraryRepository::new(operator.clone(), 3);
     let committed_library = shared
         .compare_replace(&expected.library, &accepted_library)
         .await
         .context("failed to publish the updated V2 Shared Library")?;
-    let profiles = DeviceProfileRepository::new(operator, 3);
+    let profiles = DeviceProfileRepository::new(operator.clone(), 3);
     if let Err(error) = profiles
         .publish(&accepted_state.current_device_id, &accepted_profile)
         .await
@@ -382,8 +382,7 @@ async fn publish_v2_game_change(expected: ExpectedV2GameChange) -> Result<()> {
         .map(|game| game.storage_key.clone())
         .collect::<Vec<_>>();
     if !added_game_ids.is_empty() {
-        let session = CloudSyncSessionConfig::from(&expected.local_state.cloud_settings);
-        let manifest = CloudManifestRepository::new(session.get_op()?, CLOUD_MANIFEST_PATH, 3);
+        let manifest = CloudManifestRepository::new(operator, CLOUD_MANIFEST_PATH, 3);
         if let Err(error) = manifest
             .mutate(move |manifest| {
                 for game_id in &added_game_ids {

--- a/crates/rgsm-core/src/services/game_deletion.rs
+++ b/crates/rgsm-core/src/services/game_deletion.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::app_dirs::resolve_app_path;
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
     CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryRepository,
     DeviceProfileRepository, SharedGameDeletion, SharedGameDeletionOutcome,
@@ -11,7 +10,7 @@ use crate::cloud_sync::v2::{
 };
 use crate::config::{CloudNamespaceGeneration, cloud_bootstrap_inputs, remove_shared_game};
 
-use super::{CloudLibraryServiceError, ServiceContext};
+use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::bound_v2_operator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct DeletedCloudGameView {
@@ -29,7 +28,7 @@ impl ServiceContext {
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
         }
-        let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+        let operator = bound_v2_operator(&local_state).await?;
         let registry = DeletionRegistryRepository::new(operator.clone(), 3)
             .load()
             .await?;
@@ -83,7 +82,7 @@ impl ServiceContext {
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
         }
-        let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+        let operator = bound_v2_operator(&local_state).await?;
         let registry = DeletionRegistryRepository::new(operator.clone(), 3)
             .load()
             .await?;
@@ -119,7 +118,7 @@ pub(crate) async fn converge_local_deleted_games() -> Result<(), CloudLibrarySer
     if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
         return Ok(());
     }
-    let operator = CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?;
+    let operator = bound_v2_operator(&local_state).await?;
     let registry = DeletionRegistryRepository::new(operator, 3).load().await?;
     for (game_id, deletion) in registry.deleted_games {
         if let Some(root) = profile.local_archive_root.as_deref().map(resolve_app_path) {
@@ -303,6 +302,7 @@ mod tests {
             const GAME_ID: &str = "example-game";
             const GAME_NAME: &str = "Example Game";
             const SNAPSHOT_ID: &str = "snapshot-a";
+            const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
             const ARCHIVE_BYTES: &[u8] = b"service deletion archive bytes";
 
             let _ = crate::app_dirs::get_app_data_dir();
@@ -336,7 +336,7 @@ mod tests {
             set_config_local(&config).expect("effective V2 configuration should persist");
             let (library, profile, _) =
                 cloud_bootstrap_inputs().expect("persisted configuration should load");
-            activate_cloud_namespace_v2(&library, &profile)
+            activate_cloud_namespace_v2(&library, &profile, LIBRARY_ID)
                 .expect("configuration should activate the V2 namespace");
             assert_eq!(
                 crate::config::cloud_namespace_generation()
@@ -352,7 +352,11 @@ mod tests {
                 games: Vec::new(),
             };
             CloudLibraryBootstrap::new(operator.clone(), 2)
-                .create_empty(&empty_library, &profile)
+                .create_empty(
+                    &crate::cloud_sync::v2::CloudNamespaceDescriptor::with_library_id(LIBRARY_ID),
+                    &empty_library,
+                    &profile,
+                )
                 .await
                 .expect("empty Cloud Namespace should bootstrap");
             SharedLibraryRepository::new(operator.clone(), 2)

--- a/crates/rgsm-core/src/services/mod.rs
+++ b/crates/rgsm-core/src/services/mod.rs
@@ -1,4 +1,5 @@
 mod cloud_archive;
+mod cloud_library_target;
 mod config;
 mod conflict_resolution;
 mod device_game_lifecycle;

--- a/crates/rgsm-core/src/services/profile_management.rs
+++ b/crates/rgsm-core/src/services/profile_management.rs
@@ -3,14 +3,13 @@ use std::collections::{BTreeMap, BTreeSet};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
     CLOUD_MANIFEST_PATH, CloudManifestRepository, DeletionRegistryRepository, DeviceProfileRemoval,
     DeviceProfileRemovalOutcome, DeviceProfileRepository,
 };
 use crate::config::{CloudNamespaceGeneration, cloud_bootstrap_inputs, remove_device_profile};
 
-use super::{CloudLibraryServiceError, ServiceContext};
+use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::bound_v2_operator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct CloudDeviceProfileView {
@@ -30,8 +29,7 @@ impl ServiceContext {
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
         }
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-        let operator = session.get_op()?;
+        let operator = bound_v2_operator(&local_state).await?;
         let profiles = DeviceProfileRepository::new(operator.clone(), 3)
             .list()
             .await?
@@ -82,11 +80,13 @@ impl ServiceContext {
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
         }
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-        let outcome =
-            DeviceProfileRemoval::new(session.get_op()?, local_state.current_device_id, 3)
-                .remove(device_id, confirmed)
-                .await?;
+        let outcome = DeviceProfileRemoval::new(
+            bound_v2_operator(&local_state).await?,
+            local_state.current_device_id,
+            3,
+        )
+        .remove(device_id, confirmed)
+        .await?;
         remove_device_profile(device_id)?;
         Ok(outcome)
     }

--- a/crates/rgsm-core/src/services/retention.rs
+++ b/crates/rgsm-core/src/services/retention.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::app_dirs::resolve_app_path;
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
     CLOUD_MANIFEST_PATH, CloudManifestRepository, DeviceProfileRepository, ManifestError,
     SharedLibraryRepository, SnapshotState, SnapshotSyncCoordinator,
@@ -12,8 +11,8 @@ use crate::config::{
     cloud_bootstrap_inputs, get_config, replace_shared_library,
 };
 
-use super::ServiceContext;
 use super::sync::CloudLibraryServiceError;
+use super::{ServiceContext, cloud_library_target::bound_v2_operator};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct SnapshotRetentionOutcome {
@@ -29,8 +28,7 @@ pub(crate) async fn refresh_v2_snapshot_retention() -> Result<(), CloudLibrarySe
     if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
         return Ok(());
     }
-    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-    let operator = session.get_op()?;
+    let operator = bound_v2_operator(&local_state).await?;
     if !DeviceProfileRepository::new(operator.clone(), 3)
         .list()
         .await?
@@ -52,6 +50,10 @@ pub(crate) async fn refresh_v2_snapshot_retention() -> Result<(), CloudLibrarySe
             &expected_profile,
             &remote,
             &accepted_profile,
+            local_state
+                .cloud_library_id
+                .as_deref()
+                .ok_or(CloudLibraryServiceError::ActiveLibraryUnavailable)?,
         )?;
     }
     Ok(())
@@ -97,10 +99,10 @@ impl ServiceContext {
                         automatic_snapshots_per_branch,
                     },
                 );
-            let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-            let accepted_library = SharedLibraryRepository::new(session.get_op()?, 3)
-                .compare_replace(&expected_library, &accepted_library)
-                .await?;
+            let accepted_library =
+                SharedLibraryRepository::new(bound_v2_operator(&local_state).await?, 3)
+                    .compare_replace(&expected_library, &accepted_library)
+                    .await?;
             replace_shared_library(&expected_library, &accepted_library)?;
         }
 
@@ -134,24 +136,27 @@ impl ServiceContext {
             .map(|policy| policy.automatic_snapshots_per_branch);
         let game_id_owned = game_id.to_string();
         let snapshot_id_owned = snapshot_id.to_string();
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-        CloudManifestRepository::new(session.get_op()?, CLOUD_MANIFEST_PATH, 3)
-            .mutate(move |manifest| {
-                let game = manifest
-                    .games
-                    .get_mut(&game_id_owned)
-                    .ok_or_else(|| ManifestError::MissingGame(game_id_owned.clone()))?;
-                let node = game
-                    .snapshots
-                    .get_mut(&snapshot_id_owned)
-                    .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id_owned.clone()))?;
-                let SnapshotState::Live(live) = &mut node.state else {
-                    return Err(ManifestError::ExpectedLive(snapshot_id_owned.clone()));
-                };
-                live.retention_protected = protected;
-                Ok(())
-            })
-            .await?;
+        CloudManifestRepository::new(
+            bound_v2_operator(&local_state).await?,
+            CLOUD_MANIFEST_PATH,
+            3,
+        )
+        .mutate(move |manifest| {
+            let game = manifest
+                .games
+                .get_mut(&game_id_owned)
+                .ok_or_else(|| ManifestError::MissingGame(game_id_owned.clone()))?;
+            let node = game
+                .snapshots
+                .get_mut(&snapshot_id_owned)
+                .ok_or_else(|| ManifestError::MissingSnapshot(snapshot_id_owned.clone()))?;
+            let SnapshotState::Live(live) = &mut node.state else {
+                return Err(ManifestError::ExpectedLive(snapshot_id_owned.clone()));
+            };
+            live.retention_protected = protected;
+            Ok(())
+        })
+        .await?;
         let deleted = match (protected, limit) {
             (false, Some(limit)) => self.enforce_retention_now(game_id, limit).await?,
             _ => 0,
@@ -159,7 +164,9 @@ impl ServiceContext {
         Ok(SnapshotRetentionOutcome { limit, deleted })
     }
 
-    fn retention_coordinator(&self) -> Result<SnapshotSyncCoordinator, CloudLibraryServiceError> {
+    async fn retention_coordinator(
+        &self,
+    ) -> Result<SnapshotSyncCoordinator, CloudLibraryServiceError> {
         let (_, profile, local_state) = cloud_bootstrap_inputs()?;
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
@@ -169,9 +176,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         Ok(SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -185,7 +191,8 @@ impl ServiceContext {
         limit: u32,
     ) -> Result<usize, CloudLibraryServiceError> {
         let outcome = self
-            .retention_coordinator()?
+            .retention_coordinator()
+            .await?
             .enforce_retention(game_id, limit)
             .await?;
         if !outcome.tombstones.is_empty()

--- a/crates/rgsm-core/src/services/snapshot_sync.rs
+++ b/crates/rgsm-core/src/services/snapshot_sync.rs
@@ -7,16 +7,17 @@ use tokio_util::sync::CancellationToken;
 
 use crate::app_dirs::resolve_app_path;
 use crate::backup::GameSnapshots;
-use crate::cloud_sync::CloudSyncSessionConfig;
 use crate::cloud_sync::v2::{
-    ProgressRelation, SnapshotReconciliationOutcome, SnapshotSyncCoordinator, SnapshotSyncError,
-    V2ConflictInspector, V2ConflictReview,
+    CloudLibraryTarget, ProgressRelation, SnapshotReconciliationOutcome, SnapshotSyncCoordinator,
+    SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
 };
 use crate::config::{
     CloudNamespaceGeneration, Config, DeviceProfile, cloud_bootstrap_inputs, get_config,
 };
 use crate::hooks::{SnapshotSyncTarget, V2SnapshotSyncHook};
 use crate::preclude::{BackendError, BackupError, ConfigError};
+
+use super::cloud_library_target::{bound_v2_operator, cloud_library_target};
 
 pub const DEFAULT_SNAPSHOT_SYNC_POLL_MINUTES: u64 = 5;
 
@@ -36,6 +37,7 @@ pub struct LiveSaveApplyPlan {
 }
 
 struct SnapshotSyncRuntime {
+    target: CloudLibraryTarget,
     coordinator: SnapshotSyncCoordinator,
     targets: BTreeMap<String, SnapshotSyncTarget>,
     game_names: BTreeMap<String, String>,
@@ -46,7 +48,12 @@ pub fn build_v2_snapshot_sync_hook(
     operation_lock: Arc<Mutex<()>>,
 ) -> Result<Option<V2SnapshotSyncHook>, SnapshotSyncServiceError> {
     Ok(load_runtime()?.map(|runtime| {
-        V2SnapshotSyncHook::new(runtime.coordinator, runtime.targets, operation_lock)
+        V2SnapshotSyncHook::new(
+            runtime.target,
+            runtime.coordinator,
+            runtime.targets,
+            operation_lock,
+        )
     }))
 }
 
@@ -58,6 +65,7 @@ pub async fn run_v2_snapshot_sync_once(
     let Some(runtime) = load_runtime()? else {
         return Ok(SnapshotReconciliationOutcome::default());
     };
+    runtime.target.verify().await.map_err(BackendError::from)?;
     let tombstones = runtime.coordinator.converge_local_tombstones().await?;
     let mut total = SnapshotReconciliationOutcome::default();
     for (game_id, target) in &runtime.targets {
@@ -169,6 +177,7 @@ pub async fn resume_v2_snapshot_sync(
     let Some(runtime) = load_runtime()? else {
         return Ok(0);
     };
+    runtime.target.verify().await.map_err(BackendError::from)?;
     let downloaded = runtime.coordinator.resume_pending(cancellation).await;
     let import =
         super::sync::import_local_verified_catalog(runtime.coordinator.materializer()).await;
@@ -251,7 +260,7 @@ pub async fn review_v2_live_save_apply(
         .map(resolve_app_path)
         .ok_or(SnapshotSyncServiceError::StorageLocationRequired)?;
     let review = V2ConflictInspector::new(
-        CloudSyncSessionConfig::from(&local_state.cloud_settings).get_op()?,
+        bound_v2_operator(&local_state).await?,
         archive_root,
         local_state.current_device_id.clone(),
         3,
@@ -310,10 +319,11 @@ fn load_runtime() -> Result<Option<SnapshotSyncRuntime>, SnapshotSyncServiceErro
         .as_deref()
         .map(resolve_app_path)
         .ok_or(SnapshotSyncServiceError::StorageLocationRequired)?;
-    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+    let target = cloud_library_target(&local_state)?;
     Ok(Some(SnapshotSyncRuntime {
+        target: target.clone(),
         coordinator: SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            target.operator(),
             archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -379,9 +389,8 @@ async fn refresh_multi_device_sync_suspension(
     else {
         return Ok(settings.multi_device_sync_suspended);
     };
-    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
     let review = V2ConflictInspector::new(
-        session.get_op()?,
+        bound_v2_operator(&local_state).await?,
         local_archive_root,
         local_state.current_device_id,
         3,

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -12,10 +12,11 @@ use crate::cloud_sync::v2::{
     CloudArchiveMaterializer, CloudLibraryBootstrap, CloudLibraryBootstrapError,
     CloudLibraryCutover, CloudLibraryCutoverError, CloudLibraryCutoverReview, CloudLibraryJoin,
     CloudLibraryJoinError, CloudLibraryJoinReview, CloudManifestRepository,
-    CloudNamespaceClassification, CloudNamespaceError, ConflictReviewError, DeletionRegistryError,
-    DeviceProfileRemovalError, DeviceProfileRepository, DeviceProfileRepositoryError,
-    JoinGameDecision, KeepLocalProgressError, LocalArchiveEvictionError, ManifestRepositoryError,
-    MaterializationError, MaterializationOutcome, MaterializationPreview, SharedGameDeletionError,
+    CloudNamespaceClassification, CloudNamespaceDescriptor, CloudNamespaceError,
+    ConflictReviewError, DeletionRegistryError, DeviceProfileRemovalError, DeviceProfileRepository,
+    DeviceProfileRepositoryError, JoinGameDecision, KeepLocalProgressError,
+    LocalArchiveEvictionError, ManifestRepositoryError, MaterializationError,
+    MaterializationOutcome, MaterializationPreview, SharedGameDeletionError,
     SharedLibraryRepositoryError, SnapshotDeletionLifecycleError, SnapshotReconcilePolicy,
     SnapshotSyncCoordinator, SnapshotSyncError, V2ConflictInspector, V2ConflictReview,
 };
@@ -34,7 +35,7 @@ use crate::config::{
 use crate::hooks::{HookSource, MetadataChangedCtx};
 use crate::preclude::BackendError;
 
-use super::ServiceContext;
+use super::{ServiceContext, cloud_library_target::bound_v2_operator};
 
 fn cloud_session(config: &Config) -> CloudSyncSessionConfig {
     CloudSyncSessionConfig::from(&config.settings.cloud_settings)
@@ -271,17 +272,29 @@ impl ServiceContext {
         match bootstrap.inspect().await {
             Ok(classification) => {
                 if generation == CloudNamespaceGeneration::V2
-                    && let CloudNamespaceClassification::SupportedV2 { shared_library, .. } =
-                        &classification
-                    && !DeviceProfileRepository::new(operator, 3)
+                    && let CloudNamespaceClassification::SupportedV2 {
+                        descriptor,
+                        shared_library,
+                        ..
+                    } = &classification
+                {
+                    if local_state.cloud_library_id.as_deref()
+                        != Some(descriptor.library_id.as_str())
+                    {
+                        return Ok(CloudLibraryStatus::ReconnectRequired {
+                            game_count: shared_library.games.len(),
+                        });
+                    }
+                    let profile_missing = !DeviceProfileRepository::new(operator, 3)
                         .list()
                         .await?
                         .iter()
-                        .any(|profile| profile.device.id == local_state.current_device_id)
-                {
-                    return Ok(CloudLibraryStatus::ReconnectRequired {
-                        game_count: shared_library.games.len(),
-                    });
+                        .any(|profile| profile.device.id == local_state.current_device_id);
+                    if profile_missing {
+                        return Ok(CloudLibraryStatus::ReconnectRequired {
+                            game_count: shared_library.games.len(),
+                        });
+                    }
                 }
                 map_library_status(generation, classification, resumable_cutover)
             }
@@ -304,6 +317,10 @@ impl ServiceContext {
         }
         let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let operator = session.get_op()?;
+        let library_id = local_state
+            .cloud_library_id
+            .as_deref()
+            .ok_or(CloudLibraryServiceError::ActiveLibraryUnavailable)?;
         match operator
             .delete_with(crate::cloud_sync::v2::V2_NAMESPACE_PREFIX)
             .recursive(true)
@@ -313,8 +330,9 @@ impl ServiceContext {
             Err(err) if err.kind() == opendal::ErrorKind::NotFound => {}
             Err(err) => return Err(BackendError::from(err).into()),
         }
+        let descriptor = CloudNamespaceDescriptor::with_library_id(library_id);
         CloudLibraryBootstrap::new(operator, 3)
-            .create_empty(&shared_library, &device_profile)
+            .create_empty(&descriptor, &shared_library, &device_profile)
             .await?;
         self.reupload_enabled_local_progress(&CancellationToken::new())
             .await?;
@@ -341,7 +359,11 @@ impl ServiceContext {
         let classification = CloudLibraryBootstrap::new(operator.clone(), 3)
             .inspect()
             .await?;
-        let CloudNamespaceClassification::SupportedV2 { shared_library, .. } = classification
+        let CloudNamespaceClassification::SupportedV2 {
+            descriptor,
+            shared_library,
+            ..
+        } = classification
         else {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
         };
@@ -354,6 +376,7 @@ impl ServiceContext {
             &expected_profile,
             &shared_library,
             &accepted_profile,
+            &descriptor.library_id,
         )?;
         Ok(CloudLibraryStatus::Active {
             game_count: shared_library.games.len(),
@@ -374,10 +397,11 @@ impl ServiceContext {
 
         let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let bootstrap = CloudLibraryBootstrap::new(session.get_op()?, 3);
+        let descriptor = CloudNamespaceDescriptor::default();
         bootstrap
-            .create_empty(&shared_library, &device_profile)
+            .create_empty(&descriptor, &shared_library, &device_profile)
             .await?;
-        activate_cloud_namespace_v2(&shared_library, &device_profile)?;
+        activate_cloud_namespace_v2(&shared_library, &device_profile, &descriptor.library_id)?;
         self.publish_enabled_local_progress(&CancellationToken::new())
             .await?;
         Ok(CloudLibraryStatus::Active {
@@ -416,7 +440,7 @@ impl ServiceContext {
                 confirmed_replacements,
             )
             .await;
-        let (accepted_library, accepted_profile) = match joined {
+        let joined = match joined {
             Ok(joined) => joined,
             Err(CloudLibraryJoinError::TargetChanged(game_name))
             | Err(CloudLibraryJoinError::LocalGameChanged(game_name)) => {
@@ -427,13 +451,14 @@ impl ServiceContext {
         activate_joined_cloud_library(
             &local_library,
             &local_profile,
-            &accepted_library,
-            &accepted_profile,
+            &joined.shared_library,
+            &joined.device_profile,
+            &joined.library_id,
         )?;
         self.publish_enabled_local_progress(&CancellationToken::new())
             .await?;
         Ok(CloudLibraryJoinOutcome::Active {
-            game_count: accepted_library.games.len(),
+            game_count: joined.shared_library.games.len(),
         })
     }
 
@@ -468,6 +493,7 @@ impl ServiceContext {
             &local_profile,
             &result.shared_library,
             &result.device_profiles,
+            &result.library_id,
         )?;
         if let Err(error) = cutover.finish().await {
             log::warn!(
@@ -516,9 +542,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         Ok(V2ConflictInspector::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             3,
@@ -565,9 +590,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let coordinator = SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -725,7 +749,7 @@ impl ServiceContext {
             settings.live_save_snapshot_on_exit = options.snapshot_on_exit;
         }
 
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
+        let operator = bound_v2_operator(&local_state).await?;
 
         // When disabling cloud sync, clear this Device's advertised head
         // BEFORE publishing the disabled profile. If we published first and
@@ -734,7 +758,7 @@ impl ServiceContext {
         // other Devices indefinitely.
         if !enabled && was_enabled {
             let device_id = local_state.current_device_id.clone();
-            CloudManifestRepository::new(session.get_op()?, CLOUD_MANIFEST_PATH, 3)
+            CloudManifestRepository::new(operator.clone(), CLOUD_MANIFEST_PATH, 3)
                 .mutate(move |manifest| {
                     if let Some(game) = manifest.games.get_mut(game_id) {
                         game.clear_head(&device_id);
@@ -744,7 +768,7 @@ impl ServiceContext {
                 .await?;
         }
 
-        DeviceProfileRepository::new(session.get_op()?, 3)
+        DeviceProfileRepository::new(operator.clone(), 3)
             .publish(&local_state.current_device_id, &accepted_profile)
             .await?;
         replace_current_device_profile(&expected_profile, &accepted_profile)?;
@@ -759,7 +783,7 @@ impl ServiceContext {
                 })?;
             let snapshots = game.get_game_snapshots_info()?;
             let coordinator = SnapshotSyncCoordinator::new(
-                session.get_op()?,
+                operator,
                 accepted_profile
                     .local_archive_root
                     .as_deref()
@@ -818,7 +842,7 @@ impl ServiceContext {
         ))
     }
 
-    fn materializer(&self) -> Result<CloudArchiveMaterializer, CloudLibraryServiceError> {
+    async fn materializer(&self) -> Result<CloudArchiveMaterializer, CloudLibraryServiceError> {
         let (_, profile, local_state) = cloud_bootstrap_inputs()?;
         if local_state.cloud_namespace_generation != CloudNamespaceGeneration::V2 {
             return Err(CloudLibraryServiceError::ActiveLibraryUnavailable);
@@ -828,9 +852,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         Ok(CloudArchiveMaterializer::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -851,9 +874,8 @@ impl ServiceContext {
         else {
             return Ok(());
         };
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let coordinator = SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id.clone(),
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -903,9 +925,8 @@ impl ServiceContext {
             .as_deref()
             .map(resolve_app_path)
             .ok_or(CloudLibraryServiceError::StorageLocationRequired)?;
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         let coordinator = SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id.clone(),
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -943,7 +964,7 @@ impl ServiceContext {
         &self,
     ) -> Result<CloudArchiveMaterializer, CloudLibraryServiceError> {
         super::game_deletion::converge_local_deleted_games().await?;
-        let materializer = self.materializer()?;
+        let materializer = self.materializer().await?;
         self.converge_local_tombstone_metadata(&materializer)
             .await?;
         Ok(materializer)
@@ -1044,9 +1065,8 @@ impl ServiceContext {
         else {
             return Ok(());
         };
-        let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
         SnapshotSyncCoordinator::new(
-            session.get_op()?,
+            bound_v2_operator(&local_state).await?,
             local_archive_root,
             local_state.current_device_id,
             resolve_app_path("GameSaveManager.cloud-v2-materialization.json"),
@@ -1099,8 +1119,7 @@ pub(super) async fn set_multi_device_sync_suspended(
         return Ok(());
     }
     settings.multi_device_sync_suspended = suspended;
-    let session = CloudSyncSessionConfig::from(&local_state.cloud_settings);
-    DeviceProfileRepository::new(session.get_op()?, 3)
+    DeviceProfileRepository::new(bound_v2_operator(&local_state).await?, 3)
         .publish(&local_state.current_device_id, &accepted)
         .await?;
     replace_current_device_profile(&expected, &accepted)?;
@@ -1221,10 +1240,18 @@ pub(crate) async fn import_local_verified_catalog(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::cloud_sync::CloudSettings;
-    use crate::cloud_sync::v2::{CloudManifest, CloudNamespaceDescriptor};
-    use crate::config::{Config, SharedLibrary, V2_CONFIG_SCHEMA_VERSION};
+    use crate::cloud_sync::v2::{CloudManifest, CloudNamespaceDescriptor, device_profile_path};
+    use crate::cloud_sync::{Backend, CloudSettings};
+    use crate::config::{
+        Config, ConfigTestStateGuard, SharedLibrary, V2_CONFIG_SCHEMA_VERSION, set_config_local,
+    };
+    use crate::hooks::HookPipeline;
+
+    const LOCAL_LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+    const REMOTE_LIBRARY_ID: &str = "22222222-2222-4222-8222-222222222222";
 
     fn supported() -> CloudNamespaceClassification {
         CloudNamespaceClassification::SupportedV2 {
@@ -1293,6 +1320,52 @@ mod tests {
             map_library_status(CloudNamespaceGeneration::V2, v1_only(), false),
             Err(CloudLibraryServiceError::ActiveLibraryUnavailable)
         ));
+    }
+
+    #[test]
+    fn identity_mismatch_bypasses_unrelated_profile_corruption() {
+        let _config_lock = crate::config::lock_config_test_file();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let cloud_root = temp_dir::TempDir::new().unwrap();
+            let mut config = Config::default();
+            config.settings.cloud_settings = CloudSettings {
+                backend: Backend::Fs,
+                root_path: cloud_root.path().to_string_lossy().into_owned(),
+                ..CloudSettings::default()
+            };
+            let _config_state = ConfigTestStateGuard::replace_with(&config).unwrap();
+            set_config_local(&config).unwrap();
+            let (library, profile, _) = cloud_bootstrap_inputs().unwrap();
+            activate_cloud_namespace_v2(&library, &profile, LOCAL_LIBRARY_ID).unwrap();
+
+            let operator = CloudSyncSessionConfig::from(&config.settings.cloud_settings)
+                .get_op()
+                .unwrap();
+            CloudLibraryBootstrap::new(operator.clone(), 2)
+                .create_empty(
+                    &CloudNamespaceDescriptor::with_library_id(REMOTE_LIBRARY_ID),
+                    &library,
+                    &profile,
+                )
+                .await
+                .unwrap();
+            operator
+                .write(&device_profile_path("broken-device"), b"{".to_vec())
+                .await
+                .unwrap();
+
+            let service = ServiceContext::new(Arc::new(HookPipeline::new(vec![])));
+            assert_eq!(
+                service.inspect_cloud_library().await.unwrap(),
+                CloudLibraryStatus::ReconnectRequired {
+                    game_count: library.games.len(),
+                }
+            );
+        });
     }
 
     #[test]

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/destructive.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/destructive.rs
@@ -10,7 +10,9 @@ use rgsm_core::cloud_sync::v2::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, no_baseline, snapshot};
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, cloud_namespace_descriptor, no_baseline, snapshot,
+};
 
 const GAME_ID: &str = "example-game";
 const GAME_NAME: &str = "Example Game";
@@ -22,7 +24,11 @@ async fn bootstrap_game(
 ) {
     let (empty_library, empty_profile) = device_a.empty_library_and_profile();
     CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
-        .create_empty(&empty_library, &empty_profile)
+        .create_empty(
+            &cloud_namespace_descriptor(),
+            &empty_library,
+            &empty_profile,
+        )
         .await
         .expect("empty Fs root should bootstrap");
 

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/interleaving.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/interleaving.rs
@@ -4,7 +4,9 @@ use rgsm_core::cloud_sync::v2::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, no_baseline, snapshot};
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, cloud_namespace_descriptor, no_baseline, snapshot,
+};
 
 #[tokio::test]
 async fn two_devices_rebase_stale_library_changes_and_preserve_independent_heads() {
@@ -21,7 +23,11 @@ async fn two_devices_rebase_stale_library_changes_and_preserve_independent_heads
     let device_b = DeviceFixture::new("device-b");
     let (empty_library, empty_profile) = device_a.empty_library_and_profile();
     CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
-        .create_empty(&empty_library, &empty_profile)
+        .create_empty(
+            &cloud_namespace_descriptor(),
+            &empty_library,
+            &empty_profile,
+        )
         .await
         .expect("empty Fs root should bootstrap");
 

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/normal_path.rs
@@ -7,16 +7,19 @@ use rgsm_core::cloud_sync::v2::{
 };
 use tokio_util::sync::CancellationToken;
 
-use crate::support::{DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, no_baseline, snapshot};
+use crate::support::{
+    DeviceFixture, FsCloudFixture, MAX_ATTEMPTS, cloud_namespace_descriptor, no_baseline, snapshot,
+};
 
 #[tokio::test]
 async fn bootstrap_persists_complete_v2_namespace_across_fresh_operators() {
     let cloud = FsCloudFixture::new();
     let device = DeviceFixture::new("device-a");
     let (shared_library, device_profile) = device.empty_library_and_profile();
+    let expected_descriptor = cloud_namespace_descriptor();
 
     CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
-        .create_empty(&shared_library, &device_profile)
+        .create_empty(&expected_descriptor, &shared_library, &device_profile)
         .await
         .expect("empty Fs root should bootstrap");
 
@@ -34,7 +37,7 @@ async fn bootstrap_persists_complete_v2_namespace_across_fresh_operators() {
     else {
         panic!("bootstrapped Fs root should classify as V2");
     };
-    assert_eq!(descriptor, Default::default());
+    assert_eq!(descriptor, expected_descriptor);
     assert_eq!(stored_library, shared_library);
     assert_eq!(manifest, Default::default());
 
@@ -68,7 +71,11 @@ async fn single_device_snapshot_round_trip_survives_fresh_operators() {
     let device = DeviceFixture::new("device-a");
     let (empty_library, empty_profile) = device.empty_library_and_profile();
     CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
-        .create_empty(&empty_library, &empty_profile)
+        .create_empty(
+            &cloud_namespace_descriptor(),
+            &empty_library,
+            &empty_profile,
+        )
         .await
         .expect("empty Fs root should bootstrap");
 

--- a/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
+++ b/crates/rgsm-core/tests/cloud_sync_v2_fs/support.rs
@@ -5,7 +5,8 @@ use opendal::Operator;
 use rgsm_core::backup::{ArchiveFormat, CreatedBy, Game, GameSnapshots, Snapshot, archive_path};
 use rgsm_core::cloud_sync::v2::{
     CLOUD_MANIFEST_PATH, CloudLibraryBootstrap, CloudManifest, CloudManifestRepository,
-    DeviceProfileRepository, SharedLibraryRepository, SnapshotSyncCoordinator, cloud_archive_path,
+    CloudNamespaceDescriptor, DeviceProfileRepository, SharedLibraryRepository,
+    SnapshotSyncCoordinator, cloud_archive_path,
 };
 use rgsm_core::cloud_sync::{Backend, CloudSyncSessionConfig};
 use rgsm_core::config::{
@@ -15,6 +16,11 @@ use rgsm_core::device::DeviceId;
 use tokio_util::sync::CancellationToken;
 
 pub const MAX_ATTEMPTS: usize = 2;
+pub const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+pub fn cloud_namespace_descriptor() -> CloudNamespaceDescriptor {
+    CloudNamespaceDescriptor::with_library_id(LIBRARY_ID)
+}
 
 pub struct FsCloudFixture {
     root: temp_dir::TempDir,
@@ -142,7 +148,11 @@ pub async fn bootstrap_game(
 ) {
     let (empty_library, empty_profile) = device_a.empty_library_and_profile();
     CloudLibraryBootstrap::new(cloud.new_operator(), MAX_ATTEMPTS)
-        .create_empty(&empty_library, &empty_profile)
+        .create_empty(
+            &cloud_namespace_descriptor(),
+            &empty_library,
+            &empty_profile,
+        )
         .await
         .expect("empty Fs root should bootstrap");
 


### PR DESCRIPTION
Second PR in the 1.9 release stack, based on #516

Gives each V2 cloud library one random stable identity, binds each active installation to it, and stops normal cloud operations when the configured target changes

Explicit reconnect remains the only path that can adopt a different existing library
