### PR TITLE
fix(sync): serialize local cloud mutations

### DIFF
--- a/apps/rgsm-gui/src-tauri/src/cloud_library.rs
+++ b/apps/rgsm-gui/src-tauri/src/cloud_library.rs
@@ -18,44 +18,44 @@ pub async fn create(
     app: &AppHandle,
     confirmed: bool,
 ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
-    app.state::<Arc<CloudSyncTaskManager>>()
-        .cancel_all_and_wait()
-        .await;
-    let pipeline = app.state::<HookPipelineState>().snapshot();
-    let status = ServiceContext::new(pipeline)
-        .create_cloud_library(confirmed)
-        .await?;
-    let config = get_config()?;
-    crate::hooks::rebuild_pipeline(app, &config);
-    Ok(status)
+    crate::cloud_operation::run_after_cancelling(app, async {
+        let pipeline = app.state::<HookPipelineState>().snapshot();
+        let status = ServiceContext::new(pipeline)
+            .create_cloud_library(confirmed)
+            .await?;
+        let config = get_config()?;
+        crate::hooks::rebuild_pipeline(app, &config);
+        Ok(status)
+    })
+    .await
 }
 
 pub async fn rebuild(
     app: &AppHandle,
     confirmed: bool,
 ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
-    app.state::<Arc<CloudSyncTaskManager>>()
-        .cancel_all_and_wait()
-        .await;
-    let status = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
-        .rebuild_cloud_library_from_local(confirmed)
-        .await?;
-    crate::hooks::rebuild_pipeline(app, &get_config()?);
-    Ok(status)
+    crate::cloud_operation::run_after_cancelling(app, async {
+        let status = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+            .rebuild_cloud_library_from_local(confirmed)
+            .await?;
+        crate::hooks::rebuild_pipeline(app, &get_config()?);
+        Ok(status)
+    })
+    .await
 }
 
 pub async fn reconnect(
     app: &AppHandle,
     confirmed: bool,
 ) -> Result<CloudLibraryStatus, CloudLibraryServiceError> {
-    app.state::<Arc<CloudSyncTaskManager>>()
-        .cancel_all_and_wait()
-        .await;
-    let status = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
-        .reconnect_cloud_library(confirmed)
-        .await?;
-    crate::hooks::rebuild_pipeline(app, &get_config()?);
-    Ok(status)
+    crate::cloud_operation::run_after_cancelling(app, async {
+        let status = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+            .reconnect_cloud_library(confirmed)
+            .await?;
+        crate::hooks::rebuild_pipeline(app, &get_config()?);
+        Ok(status)
+    })
+    .await
 }
 
 pub async fn review(app: &AppHandle) -> Result<CloudLibraryJoinReview, CloudLibraryServiceError> {
@@ -69,16 +69,16 @@ pub async fn join(
     decisions: &[JoinGameDecision],
     confirmed_replacements: bool,
 ) -> Result<CloudLibraryJoinOutcome, CloudLibraryServiceError> {
-    app.state::<Arc<CloudSyncTaskManager>>()
-        .cancel_all_and_wait()
-        .await;
-    let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
-        .join_cloud_library(decisions, confirmed_replacements)
-        .await?;
-    if matches!(outcome, CloudLibraryJoinOutcome::Active { .. }) {
-        crate::hooks::rebuild_pipeline(app, &get_config()?);
-    }
-    Ok(outcome)
+    crate::cloud_operation::run_after_cancelling(app, async {
+        let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+            .join_cloud_library(decisions, confirmed_replacements)
+            .await?;
+        if matches!(outcome, CloudLibraryJoinOutcome::Active { .. }) {
+            crate::hooks::rebuild_pipeline(app, &get_config()?);
+        }
+        Ok(outcome)
+    })
+    .await
 }
 
 pub async fn review_cutover(
@@ -93,17 +93,32 @@ pub async fn cutover(
     app: &AppHandle,
     confirmed: bool,
 ) -> Result<CloudLibraryCutoverOutcome, CloudLibraryServiceError> {
-    app.state::<Arc<CloudSyncTaskManager>>()
-        .cancel_all_and_wait()
-        .await;
-    let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
-        .cutover_cloud_library(confirmed)
-        .await?;
-    crate::hooks::rebuild_pipeline(app, &get_config()?);
-    Ok(outcome)
+    crate::cloud_operation::run_after_cancelling(app, async {
+        let outcome = ServiceContext::new(app.state::<HookPipelineState>().snapshot())
+            .cutover_cloud_library(confirmed)
+            .await?;
+        crate::hooks::rebuild_pipeline(app, &get_config()?);
+        Ok(outcome)
+    })
+    .await
 }
 
 pub async fn set_game_sync_mode(
+    app: &AppHandle,
+    game_id: &str,
+    enabled: bool,
+    mode: SyncMode,
+    initial_catch_up: InitialCatchUpPolicy,
+    live_save: Option<rgsm_core::services::LiveSaveSyncOptions>,
+) -> Result<GameSyncModeOutcome, CloudLibraryServiceError> {
+    crate::cloud_operation::run(
+        app,
+        set_game_sync_mode_inner(app, game_id, enabled, mode, initial_catch_up, live_save),
+    )
+    .await
+}
+
+async fn set_game_sync_mode_inner(
     app: &AppHandle,
     game_id: &str,
     enabled: bool,

--- a/apps/rgsm-gui/src-tauri/src/cloud_operation.rs
+++ b/apps/rgsm-gui/src-tauri/src/cloud_operation.rs
@@ -1,0 +1,83 @@
+use std::future::Future;
+use std::sync::Arc;
+
+use rgsm_core::cloud_sync::CloudSyncTaskManager;
+use tauri::{AppHandle, Manager};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Default)]
+pub struct CloudOperationState {
+    operation_lock: Arc<Mutex<()>>,
+}
+
+pub async fn run<T>(app: &AppHandle, operation: impl Future<Output = T>) -> T {
+    let state = app.state::<CloudOperationState>().inner().clone();
+    state.run(operation).await
+}
+
+pub async fn run_after_cancelling<T>(app: &AppHandle, operation: impl Future<Output = T>) -> T {
+    let manager = Arc::clone(app.state::<Arc<CloudSyncTaskManager>>().inner());
+    manager.cancel_all().await;
+    run(app, async move {
+        manager.cancel_all_and_wait().await;
+        operation.await
+    })
+    .await
+}
+
+impl CloudOperationState {
+    pub async fn run<T>(&self, operation: impl Future<Output = T>) -> T {
+        let _guard = self.operation_lock.lock().await;
+        operation.await
+    }
+
+    pub fn lock_handle(&self) -> Arc<Mutex<()>> {
+        Arc::clone(&self.operation_lock)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::oneshot;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn operations_enter_one_at_a_time() {
+        let state = CloudOperationState::default();
+        let first_state = state.clone();
+        let (first_started_tx, first_started_rx) = oneshot::channel();
+        let (release_first_tx, release_first_rx) = oneshot::channel();
+        let first = tokio::spawn(async move {
+            first_state
+                .run(async move {
+                    first_started_tx.send(()).unwrap();
+                    release_first_rx.await.unwrap();
+                })
+                .await;
+        });
+        first_started_rx.await.unwrap();
+
+        let second_state = state.clone();
+        let (second_started_tx, mut second_started_rx) = oneshot::channel();
+        let second = tokio::spawn(async move {
+            second_state
+                .run(async move {
+                    second_started_tx.send(()).unwrap();
+                })
+                .await;
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut second_started_rx)
+                .await
+                .is_err()
+        );
+
+        release_first_tx.send(()).unwrap();
+        first.await.unwrap();
+        second_started_rx.await.unwrap();
+        second.await.unwrap();
+    }
+}

--- a/apps/rgsm-gui/src-tauri/src/commands.rs
+++ b/apps/rgsm-gui/src-tauri/src/commands.rs
@@ -140,6 +140,13 @@ fn svc<R: tauri::Runtime, M: Manager<R>>(manager: &M) -> ServiceContext {
     ServiceContext::new(hook_pipeline(manager))
 }
 
+async fn run_cloud_operation<T>(
+    app: &AppHandle,
+    operation: impl std::future::Future<Output = T>,
+) -> T {
+    crate::cloud_operation::run(app, operation).await
+}
+
 async fn rebuild_pipeline_and_fire_config_saved(
     app_handle: &AppHandle,
     config: Config,
@@ -653,10 +660,13 @@ pub async fn cutover_cloud_library(
 pub async fn get_cloud_archive_library(
     app_handle: AppHandle,
 ) -> Result<CloudArchiveLibraryView, String> {
-    svc(&app_handle)
-        .cloud_archive_library()
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .cloud_archive_library()
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn review_v2_game_progress(
@@ -675,14 +685,13 @@ pub async fn keep_v2_local_progress(
     local_snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::cloud_sync::v2::KeepLocalProgressOutcome, String> {
-    let operation_lock = app_handle
-        .state::<crate::snapshot_sync::SnapshotSyncRuntimeState>()
-        .operation_lock();
-    let _guard = operation_lock.lock().await;
-    svc(&app_handle)
-        .keep_v2_local_progress(&game_id, manifest_revision, &local_snapshot_id)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .keep_v2_local_progress(&game_id, manifest_revision, &local_snapshot_id)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn accept_v2_remote_progress(
@@ -692,28 +701,30 @@ pub async fn accept_v2_remote_progress(
     selected_snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::AcceptRemoteProgressOutcome, String> {
-    let operation_lock = app_handle
-        .state::<crate::snapshot_sync::SnapshotSyncRuntimeState>()
-        .operation_lock();
-    let _guard = operation_lock.lock().await;
-    svc(&app_handle)
-        .accept_v2_remote_progress(
-            &game_id,
-            manifest_revision,
-            expected_local_snapshot_id.as_deref(),
-            &selected_snapshot_id,
-        )
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .accept_v2_remote_progress(
+                &game_id,
+                manifest_revision,
+                expected_local_snapshot_id.as_deref(),
+                &selected_snapshot_id,
+            )
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn preview_materialize_all(
     app_handle: AppHandle,
 ) -> Result<MaterializationPreview, String> {
-    svc(&app_handle)
-        .preview_materialize_all()
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .preview_materialize_all()
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn upload_cloud_archive(
@@ -721,10 +732,13 @@ pub async fn upload_cloud_archive(
     snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<(), String> {
-    svc(&app_handle)
-        .upload_cloud_archive(&game_id, &snapshot_id)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .upload_cloud_archive(&game_id, &snapshot_id)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn download_cloud_archive(
@@ -732,10 +746,13 @@ pub async fn download_cloud_archive(
     snapshot_id: String,
     app_handle: AppHandle,
 ) -> Result<(), String> {
-    svc(&app_handle)
-        .download_cloud_archive(&game_id, &snapshot_id)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .download_cloud_archive(&game_id, &snapshot_id)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn delete_v2_snapshot(
@@ -745,10 +762,13 @@ pub async fn delete_v2_snapshot(
     current_position: Option<CurrentPositionDecision>,
     app_handle: AppHandle,
 ) -> Result<(), String> {
-    ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
-        .delete_v2_snapshot(&game_id, &snapshot_id, confirmed, current_position)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
+            .delete_v2_snapshot(&game_id, &snapshot_id, confirmed, current_position)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn rebuild_cloud_library_from_local(
@@ -775,10 +795,13 @@ pub async fn set_shared_snapshot_retention(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::SnapshotRetentionOutcome, String> {
-    ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
-        .set_shared_snapshot_retention(&game_id, limit, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
+            .set_shared_snapshot_retention(&game_id, limit, confirmed)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn set_snapshot_retention_protected(
@@ -788,10 +811,18 @@ pub async fn set_snapshot_retention_protected(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::SnapshotRetentionOutcome, String> {
-    ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
-        .set_snapshot_retention_protected(&game_id, &snapshot_id, retention_protected, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        ServiceContext::new(app_handle.state::<HookPipelineState>().snapshot())
+            .set_snapshot_retention_protected(
+                &game_id,
+                &snapshot_id,
+                retention_protected,
+                confirmed,
+            )
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub fn get_current_device_game_statuses(
@@ -807,12 +838,15 @@ pub async fn set_device_game_visibility(
     visible: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::DeviceGameStatus, String> {
-    let status = svc(&app_handle)
-        .set_device_game_visibility(&game_id, visible)
-        .await
-        .map_err(|error| error.to_string())?;
-    reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
-    Ok(status)
+    run_cloud_operation(&app_handle, async {
+        let status = svc(&app_handle)
+            .set_device_game_visibility(&game_id, visible)
+            .await
+            .map_err(|error| error.to_string())?;
+        reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
+        Ok(status)
+    })
+    .await
 }
 
 pub async fn set_device_game_managed(
@@ -821,12 +855,15 @@ pub async fn set_device_game_managed(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::services::DeviceGameStatus, String> {
-    let status = svc(&app_handle)
-        .set_device_game_managed(&game_id, managed, confirmed)
-        .await
-        .map_err(|error| error.to_string())?;
-    reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
-    Ok(status)
+    run_cloud_operation(&app_handle, async {
+        let status = svc(&app_handle)
+            .set_device_game_managed(&game_id, managed, confirmed)
+            .await
+            .map_err(|error| error.to_string())?;
+        reload_pipeline_and_fire_config_saved(&app_handle, HookSource::UserManual).await?;
+        Ok(status)
+    })
+    .await
 }
 
 pub async fn evict_local_archive(
@@ -835,10 +872,13 @@ pub async fn evict_local_archive(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<bool, String> {
-    svc(&app_handle)
-        .evict_local_archive(&game_id, &snapshot_id, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .evict_local_archive(&game_id, &snapshot_id, confirmed)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn evict_cloud_archive(
@@ -847,10 +887,13 @@ pub async fn evict_cloud_archive(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<bool, String> {
-    svc(&app_handle)
-        .evict_cloud_archive(&game_id, &snapshot_id, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .evict_cloud_archive(&game_id, &snapshot_id, confirmed)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn get_cloud_device_profiles(
@@ -867,10 +910,13 @@ pub async fn remove_cloud_device_profile(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::cloud_sync::v2::DeviceProfileRemovalOutcome, String> {
-    svc(&app_handle)
-        .remove_cloud_device_profile(&device_id, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .remove_cloud_device_profile(&device_id, confirmed)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn get_deleted_cloud_games(
@@ -887,34 +933,40 @@ pub async fn permanently_delete_cloud_game(
     confirmed: bool,
     app_handle: AppHandle,
 ) -> Result<rgsm_core::cloud_sync::v2::SharedGameDeletionOutcome, String> {
-    svc(&app_handle)
-        .permanently_delete_cloud_game(&game_id, confirmed)
-        .await
-        .map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        svc(&app_handle)
+            .permanently_delete_cloud_game(&game_id, confirmed)
+            .await
+            .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn materialize_all_cloud_archives(
     app_handle: AppHandle,
 ) -> Result<MaterializationOutcome, String> {
-    let manager = Arc::clone(app_handle.state::<Arc<CloudSyncTaskManager>>().inner());
-    let (job_id, token) = manager
-        .begin_manual_job("Downloading all Cloud Snapshots".into())
-        .await;
-    let result = svc(&app_handle)
-        .materialize_all_cloud_archives(&token)
-        .await;
-    let status = if result.is_ok() {
-        cloud_sync::CloudSyncJobStatus::Completed
-    } else if token.is_cancelled() {
-        cloud_sync::CloudSyncJobStatus::Cancelled
-    } else {
-        cloud_sync::CloudSyncJobStatus::Failed
-    };
-    let error = result.as_ref().err().map(ToString::to_string);
-    manager
-        .finish_manual_job(job_id, "Downloading all Cloud Snapshots", status, error)
-        .await;
-    result.map_err(|error| error.to_string())
+    run_cloud_operation(&app_handle, async {
+        let manager = Arc::clone(app_handle.state::<Arc<CloudSyncTaskManager>>().inner());
+        let (job_id, token) = manager
+            .begin_manual_job("Downloading all Cloud Snapshots".into())
+            .await;
+        let result = svc(&app_handle)
+            .materialize_all_cloud_archives(&token)
+            .await;
+        let status = if result.is_ok() {
+            cloud_sync::CloudSyncJobStatus::Completed
+        } else if token.is_cancelled() {
+            cloud_sync::CloudSyncJobStatus::Cancelled
+        } else {
+            cloud_sync::CloudSyncJobStatus::Failed
+        };
+        let error = result.as_ref().err().map(ToString::to_string);
+        manager
+            .finish_manual_job(job_id, "Downloading all Cloud Snapshots", status, error)
+            .await;
+        result.map_err(|error| error.to_string())
+    })
+    .await
 }
 
 pub async fn set_game_sync_mode(
@@ -941,67 +993,71 @@ pub async fn cloud_upload_all(
     session: CloudSyncSessionConfig,
     app_handle: AppHandle,
 ) -> Result<BatchSyncReport, String> {
-    let manager_state: tauri::State<Arc<CloudSyncTaskManager>> = app_handle.state();
-    let manager = Arc::clone(manager_state.inner());
-    let _ = manager.cancel_all().await;
-
-    let description = format!(
-        "Overwrite upload ({:?})",
-        session.backend.clone().sanitize()
-    );
-    let (job_id, token) = manager.begin_manual_job(description.clone()).await;
-    let result = svc(&app_handle)
-        .upload_all_from_session(&session, Some(token))
-        .await;
-    let (status, error) = summarize_batch_result(&result);
-    manager
-        .finish_manual_job(job_id, &description, status, error.clone())
-        .await;
-    result.map_err(|e| e.to_string())
+    crate::cloud_operation::run_after_cancelling(&app_handle, async {
+        let manager = Arc::clone(app_handle.state::<Arc<CloudSyncTaskManager>>().inner());
+        let description = format!(
+            "Overwrite upload ({:?})",
+            session.backend.clone().sanitize()
+        );
+        let (job_id, token) = manager.begin_manual_job(description.clone()).await;
+        let result = svc(&app_handle)
+            .upload_all_from_session(&session, Some(token))
+            .await;
+        let (status, error) = summarize_batch_result(&result);
+        manager
+            .finish_manual_job(job_id, &description, status, error.clone())
+            .await;
+        result.map_err(|e| e.to_string())
+    })
+    .await
 }
 
 pub async fn cloud_download_all(
     session: CloudSyncSessionConfig,
     app_handle: AppHandle,
 ) -> Result<BatchSyncReport, String> {
-    let manager_state: tauri::State<Arc<CloudSyncTaskManager>> = app_handle.state();
-    let manager = Arc::clone(manager_state.inner());
-    let _ = manager.cancel_all().await;
+    crate::cloud_operation::run_after_cancelling(&app_handle, async {
+        let manager = Arc::clone(app_handle.state::<Arc<CloudSyncTaskManager>>().inner());
+        let description = format!(
+            "Overwrite download ({:?})",
+            session.backend.clone().sanitize()
+        );
+        let (job_id, token) = manager.begin_manual_job(description.clone()).await;
+        let result = svc(&app_handle)
+            .download_all_from_session(&session, Some(token))
+            .await;
 
-    let description = format!(
-        "Overwrite download ({:?})",
-        session.backend.clone().sanitize()
-    );
-    let (job_id, token) = manager.begin_manual_job(description.clone()).await;
-    let result = svc(&app_handle)
-        .download_all_from_session(&session, Some(token))
-        .await;
-
-    // After a successful download, the config may contain new games or updated
-    // auto-backup settings. Rebuild the hook pipeline so the scheduler syncs.
-    if matches!(
-        summarize_batch_result(&result).0,
-        cloud_sync::CloudSyncJobStatus::Completed
-    ) {
-        match get_config() {
-            Ok(config) => {
-                rebuild_pipeline_and_fire_config_saved(&app_handle, config, HookSource::CloudSync)
+        // After a successful download, the config may contain new games or updated
+        // auto-backup settings. Rebuild the hook pipeline so the scheduler syncs.
+        if matches!(
+            summarize_batch_result(&result).0,
+            cloud_sync::CloudSyncJobStatus::Completed
+        ) {
+            match get_config() {
+                Ok(config) => {
+                    rebuild_pipeline_and_fire_config_saved(
+                        &app_handle,
+                        config,
+                        HookSource::CloudSync,
+                    )
                     .await;
-            }
-            Err(err) => {
-                warn!(
-                    target: "rgsm::commands",
-                    "Failed to reload config after cloud download: {err:?}"
-                );
+                }
+                Err(err) => {
+                    warn!(
+                        target: "rgsm::commands",
+                        "Failed to reload config after cloud download: {err:?}"
+                    );
+                }
             }
         }
-    }
 
-    let (status, error) = summarize_batch_result(&result);
-    manager
-        .finish_manual_job(job_id, &description, status, error.clone())
-        .await;
-    result.map_err(|e| e.to_string())
+        let (status, error) = summarize_batch_result(&result);
+        manager
+            .finish_manual_job(job_id, &description, status, error.clone())
+            .await;
+        result.map_err(|e| e.to_string())
+    })
+    .await
 }
 
 pub async fn set_snapshot_description(

--- a/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/hooks/mod.rs
@@ -83,8 +83,8 @@ pub fn build_builtin_pipeline(app: &AppHandle, config: &Config) -> HookPipeline 
                 "Automatic legacy cloud writes are paused until Cloud Library activation"
             ),
             Ok(CloudNamespaceGeneration::V2) => {
-                let state = app.state::<crate::snapshot_sync::SnapshotSyncRuntimeState>();
-                match rgsm_core::services::build_v2_snapshot_sync_hook(state.operation_lock()) {
+                let state = app.state::<crate::cloud_operation::CloudOperationState>();
+                match rgsm_core::services::build_v2_snapshot_sync_hook(state.lock_handle()) {
                     Ok(Some(hook)) => hooks.push(Box::new(hook)),
                     Ok(None) => {}
                     Err(error) => warn!(

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use rgsm_core::config::config_check;
 
 // GUI-specific modules
 mod cloud_library;
+mod cloud_operation;
 mod commands;
 mod hooks;
 mod http;
@@ -174,13 +175,13 @@ pub fn run() -> anyhow::Result<()> {
                 cloud_sync_worker.run().await;
             });
             let config = get_config().expect("Failed to load config while building hooks");
-            let snapshot_sync_runtime = snapshot_sync::SnapshotSyncRuntimeState::default();
-            app.manage(snapshot_sync_runtime.clone());
+            let cloud_operation_state = cloud_operation::CloudOperationState::default();
+            app.manage(cloud_operation_state.clone());
             let pipeline = hooks::build_builtin_pipeline(app.handle(), &config);
             app.manage(hooks::HookPipelineState::new(pipeline));
 
             app.manage(cloud_sync_manager);
-            snapshot_sync::setup(app.handle().clone(), snapshot_sync_runtime);
+            snapshot_sync::setup(app.handle().clone(), cloud_operation_state);
 
             sound::setup(app).expect("Cannot setup sound manager");
             // 处理快捷备份，包括托盘、定时、快捷键

--- a/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
+++ b/apps/rgsm-gui/src-tauri/src/snapshot_sync.rs
@@ -1,46 +1,36 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use log::{info, warn};
 use tauri::{AppHandle, Manager};
-use tokio::sync::Mutex;
 use tokio::time::{Instant, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 
+use crate::cloud_operation::CloudOperationState;
+
 const CONTROL_POLL_INTERVAL: Duration = Duration::from_secs(15);
 
-#[derive(Clone, Default)]
-pub struct SnapshotSyncRuntimeState {
-    operation_lock: Arc<Mutex<()>>,
-}
-
-impl SnapshotSyncRuntimeState {
-    pub fn operation_lock(&self) -> Arc<Mutex<()>> {
-        Arc::clone(&self.operation_lock)
-    }
-}
-
-pub fn setup(app: AppHandle, state: SnapshotSyncRuntimeState) {
+pub fn setup(app: AppHandle, state: CloudOperationState) {
     tauri::async_runtime::spawn(run(app, state));
 }
 
-async fn run(app: AppHandle, state: SnapshotSyncRuntimeState) {
+async fn run(app: AppHandle, state: CloudOperationState) {
     let cancellation = CancellationToken::new();
-    {
-        let _guard = state.operation_lock.lock().await;
-        match rgsm_core::services::resume_v2_snapshot_sync(&cancellation).await {
-            Ok(downloaded) if downloaded > 0 => info!(
-                target: "rgsm::cloud::v2_snapshot_sync",
-                "Resumed {downloaded} pending Snapshot downloads at startup"
-            ),
-            Ok(_) => {}
-            Err(error) => warn!(
-                target: "rgsm::cloud::v2_snapshot_sync",
-                "V2 Snapshot download recovery failed: {error}"
-            ),
-        }
-        run_reconciliation(&cancellation).await;
-    }
+    state
+        .run(async {
+            match rgsm_core::services::resume_v2_snapshot_sync(&cancellation).await {
+                Ok(downloaded) if downloaded > 0 => info!(
+                    target: "rgsm::cloud::v2_snapshot_sync",
+                    "Resumed {downloaded} pending Snapshot downloads at startup"
+                ),
+                Ok(_) => {}
+                Err(error) => warn!(
+                    target: "rgsm::cloud::v2_snapshot_sync",
+                    "V2 Snapshot download recovery failed: {error}"
+                ),
+            }
+            run_reconciliation(&cancellation).await;
+        })
+        .await;
 
     let mut last_run = Instant::now();
     let mut control_tick = tokio::time::interval(CONTROL_POLL_INTERVAL);
@@ -66,9 +56,12 @@ async fn run(app: AppHandle, state: SnapshotSyncRuntimeState) {
         if last_run.elapsed() < poll_interval {
             continue;
         }
-        let _guard = state.operation_lock.lock().await;
-        run_reconciliation(&cancellation).await;
-        run_live_save_apply(&app).await;
+        state
+            .run(async {
+                run_reconciliation(&cancellation).await;
+                run_live_save_apply(&app).await;
+            })
+            .await;
         last_run = Instant::now();
     }
 }

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -111,7 +111,6 @@ async function fetchCurrentDevice() {
 fetchCurrentDevice();
 
 const describe = ref('');
-let backup_button_time_limit = true; // 两次备份时间间隔1秒
 let backup_button_backup_limit = true; // 上次没备份好禁止再备份或读取
 let apply_button_apply_limit = true; // 上次未恢复好禁止读取或备份
 
@@ -487,10 +486,6 @@ ${items}`,
 }
 
 async function send_save_to_background() {
-  if (!backup_button_time_limit) {
-    notifyError($t('manage.save_too_fast_error'));
-    return;
-  }
   if (!backup_button_backup_limit) {
     notifyError($t('manage.last_backup_unfinished_error'));
     return;
@@ -505,7 +500,6 @@ async function send_save_to_background() {
     return;
   }
 
-  backup_button_time_limit = false;
   backup_button_backup_limit = false;
 
   const activityId = addActivity({
@@ -537,9 +531,6 @@ async function send_save_to_background() {
   refresh_backups_info();
 
   describe.value = '';
-  setTimeout(() => {
-    backup_button_time_limit = true;
-  }, 1000);
 }
 
 async function create_new_save() {


### PR DESCRIPTION
Third PR in the 1.9 release stack

Uses one application-level operation boundary for cloud library lifecycle actions, player-triggered V2 mutations, and background reconciliation

Removes the redundant post-backup cooldown while keeping the in-flight operation guard

Keeps provider concurrency and cross-device coordination unchanged