### PR TITLE
fix(backup): :bug: restore V2 archives after path migration

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -49,6 +49,7 @@ jobs:
           e2e/local-main-path.spec.ts
           e2e/local-compression.spec.ts
           e2e/local-legacy-archive.spec.ts
+          e2e/local-v1-8-upgrade.spec.ts
           e2e/local-failure-surface.spec.ts
           e2e/local-extra-backup.spec.ts
           e2e/local-restore-permissions.spec.ts

--- a/apps/rgsm-gui/e2e/local-v1-8-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/local-v1-8-upgrade.spec.ts
@@ -1,0 +1,297 @@
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+import AdmZip from 'adm-zip';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME } from './support/constants';
+import { openApp, openGame, snapshotRow } from './support/gui';
+import { listSnapshotsFor } from './support/local-gui';
+import {
+  createRunRoot,
+  hostPost,
+  newDeviceContext,
+  removeRunRoot,
+  startRgsmHost,
+  startTestWeb,
+  workspacePath,
+  type RgsmHost,
+} from './support/rgsm-instance';
+
+const RELEASED_DATE = '2025-01-02_03-04-05';
+const RELEASED_CONTENT = 'released-save-content';
+const RELEASED_REGISTRY_NAMED_FILE_CONTENT = 'ordinary-file-named-registry';
+
+type MigratedConfig = {
+  version: string;
+  games: Array<{
+    name: string;
+    save_paths: Array<{
+      id: number;
+      source: {
+        type: string;
+        pattern?: string;
+        expected_type?: string;
+        unit_type?: string;
+        paths?: Record<string, string>;
+      };
+    }>;
+    device_bindings?: Record<string, { rootIds?: number[] }>;
+  }>;
+  settings: Record<string, unknown>;
+  devices: Record<
+    string,
+    { resources: Array<{ id: number; kind: { type: string; path?: string } }> }
+  >;
+  [key: string]: unknown;
+};
+
+function normalizePath(path: string): string {
+  return path.replaceAll('\\', '/').replace(/\/$/, '').toLowerCase();
+}
+
+async function seedV1_8Scene(runRoot: string) {
+  const appDataDir = join(runRoot, 'app-data');
+  const archiveRoot = join(appDataDir, 'save_data');
+  const gameRoot = join(runRoot, 'game-root[legacy]');
+  const savePath = join(gameRoot, 'Saved', 'profile.sav');
+  const registryNamedFilePath = join(gameRoot, 'registry.reg');
+  const logPath = join(runRoot, 'host.log');
+  const configPath = workspacePath(
+    'crates',
+    'rgsm-core',
+    'tests',
+    'fixtures',
+    'config-upgrade',
+    'config_v1_8_0.json'
+  );
+  const config = JSON.parse(await readFile(configPath, 'utf8')) as Record<string, any>;
+  config.backup_path = archiveRoot.replaceAll('\\', '/');
+  config.games[0].name = GAME_NAME;
+  config.games[0].save_paths = [
+    {
+      id: 11,
+      unit_type: 'Folder',
+      paths: { [DEVICE_A_ID]: '<root>/Saved' },
+      delete_before_apply: true,
+    },
+    {
+      id: 12,
+      unit_type: 'File',
+      paths: { [DEVICE_A_ID]: registryNamedFilePath.replaceAll('\\', '/') },
+      delete_before_apply: true,
+    },
+  ];
+  config.games[0].game_paths = {
+    [DEVICE_A_ID]: join(gameRoot, 'game.exe').replaceAll('\\', '/'),
+  };
+  config.games[0].next_save_unit_id = 13;
+  config.settings.extra_backup_when_apply = false;
+  config.settings.confirm_before_apply_snapshot = false;
+  config.devices = {
+    [DEVICE_A_ID]: {
+      id: DEVICE_A_ID,
+      name: 'Upgrade device',
+      game_roots: [gameRoot.replaceAll('\\', '/')],
+    },
+  };
+
+  await mkdir(appDataDir, { recursive: true });
+  await writeFile(
+    join(appDataDir, 'GameSaveManager.config.json'),
+    `${JSON.stringify(config, null, 2)}\n`,
+    'utf8'
+  );
+  await mkdir(dirname(savePath), { recursive: true });
+  await writeFile(savePath, 'current-save', 'utf8');
+  await writeFile(registryNamedFilePath, 'current-ordinary-file', 'utf8');
+
+  const snapshotsDir = join(archiveRoot, GAME_NAME);
+  const releasedArchive = join(snapshotsDir, `${RELEASED_DATE}.zip`);
+  const zip = new AdmZip();
+  zip.addFile('11/Saved/profile.sav', Buffer.from(RELEASED_CONTENT, 'utf8'));
+  zip.addFile('12/registry.reg', Buffer.from(RELEASED_REGISTRY_NAMED_FILE_CONTENT, 'utf8'));
+  zip.addZipComment('RGSM_ARCHIVE_V2\n{"version":2,"compression":"zstd:3"}');
+  await mkdir(snapshotsDir, { recursive: true });
+  await writeFile(releasedArchive, zip.toBuffer());
+  await writeFile(
+    join(snapshotsDir, 'Backups.json'),
+    `${JSON.stringify(
+      {
+        name: GAME_NAME,
+        backups: [
+          {
+            date: RELEASED_DATE,
+            describe: 'Released 1.8 snapshot',
+            path: `save_data/${GAME_NAME}/${RELEASED_DATE}.zip`,
+            size: (await readFile(releasedArchive)).length,
+            device_id: DEVICE_A_ID,
+          },
+        ],
+        device_heads: { [DEVICE_A_ID]: RELEASED_DATE },
+        sync_version: 3,
+        last_sync_device: DEVICE_A_ID,
+      },
+      null,
+      2
+    )}\n`,
+    'utf8'
+  );
+
+  return {
+    appDataDir,
+    archiveRoot,
+    gameRoot,
+    savePath,
+    registryNamedFilePath,
+    logPath,
+    releasedArchive,
+  };
+}
+
+async function getMigratedConfig(host: RgsmHost, gameRoot: string): Promise<MigratedConfig> {
+  const result = await hostPost<MigratedConfig>(host, '/api/v1/get-local-config');
+  expect(result.ok, result.raw).toBe(true);
+  const config = result.data;
+  const root = config.devices[DEVICE_A_ID].resources.find(
+    (resource) =>
+      resource.kind.type === 'gameRoot' &&
+      resource.kind.path !== undefined &&
+      normalizePath(resource.kind.path) === normalizePath(gameRoot)
+  );
+  expect(root, 'the migrated 1.8 game root was not retained').toBeTruthy();
+  const game = config.games.find((candidate) => candidate.name === GAME_NAME);
+  expect(game).toBeTruthy();
+  expect(game!.device_bindings?.[DEVICE_A_ID]?.rootIds).toEqual([root!.id]);
+  return config;
+}
+
+async function applyAndExpectSave(
+  page: Page,
+  snapshotId: string,
+  expectations: Array<{ path: string; content: string }>
+): Promise<void> {
+  await snapshotRow(page, snapshotId).getByRole('button', { name: 'Apply' }).click();
+  await expect
+    .poll(
+      async () =>
+        Promise.all(
+          expectations.map(async ({ path }) => {
+            try {
+              return await readFile(path, 'utf8');
+            } catch {
+              // delete_before_apply intentionally leaves a short missing-target window.
+              return null;
+            }
+          })
+        ),
+      { timeout: 30_000 }
+    )
+    .toEqual(expectations.map(({ content }) => content));
+}
+
+test('1.8 dynamic and concrete save paths keep their V2 zip usable after the 1.9 upgrade', async ({
+  browser,
+}) => {
+  test.skip(process.platform !== 'win32', 'the released 1.8 upgrade contract targets Windows');
+
+  const runRoot = await createRunRoot('local-v1-8-upgrade');
+  const scene = await seedV1_8Scene(runRoot);
+  const originalArchive = await readFile(scene.releasedArchive);
+  const web = await startTestWeb();
+  let host: RgsmHost | undefined;
+  let context: BrowserContext | undefined;
+  try {
+    host = await startRgsmHost({
+      appDataDir: scene.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: scene.logPath,
+    });
+    const migrated = await getMigratedConfig(host, scene.gameRoot);
+    expect(migrated.version).toBe('1.9.0');
+    expect(migrated.games[0].save_paths).toEqual([
+      expect.objectContaining({
+        id: 11,
+        source: expect.objectContaining({
+          type: 'manifestPattern',
+          expected_type: 'Folder',
+          pattern: '<root>/Saved',
+        }),
+      }),
+      expect.objectContaining({
+        id: 12,
+        source: expect.objectContaining({
+          type: 'concrete',
+          unit_type: 'File',
+          paths: { [DEVICE_A_ID]: scene.registryNamedFilePath.replaceAll('\\', '/') },
+        }),
+      }),
+    ]);
+
+    ({ context } = await newDeviceContext(browser, host));
+    let page = context.pages()[0]!;
+    await openApp(page);
+    await openGame(page);
+    await expect(snapshotRow(page, RELEASED_DATE)).toContainText('Released 1.8 snapshot');
+
+    await applyAndExpectSave(page, RELEASED_DATE, [
+      { path: scene.savePath, content: RELEASED_CONTENT },
+      {
+        path: scene.registryNamedFilePath,
+        content: RELEASED_REGISTRY_NAMED_FILE_CONTENT,
+      },
+    ]);
+
+    await writeFile(scene.savePath, 'created-by-1.9', 'utf8');
+    await writeFile(scene.registryNamedFilePath, 'ordinary-file-created-by-1.9', 'utf8');
+    await page.getByPlaceholder('New backup description').fill('Created after upgrade');
+    await page.getByRole('button', { name: 'Create new snapshot' }).click();
+    await expect
+      .poll(async () => (await listSnapshotsFor(host!, GAME_NAME)).length, { timeout: 30_000 })
+      .toBe(2);
+    const created = (await listSnapshotsFor(host, GAME_NAME)).find(
+      (snapshot) => snapshot.describe === 'Created after upgrade'
+    );
+    expect(created).toBeTruthy();
+    expect(created!.date).not.toBe(RELEASED_DATE);
+    await expect(
+      readFile(join(scene.archiveRoot, GAME_NAME, `${created!.date}.7z`))
+    ).resolves.toBeTruthy();
+
+    await context.close();
+    context = undefined;
+    await host.stop();
+    host = await startRgsmHost({
+      appDataDir: scene.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: scene.logPath,
+    });
+    ({ context } = await newDeviceContext(browser, host));
+    page = context.pages()[0]!;
+    await openApp(page);
+    await openGame(page);
+    await expect(snapshotRow(page, RELEASED_DATE)).toBeVisible();
+    await expect(snapshotRow(page, created!.date)).toBeVisible();
+
+    await writeFile(scene.savePath, 'before-old-restore', 'utf8');
+    await writeFile(scene.registryNamedFilePath, 'ordinary-file-before-old-restore', 'utf8');
+    await applyAndExpectSave(page, RELEASED_DATE, [
+      { path: scene.savePath, content: RELEASED_CONTENT },
+      {
+        path: scene.registryNamedFilePath,
+        content: RELEASED_REGISTRY_NAMED_FILE_CONTENT,
+      },
+    ]);
+
+    await writeFile(scene.savePath, 'before-new-restore', 'utf8');
+    await writeFile(scene.registryNamedFilePath, 'ordinary-file-before-new-restore', 'utf8');
+    await applyAndExpectSave(page, created!.date, [
+      { path: scene.savePath, content: 'created-by-1.9' },
+      { path: scene.registryNamedFilePath, content: 'ordinary-file-created-by-1.9' },
+    ]);
+    expect(await readFile(scene.releasedArchive)).toEqual(originalArchive);
+  } finally {
+    await context?.close();
+    await host?.stop();
+    await web.stop();
+    await removeRunRoot(runRoot);
+  }
+});

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs",
+    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs",
     "web:e2e": "playwright test",
     "dev": "tauri dev -- --locked",
     "build": "tauri build",

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -1213,8 +1213,8 @@ export type SaveRestoreMappingRequest = {
 
 /**
  * A save unit declares one concrete per-Device location or one portable
- * Manifest Path Pattern. Dynamic patterns deliberately do not guess whether
- * their future matches will be files or directories.
+ * Manifest Path Pattern. A pattern preserves a known source kind when one was
+ * declared, while imported patterns may defer the kind to each resolved match.
  */
 export type SaveUnit = {
   delete_before_apply?: boolean;
@@ -1240,6 +1240,7 @@ export type SaveUnitSource =
     }
   | {
       constraints?: ManifestPathConstraints;
+      expected_type?: null | SaveUnitType;
       pattern: ManifestPathPattern;
       type: 'manifestPattern';
     };

--- a/apps/rgsm-gui/src/utils/saveUnit.test.mjs
+++ b/apps/rgsm-gui/src/utils/saveUnit.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { saveUnitType } from './saveUnit.ts';
+
+test('manifest save unit preserves a declared legacy type', () => {
+  assert.equal(
+    saveUnitType({
+      source: {
+        type: 'manifestPattern',
+        expected_type: 'Folder',
+        pattern: '<root>/Saved',
+        constraints: { alternatives: [] },
+      },
+    }),
+    'Folder'
+  );
+});
+
+test('untyped manifest save unit defers its kind to resolved locations', () => {
+  assert.equal(
+    saveUnitType({
+      source: {
+        type: 'manifestPattern',
+        pattern: '<home>/*.sav',
+        constraints: { alternatives: [] },
+      },
+    }),
+    undefined
+  );
+});

--- a/apps/rgsm-gui/src/utils/saveUnit.ts
+++ b/apps/rgsm-gui/src/utils/saveUnit.ts
@@ -34,7 +34,9 @@ export function saveUnitPaths(unit: Unit): Partial<Record<string, string>> | und
 }
 
 export function saveUnitType(unit: Unit): SaveUnitType | undefined {
-  return unit.source.type === 'concrete' ? unit.source.unit_type : undefined;
+  return unit.source.type === 'concrete'
+    ? unit.source.unit_type
+    : (unit.source.expected_type ?? undefined);
 }
 
 export function saveUnitPattern(unit: Unit): string | undefined {

--- a/crates/rgsm-core/src/backup/archive/decompress.rs
+++ b/crates/rgsm-core/src/backup/archive/decompress.rs
@@ -4,6 +4,7 @@
 //! V2 archives have index-prefixed entries that are mapped back to save units by stable ID.
 
 use std::{
+    collections::BTreeMap,
     fs::{self, File},
     io::Read,
     path::{Path, PathBuf},
@@ -37,8 +38,8 @@ pub trait RestoreNotifier: Send + Sync {
 }
 
 use super::{
-    ArchiveManifestV3, V3_MANIFEST_ENTRY, timestamp::zip_datetime_to_system_time,
-    version::ArchiveVersion,
+    ArchiveCaptureGroup, ArchiveManifestV3, V3_MANIFEST_ENTRY,
+    timestamp::zip_datetime_to_system_time, version::ArchiveVersion,
 };
 
 pub(super) fn archive_version(archive_path: &Path) -> Result<ArchiveVersion, CompressError> {
@@ -53,16 +54,93 @@ pub(super) fn read_capture_manifest(
     let file = File::open(archive_path).map_err(|error| CompressError::Single(error.into()))?;
     let mut zip =
         zip::ZipArchive::new(file).map_err(|error| CompressError::Single(error.into()))?;
-    if ArchiveVersion::from_comment(zip.comment()) != ArchiveVersion::V3 {
+    match ArchiveVersion::from_comment(zip.comment()) {
+        ArchiveVersion::V2 => read_v2_capture_manifest(&mut zip),
+        ArchiveVersion::V3 => serde_json::from_reader(
+            zip.by_name(V3_MANIFEST_ENTRY)
+                .map_err(|error| CompressError::Single(error.into()))?,
+        )
+        .map_err(|error| CompressError::Single(BackupFileError::Unexpected(error.into()))),
+        _ => Err(CompressError::Single(BackupFileError::Unexpected(
+            anyhow::anyhow!("capture manifest requested from an archive without save-unit IDs"),
+        ))),
+    }
+}
+
+fn read_v2_capture_manifest(
+    zip: &mut zip::ZipArchive<File>,
+) -> Result<ArchiveManifestV3, CompressError> {
+    #[derive(Default)]
+    struct LegacyGroup {
+        root: Option<String>,
+        directory: bool,
+    }
+
+    let mut units = BTreeMap::<u32, LegacyGroup>::new();
+    for index in 0..zip.len() {
+        let entry = zip
+            .by_index(index)
+            .map_err(|error| CompressError::Single(error.into()))?;
+        let Some(path) = entry.enclosed_name() else {
+            continue;
+        };
+        let mut components = path.components();
+        let Some(std::path::Component::Normal(unit)) = components.next() else {
+            continue;
+        };
+        let Some(std::path::Component::Normal(root)) = components.next() else {
+            continue;
+        };
+        let Some(unit) = unit.to_str().and_then(|value| value.parse::<u32>().ok()) else {
+            continue;
+        };
+        let root = root.to_string_lossy().into_owned();
+        let group = units.entry(unit).or_default();
+        if group
+            .root
+            .as_deref()
+            .is_some_and(|existing| existing != root)
+        {
+            return Err(CompressError::Single(BackupFileError::Unexpected(
+                anyhow::anyhow!("Archive V2 save unit {unit} contains multiple roots"),
+            )));
+        }
+        group.root = Some(root);
+        group.directory |= entry.is_dir() || components.next().is_some();
+    }
+
+    let groups = units
+        .into_iter()
+        .filter_map(|(save_unit_id, group)| {
+            let root = group.root?;
+            let kind = if root == crate::backup::registry::REGISTRY_DATA_FILENAME
+                || root == crate::backup::registry::LEGACY_REGISTRY_DATA_FILENAME
+            {
+                CaptureSourceKind::Registry
+            } else if group.directory {
+                CaptureSourceKind::Directory
+            } else {
+                CaptureSourceKind::File
+            };
+            Some(ArchiveCaptureGroup {
+                id: 0,
+                save_unit_id,
+                candidate_id: "legacy-v2".to_string(),
+                dimensions: Default::default(),
+                relative_path: String::new(),
+                archive_path: format!("{save_unit_id}/{root}"),
+                kind,
+                delete_before_apply: false,
+                source_path_diagnostic: None,
+            })
+        })
+        .collect::<Vec<_>>();
+    if groups.is_empty() {
         return Err(CompressError::Single(BackupFileError::Unexpected(
-            anyhow::anyhow!("capture manifest requested from a non-V3 archive"),
+            anyhow::anyhow!("Archive V2 contains no save-unit entries"),
         )));
     }
-    serde_json::from_reader(
-        zip.by_name(V3_MANIFEST_ENTRY)
-            .map_err(|error| CompressError::Single(error.into()))?,
-    )
-    .map_err(|error| CompressError::Single(BackupFileError::Unexpected(error.into())))
+    Ok(ArchiveManifestV3 { version: 2, groups })
 }
 
 pub(super) fn restore_capture_plan(
@@ -597,8 +675,105 @@ mod tests {
 
     use filetime::{FileTime, set_file_mtime};
 
-    use super::save_unit_label;
-    use crate::backup::{SaveUnit, SaveUnitType};
+    use super::{read_capture_manifest, save_unit_label};
+    use crate::backup::{CaptureSourceKind, SaveUnit, SaveUnitType};
+
+    #[test]
+    fn v2_entries_form_a_capture_manifest_without_config_state() {
+        use std::io::Write;
+
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("legacy-v2.zip");
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        writer.set_comment("RGSM_ARCHIVE_V2\n{\"version\":2,\"compression\":\"zip\"}");
+        let options = zip::write::SimpleFileOptions::default();
+        writer.start_file("7/Saved/profile.sav", options).unwrap();
+        writer.write_all(b"folder").unwrap();
+        writer.start_file("8/slot.sav", options).unwrap();
+        writer.write_all(b"file").unwrap();
+        writer.start_file("9/registry.reg", options).unwrap();
+        writer.write_all(b"registry").unwrap();
+        writer.finish().unwrap();
+
+        let manifest = read_capture_manifest(&archive).unwrap();
+
+        assert_eq!(manifest.version, 2);
+        assert_eq!(manifest.groups.len(), 3);
+        assert_eq!(manifest.groups[0].archive_path, "7/Saved");
+        assert_eq!(manifest.groups[0].kind, CaptureSourceKind::Directory);
+        assert_eq!(manifest.groups[1].kind, CaptureSourceKind::File);
+        assert_eq!(manifest.groups[2].kind, CaptureSourceKind::Registry);
+    }
+
+    #[test]
+    fn v2_manifest_rejects_multiple_roots_for_one_save_unit() {
+        use std::io::Write;
+
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("ambiguous-v2.zip");
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        writer.set_comment("RGSM_ARCHIVE_V2\n{\"version\":2,\"compression\":\"zip\"}");
+        let options = zip::write::SimpleFileOptions::default();
+        writer.start_file("7/a.sav", options).unwrap();
+        writer.write_all(b"a").unwrap();
+        writer.start_file("7/b.sav", options).unwrap();
+        writer.write_all(b"b").unwrap();
+        writer.finish().unwrap();
+
+        assert!(read_capture_manifest(&archive).is_err());
+    }
+
+    #[test]
+    fn v2_restore_decodes_escaped_literals_before_writing_target() {
+        use std::collections::BTreeMap;
+        use std::io::Write;
+
+        use crate::backup::{ArchiveBackend, RestorePlan, ZipBackend};
+        use crate::path_resolution::{
+            CandidateDimensions, CandidateExpression, ResolutionReport, ResolutionSelectionState,
+        };
+
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("legacy-v2.zip");
+        let target = temp.path().join("Games[Main]").join("Saved");
+        let mut writer = zip::ZipWriter::new(fs::File::create(&archive).unwrap());
+        writer.set_comment("RGSM_ARCHIVE_V2\n{\"version\":2,\"compression\":\"zip\"}");
+        writer
+            .start_file(
+                "7/Saved/profile.sav",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        writer.write_all(b"captured").unwrap();
+        writer.finish().unwrap();
+
+        let manifest = read_capture_manifest(&archive).unwrap();
+        let expression = globset::escape(&target.to_string_lossy().replace('\\', "/"));
+        let reports = BTreeMap::from([(
+            7,
+            ResolutionReport {
+                raw_pattern: "<root>/Saved".to_string(),
+                selection_state: ResolutionSelectionState::ImplicitUnique {
+                    candidate_id: "root".to_string(),
+                },
+                candidates: vec![CandidateExpression {
+                    id: "root".to_string(),
+                    expression,
+                    logical_anchor: target.parent().unwrap().to_string_lossy().into_owned(),
+                    dimensions: CandidateDimensions::default(),
+                    case_sensitive: false,
+                }],
+                locations: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+        )]);
+        let plan = RestorePlan::build_legacy_v2(&manifest.groups, &reports, &[]).unwrap();
+
+        ZipBackend.restore_capture_plan(&plan, &archive).unwrap();
+
+        assert_eq!(fs::read(target.join("profile.sav")).unwrap(), b"captured");
+        assert!(!temp.path().join("Games[[]Main[]]").exists());
+    }
 
     #[test]
     fn v3_restore_plan_extracts_only_approved_target() {
@@ -639,6 +814,7 @@ mod tests {
                 kind: CaptureSourceKind::File,
                 delete_before_apply: true,
             }],
+            skipped_inactive_save_unit_ids: Vec::new(),
         };
 
         ZipBackend.restore_capture_plan(&restore, &archive).unwrap();
@@ -667,6 +843,7 @@ mod tests {
                 kind: CaptureSourceKind::File,
                 delete_before_apply: true,
             }],
+            skipped_inactive_save_unit_ids: Vec::new(),
         };
 
         assert!(super::restore_capture_plan(&restore, &archive).is_err());
@@ -720,6 +897,7 @@ mod tests {
                         kind: CaptureSourceKind::Directory,
                         delete_before_apply: false,
                     }],
+                    skipped_inactive_save_unit_ids: Vec::new(),
                 },
                 &archive,
             )

--- a/crates/rgsm-core/src/backup/archive/seven_z_tests.rs
+++ b/crates/rgsm-core/src/backup/archive/seven_z_tests.rs
@@ -38,6 +38,7 @@ fn restore_plan(target: &Path, kind: CaptureSourceKind) -> RestorePlan {
             kind,
             delete_before_apply: false,
         }],
+        skipped_inactive_save_unit_ids: Vec::new(),
     }
 }
 
@@ -361,6 +362,7 @@ fn missing_planned_entry_is_rejected_before_target_deletion() {
             kind: CaptureSourceKind::File,
             delete_before_apply: true,
         }],
+        skipped_inactive_save_unit_ids: Vec::new(),
     };
 
     assert!(restore_capture_plan(&plan, &archive).is_err());

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -128,9 +128,14 @@ fn save_unit_identity(source: &crate::backup::SaveUnitSource) -> String {
             format!("concrete:{unit_type:?}|{paths_key}")
         }
         crate::backup::SaveUnitSource::ManifestPattern {
+            expected_type,
             pattern,
             constraints,
-        } => format!("manifest:{}|{:?}", pattern.raw(), constraints.alternatives),
+        } => format!(
+            "manifest:{expected_type:?}|{}|{:?}",
+            pattern.raw(),
+            constraints.alternatives
+        ),
     }
 }
 

--- a/crates/rgsm-core/src/backup/mod.rs
+++ b/crates/rgsm-core/src/backup/mod.rs
@@ -16,6 +16,7 @@ pub mod storage_key;
 mod tests;
 mod utils;
 
+pub(crate) use archive::ArchiveCaptureGroup;
 pub use archive::{
     ArchiveBackend, ArchiveVersion, CompressionPreset, RestoreNotificationLevel, RestoreNotifier,
     SevenZBackend, ZipBackend, archive_file_name, archive_path, remote_archive_path,

--- a/crates/rgsm-core/src/backup/restore_plan.rs
+++ b/crates/rgsm-core/src/backup/restore_plan.rs
@@ -21,6 +21,7 @@ pub struct RestoreEntry {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct RestorePlan {
     pub entries: Vec<RestoreEntry>,
+    pub skipped_inactive_save_unit_ids: Vec<u32>,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -37,6 +38,12 @@ pub enum RestorePlanError {
         group_id: u32,
         source_dimensions: crate::path_resolution::CandidateDimensions,
     },
+    #[error(
+        "legacy archive cannot restore wildcard save location for save unit {save_unit_id}, capture group {group_id}"
+    )]
+    LegacyWildcardTarget { save_unit_id: u32, group_id: u32 },
+    #[error("archive has no active target save units: {save_unit_ids:?}")]
+    NoActiveTargetSaveUnits { save_unit_ids: Vec<u32> },
 }
 
 impl RestorePlan {
@@ -46,46 +53,13 @@ impl RestorePlan {
         rules: &[RestoreMappingRule],
     ) -> Result<Self, RestorePlanError> {
         let mut entries = Vec::new();
+        let mut skipped = std::collections::BTreeSet::new();
         for group in groups {
             let Some(report) = reports.get(&group.save_unit_id) else {
+                skipped.insert(group.save_unit_id);
                 continue;
             };
-            let source_group_count = groups
-                .iter()
-                .filter(|candidate| candidate.save_unit_id == group.save_unit_id)
-                .count();
-            let candidates = report.candidates.as_slice();
-            let rule = rules.iter().find(|rule| {
-                rule.save_unit_id == group.save_unit_id
-                    && rule.source_dimensions == group.dimensions
-            });
-            let selected = if let Some(rule) = rule {
-                let selected = candidates
-                    .iter()
-                    .filter(|candidate| rule.target_candidate_ids.contains(&candidate.id))
-                    .collect::<Vec<_>>();
-                if selected.len() != rule.target_candidate_ids.len() {
-                    return Err(RestorePlanError::StaleMapping {
-                        save_unit_id: group.save_unit_id,
-                        group_id: group.id,
-                        source_dimensions: group.dimensions.clone(),
-                    });
-                }
-                selected
-            } else if let Some(equivalent) = candidates
-                .iter()
-                .find(|candidate| candidate.dimensions == group.dimensions)
-            {
-                vec![equivalent]
-            } else if candidates.len() == 1 && source_group_count == 1 {
-                vec![&candidates[0]]
-            } else {
-                return Err(RestorePlanError::MappingRequired {
-                    save_unit_id: group.save_unit_id,
-                    group_id: group.id,
-                    source_dimensions: group.dimensions.clone(),
-                });
-            };
+            let selected = selected_candidates(group, groups, report, rules)?;
             for candidate in selected {
                 entries.push(RestoreEntry {
                     save_unit_id: group.save_unit_id,
@@ -98,15 +72,113 @@ impl RestorePlan {
                 });
             }
         }
-        Ok(Self { entries })
+        finish_plan(entries, skipped)
     }
+
+    /// Build targets for Archive V2, whose ID-prefixed entries predate the
+    /// embedded capture manifest. Exact current candidates are authoritative;
+    /// wildcard patterns are rejected because V2 does not record which match
+    /// produced the archived save unit.
+    pub fn build_legacy_v2(
+        groups: &[ArchiveCaptureGroup],
+        reports: &BTreeMap<u32, ResolutionReport>,
+        rules: &[RestoreMappingRule],
+    ) -> Result<Self, RestorePlanError> {
+        let mut entries = Vec::new();
+        let mut skipped = std::collections::BTreeSet::new();
+        for group in groups {
+            let Some(report) = reports.get(&group.save_unit_id) else {
+                skipped.insert(group.save_unit_id);
+                continue;
+            };
+            let selected = selected_candidates(group, groups, report, rules)?;
+            for candidate in selected {
+                let Some(target_path) = candidate.exact_target_path() else {
+                    return Err(RestorePlanError::LegacyWildcardTarget {
+                        save_unit_id: group.save_unit_id,
+                        group_id: group.id,
+                    });
+                };
+                entries.push(RestoreEntry {
+                    save_unit_id: group.save_unit_id,
+                    group_id: group.id,
+                    archive_path: group.archive_path.clone(),
+                    target_path,
+                    kind: group.kind,
+                    delete_before_apply: group.delete_before_apply,
+                });
+            }
+        }
+        finish_plan(entries, skipped)
+    }
+}
+
+fn finish_plan(
+    entries: Vec<RestoreEntry>,
+    skipped: std::collections::BTreeSet<u32>,
+) -> Result<RestorePlan, RestorePlanError> {
+    let skipped_inactive_save_unit_ids = skipped.into_iter().collect::<Vec<_>>();
+    if entries.is_empty() && !skipped_inactive_save_unit_ids.is_empty() {
+        return Err(RestorePlanError::NoActiveTargetSaveUnits {
+            save_unit_ids: skipped_inactive_save_unit_ids,
+        });
+    }
+    Ok(RestorePlan {
+        entries,
+        skipped_inactive_save_unit_ids,
+    })
+}
+
+fn selected_candidates<'a>(
+    group: &ArchiveCaptureGroup,
+    groups: &[ArchiveCaptureGroup],
+    report: &'a ResolutionReport,
+    rules: &[RestoreMappingRule],
+) -> Result<Vec<&'a crate::path_resolution::CandidateExpression>, RestorePlanError> {
+    let source_group_count = groups
+        .iter()
+        .filter(|candidate| candidate.save_unit_id == group.save_unit_id)
+        .count();
+    let candidates = report.candidates.as_slice();
+    let rule = rules.iter().find(|rule| {
+        rule.save_unit_id == group.save_unit_id && rule.source_dimensions == group.dimensions
+    });
+    if let Some(rule) = rule {
+        let selected = candidates
+            .iter()
+            .filter(|candidate| rule.target_candidate_ids.contains(&candidate.id))
+            .collect::<Vec<_>>();
+        if selected.len() != rule.target_candidate_ids.len() {
+            return Err(RestorePlanError::StaleMapping {
+                save_unit_id: group.save_unit_id,
+                group_id: group.id,
+                source_dimensions: group.dimensions.clone(),
+            });
+        }
+        return Ok(selected);
+    }
+    if let Some(equivalent) = candidates
+        .iter()
+        .find(|candidate| candidate.dimensions == group.dimensions)
+    {
+        return Ok(vec![equivalent]);
+    }
+    if candidates.len() == 1 && source_group_count == 1 {
+        return Ok(vec![&candidates[0]]);
+    }
+    Err(RestorePlanError::MappingRequired {
+        save_unit_id: group.save_unit_id,
+        group_id: group.id,
+        source_dimensions: group.dimensions.clone(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::path_resolution::{
-        CandidateDimensions, CandidateExpression, ResolutionSelectionState,
+        CandidateDimensions, CandidateExpression, ResolutionSelectionState, ResolvedLocationKind,
+        ResolvedSaveLocation,
     };
 
     fn group() -> ArchiveCaptureGroup {
@@ -228,7 +300,93 @@ mod tests {
 
     #[test]
     fn archived_groups_without_an_active_save_unit_are_skipped() {
-        let plan = RestorePlan::build(&[group()], &BTreeMap::new(), &[]).unwrap();
-        assert!(plan.entries.is_empty());
+        assert_eq!(
+            RestorePlan::build(&[group()], &BTreeMap::new(), &[]).unwrap_err(),
+            RestorePlanError::NoActiveTargetSaveUnits {
+                save_unit_ids: vec![7]
+            }
+        );
+    }
+
+    #[test]
+    fn inactive_groups_are_reported_when_active_groups_can_restore() {
+        let reports = BTreeMap::from([(7, report(&[("a", "C:/A")]))]);
+        let mut inactive = group();
+        inactive.save_unit_id = 8;
+
+        let plan = RestorePlan::build(&[group(), inactive], &reports, &[]).unwrap();
+
+        assert_eq!(plan.entries.len(), 1);
+        assert_eq!(plan.skipped_inactive_save_unit_ids, vec![8]);
+    }
+
+    #[test]
+    fn legacy_v2_uses_exact_candidate_as_restore_target() {
+        let mut legacy = group();
+        legacy.archive_path = "7/Saved".to_string();
+        legacy.kind = CaptureSourceKind::Directory;
+        let reports = BTreeMap::from([(
+            7,
+            ResolutionReport {
+                raw_pattern: "<home>/Saved".to_string(),
+                selection_state: ResolutionSelectionState::ImplicitUnique {
+                    candidate_id: "home".to_string(),
+                },
+                candidates: vec![CandidateExpression {
+                    id: "home".to_string(),
+                    expression: "C:/Users/Player/Saved".to_string(),
+                    logical_anchor: "C:/Users/Player".to_string(),
+                    dimensions: CandidateDimensions::default(),
+                    case_sensitive: false,
+                }],
+                locations: Vec::new(),
+                diagnostics: Vec::new(),
+            },
+        )]);
+
+        let plan = RestorePlan::build_legacy_v2(&[legacy], &reports, &[]).unwrap();
+
+        assert_eq!(
+            plan.entries[0].target_path,
+            PathBuf::from("C:/Users/Player/Saved")
+        );
+    }
+
+    #[test]
+    fn legacy_v2_rejects_wildcard_target_even_when_it_currently_matches() {
+        let reports = BTreeMap::from([(
+            7,
+            ResolutionReport {
+                raw_pattern: "<home>/*.sav".to_string(),
+                selection_state: ResolutionSelectionState::ImplicitUnique {
+                    candidate_id: "home".to_string(),
+                },
+                candidates: vec![CandidateExpression {
+                    id: "home".to_string(),
+                    expression: "C:/Users/Player/*.sav".to_string(),
+                    logical_anchor: "C:/Users/Player".to_string(),
+                    dimensions: CandidateDimensions::default(),
+                    case_sensitive: false,
+                }],
+                locations: vec![ResolvedSaveLocation {
+                    candidate_id: "home".to_string(),
+                    path: "C:/Users/Player/slot.sav".to_string(),
+                    kind: ResolvedLocationKind::File,
+                    logical_anchor: "C:/Users/Player".to_string(),
+                    dimensions: CandidateDimensions::default(),
+                }],
+                diagnostics: Vec::new(),
+            },
+        )]);
+
+        let error = RestorePlan::build_legacy_v2(&[group()], &reports, &[]).unwrap_err();
+
+        assert!(matches!(
+            error,
+            RestorePlanError::LegacyWildcardTarget {
+                save_unit_id: 7,
+                ..
+            }
+        ));
     }
 }

--- a/crates/rgsm-core/src/backup/save_unit.rs
+++ b/crates/rgsm-core/src/backup/save_unit.rs
@@ -27,6 +27,11 @@ pub enum SaveUnitSource {
         paths: HashMap<DeviceId, String>,
     },
     ManifestPattern {
+        /// Optional kind declared by the source that introduced the pattern.
+        /// Legacy configurations always provide it; manifest imports may leave
+        /// it unresolved and rely on the matched filesystem entry instead.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_type: Option<SaveUnitType>,
         pattern: ManifestPathPattern,
         #[serde(default)]
         constraints: ManifestPathConstraints,
@@ -34,8 +39,8 @@ pub enum SaveUnitSource {
 }
 
 /// A save unit declares one concrete per-Device location or one portable
-/// Manifest Path Pattern. Dynamic patterns deliberately do not guess whether
-/// their future matches will be files or directories.
+/// Manifest Path Pattern. A pattern preserves a known source kind when one was
+/// declared, while imported patterns may defer the kind to each resolved match.
 #[derive(Debug, Serialize, Clone, Type, utoipa::ToSchema)]
 pub struct SaveUnit {
     #[serde(default)]
@@ -163,7 +168,7 @@ impl SaveUnit {
     pub fn unit_type(&self) -> Option<&SaveUnitType> {
         match &self.source {
             SaveUnitSource::Concrete { unit_type, .. } => Some(unit_type),
-            SaveUnitSource::ManifestPattern { .. } => None,
+            SaveUnitSource::ManifestPattern { expected_type, .. } => expected_type.as_ref(),
         }
     }
 
@@ -179,6 +184,7 @@ impl SaveUnit {
             SaveUnitSource::ManifestPattern {
                 pattern,
                 constraints,
+                ..
             } => Some((pattern, constraints)),
             SaveUnitSource::Concrete { .. } => None,
         }
@@ -266,10 +272,11 @@ mod tests {
     }
 
     #[test]
-    fn manifest_pattern_has_no_concrete_type_or_device_paths() {
+    fn manifest_pattern_preserves_declared_type_without_concrete_paths() {
         let unit = SaveUnit {
             id: 1,
             source: SaveUnitSource::ManifestPattern {
+                expected_type: Some(SaveUnitType::File),
                 pattern: ManifestPathPattern::new("<home>/*.sav"),
                 constraints: ManifestPathConstraints::default(),
             },
@@ -277,9 +284,18 @@ mod tests {
             enabled: true,
         };
 
-        assert!(unit.unit_type().is_none());
+        assert_eq!(unit.unit_type(), Some(&SaveUnitType::File));
         assert!(unit.paths().is_none());
         assert_eq!(unit.manifest_pattern().unwrap().0.raw(), "<home>/*.sav");
+
+        let serialized = serde_json::to_value(&unit).unwrap();
+        assert_eq!(
+            serialized.pointer("/source/expected_type"),
+            Some(&serde_json::json!("File"))
+        );
+
+        let round_trip: SaveUnit = serde_json::from_value(serialized).unwrap();
+        assert_eq!(round_trip.unit_type(), Some(&SaveUnitType::File));
     }
 
     #[test]

--- a/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/game_comparison.rs
@@ -131,6 +131,7 @@ mod tests {
                 SharedSaveUnit {
                     id: 2,
                     source: SharedSaveUnitSource::ManifestPattern {
+                        expected_type: None,
                         pattern: crate::path_pattern::ManifestPathPattern::new("<home>/save"),
                         constraints: ManifestPathConstraints {
                             alternatives: vec![

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -86,6 +86,8 @@ pub enum SharedSaveUnitSource {
         unit_type: SaveUnitType,
     },
     ManifestPattern {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        expected_type: Option<SaveUnitType>,
         pattern: ManifestPathPattern,
         constraints: ManifestPathConstraints,
     },
@@ -563,9 +565,11 @@ impl ConfigurationOwners {
                         }
                     }
                     SharedSaveUnitSource::ManifestPattern {
+                        expected_type,
                         pattern,
                         constraints,
                     } => SaveUnitSource::ManifestPattern {
+                        expected_type: expected_type.clone(),
                         pattern: pattern.clone(),
                         constraints: constraints.clone(),
                     },
@@ -715,9 +719,11 @@ impl From<&SaveUnit> for SharedSaveUnit {
                 unit_type: unit_type.clone(),
             },
             SaveUnitSource::ManifestPattern {
+                expected_type,
                 pattern,
                 constraints,
             } => SharedSaveUnitSource::ManifestPattern {
+                expected_type: expected_type.clone(),
                 pattern: pattern.clone(),
                 constraints: constraints.clone(),
             },

--- a/crates/rgsm-core/src/path_resolution/model.rs
+++ b/crates/rgsm-core/src/path_resolution/model.rs
@@ -108,6 +108,48 @@ pub struct CandidateExpression {
     pub case_sensitive: bool,
 }
 
+impl CandidateExpression {
+    pub fn is_exact(&self) -> bool {
+        first_unescaped_glob(&self.expression).is_none()
+    }
+
+    /// Return the concrete path represented by an exact candidate expression.
+    /// Glob escaping is an expression-level concern and must not leak into the
+    /// filesystem target used by restore operations.
+    pub fn exact_target_path(&self) -> Option<PathBuf> {
+        self.is_exact()
+            .then(|| PathBuf::from(unescape_glob_literal(&self.expression)))
+    }
+}
+
+pub(super) fn unescape_glob_literal(value: &str) -> String {
+    value
+        .replace("[[]", "[")
+        .replace("[]]", "]")
+        .replace("[*]", "*")
+        .replace("[?]", "?")
+}
+
+pub(super) fn first_unescaped_glob(expression: &str) -> Option<usize> {
+    let bytes = expression.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index..].starts_with(b"[[]")
+            || bytes[index..].starts_with(b"[]]")
+            || bytes[index..].starts_with(b"[*]")
+            || bytes[index..].starts_with(b"[?]")
+        {
+            index += 3;
+            continue;
+        }
+        if matches!(bytes[index], b'*' | b'?' | b'[') {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum ResolutionSelectionState {
@@ -202,4 +244,45 @@ pub struct ResolutionReport {
     pub candidates: Vec<CandidateExpression>,
     pub locations: Vec<ResolvedSaveLocation>,
     pub diagnostics: Vec<ResolutionDiagnostic>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(expression: &str, logical_anchor: &str) -> CandidateExpression {
+        CandidateExpression {
+            id: "candidate".to_string(),
+            expression: expression.to_string(),
+            logical_anchor: logical_anchor.to_string(),
+            dimensions: CandidateDimensions::default(),
+            case_sensitive: false,
+        }
+    }
+
+    #[test]
+    fn exactness_depends_on_unescaped_globs_not_the_logical_anchor() {
+        assert!(candidate("C:/Users/Player/Saved", "C:/Users/Player").is_exact());
+        assert!(!candidate("C:/Users/Player/*.sav", "C:/Users/Player").is_exact());
+    }
+
+    #[test]
+    fn exact_target_decodes_escaped_glob_literals() {
+        let exact = candidate("C:/Games[[]Main[]]/slot[*]-answer[?].sav", "C:/Games[Main]");
+
+        assert_eq!(
+            exact.exact_target_path(),
+            Some(PathBuf::from("C:/Games[Main]/slot*-answer?.sav"))
+        );
+        assert_eq!(
+            candidate("C:/Games/*.sav", "C:/Games").exact_target_path(),
+            None
+        );
+    }
+
+    #[test]
+    fn escaped_glob_characters_are_exact_path_literals() {
+        assert!(candidate("D:/Games[[]Main[]]/slot[*].sav", "D:/Games[Main]").is_exact());
+        assert!(!candidate("D:/Games[[]Main[]]/slot[0-9].sav", "D:/Games[Main]").is_exact());
+    }
 }

--- a/crates/rgsm-core/src/path_resolution/planner.rs
+++ b/crates/rgsm-core/src/path_resolution/planner.rs
@@ -5,6 +5,8 @@ use crate::path_pattern::{
     ManifestPathConstraints, ParsedManifestPathPattern, PathPlaceholder, PlatformKind,
 };
 
+use super::model::{first_unescaped_glob, unescape_glob_literal};
+
 use super::{
     CandidateDimensions, CandidateExpression, GameInstallationCandidate, GameRootCandidate,
     ResolutionContext, ResolutionDiagnostic, ResolutionDiagnosticKind, ResolutionPlan,
@@ -337,34 +339,6 @@ fn glob_logical_anchor(expression: &str) -> PathBuf {
         None => expression,
     };
     PathBuf::from(unescape_glob_literal(anchor))
-}
-
-fn first_unescaped_glob(expression: &str) -> Option<usize> {
-    let bytes = expression.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        if bytes[index..].starts_with(b"[[]")
-            || bytes[index..].starts_with(b"[]]")
-            || bytes[index..].starts_with(b"[*]")
-            || bytes[index..].starts_with(b"[?]")
-        {
-            index += 3;
-            continue;
-        }
-        if matches!(bytes[index], b'*' | b'?' | b'[') {
-            return Some(index);
-        }
-        index += 1;
-    }
-    None
-}
-
-fn unescape_glob_literal(value: &str) -> String {
-    value
-        .replace("[[]", "[")
-        .replace("[]]", "]")
-        .replace("[*]", "*")
-        .replace("[?]", "?")
 }
 
 fn replace_path(

--- a/crates/rgsm-core/src/services/path_resolution.rs
+++ b/crates/rgsm-core/src/services/path_resolution.rs
@@ -200,6 +200,7 @@ impl ServiceContext {
             SaveUnitSource::ManifestPattern {
                 pattern,
                 constraints,
+                ..
             } => {
                 let context = resolution_context(config, game, device_id);
                 let parsed = match parse_manifest_path_pattern(pattern.raw()) {
@@ -457,7 +458,7 @@ fn resolve_concrete(
         },
         candidates: vec![CandidateExpression {
             id: "concrete".to_string(),
-            expression: resolved.to_string_lossy().into_owned(),
+            expression: globset::escape(&resolved.to_string_lossy()),
             logical_anchor: source
                 .parent()
                 .unwrap_or(source)
@@ -553,6 +554,25 @@ mod concrete_tests {
             PathBuf::from(&report.locations[0].path),
             temp.path().join("save.dat")
         );
+    }
+
+    #[test]
+    fn concrete_candidate_escapes_glob_characters_but_keeps_the_literal_target() {
+        let temp = temp_dir::TempDir::new().unwrap();
+        let save = temp.path().join("Games[Main]").join("slot*.sav");
+        let path = save.to_string_lossy().into_owned();
+
+        let report = resolve_concrete(
+            Some(&path),
+            &SaveUnitType::File,
+            None,
+            ResolutionPurpose::Restore,
+        );
+
+        assert_eq!(report.candidates.len(), 1);
+        let candidate = &report.candidates[0];
+        assert!(candidate.is_exact());
+        assert_eq!(candidate.exact_target_path(), Some(save));
     }
 
     #[test]

--- a/crates/rgsm-core/src/services/snapshot.rs
+++ b/crates/rgsm-core/src/services/snapshot.rs
@@ -1,7 +1,8 @@
 use crate::backup::{
-    ArchiveBackend, ArchiveFormat, ArchiveVersion, CaptureSnapshotOptions, CreatedBy, Game,
-    GameSnapshots, RestoreNotificationLevel, RestoreNotifier, RestorePlan, SevenZBackend,
-    TimerSnapshotDecision, ZipBackend, archive_file_name, snapshot_archive_path,
+    ArchiveBackend, ArchiveCaptureGroup, ArchiveFormat, ArchiveVersion, CaptureSnapshotOptions,
+    CaptureSourceKind, CreatedBy, Game, GameSnapshots, RestoreNotificationLevel, RestoreNotifier,
+    RestorePlan, SaveUnit, SaveUnitType, SevenZBackend, TimerSnapshotDecision, ZipBackend,
+    archive_file_name, snapshot_archive_path,
 };
 use crate::config::{get_backup_path, get_config, resolve_backup_path};
 use crate::hooks::{
@@ -206,26 +207,38 @@ impl ServiceContext {
             .await?;
 
         let snapshots = if snapshot.archive_format == ArchiveFormat::SevenZ {
-            self.restore_capture_archive(&config, game, &archive_path, &SevenZBackend)?;
-            let mut snapshots = game.get_game_snapshots_info()?;
-            snapshots.set_current_device_head(Some(date.to_string()));
-            game.set_game_snapshots_info(&snapshots)?;
-            snapshots
-        } else if ZipBackend.archive_version(&archive_path)? == ArchiveVersion::V3 {
-            self.restore_capture_archive(&config, game, &archive_path, &ZipBackend)?;
+            self.restore_capture_archive(&config, game, &archive_path, &SevenZBackend, notifier)?;
             let mut snapshots = game.get_game_snapshots_info()?;
             snapshots.set_current_device_head(Some(date.to_string()));
             game.set_game_snapshots_info(&snapshots)?;
             snapshots
         } else {
-            let device = config.devices.get(crate::device::get_current_device_id());
-            let path_context = game.path_context(device);
-            game.restore_snapshot_with_context(
-                date,
-                notifier,
-                &resolve_backup_path(&config.backup_path),
-                &path_context,
-            )?
+            match ZipBackend.archive_version(&archive_path)? {
+                ArchiveVersion::V2 | ArchiveVersion::V3 => {
+                    self.restore_capture_archive(
+                        &config,
+                        game,
+                        &archive_path,
+                        &ZipBackend,
+                        notifier,
+                    )?;
+                    let mut snapshots = game.get_game_snapshots_info()?;
+                    snapshots.set_current_device_head(Some(date.to_string()));
+                    game.set_game_snapshots_info(&snapshots)?;
+                    snapshots
+                }
+                ArchiveVersion::Legacy | ArchiveVersion::V1 => {
+                    let device = config.devices.get(crate::device::get_current_device_id());
+                    let path_context = game.path_context(device);
+                    game.restore_snapshot_with_context(
+                        date,
+                        notifier,
+                        &resolve_backup_path(&config.backup_path),
+                        &path_context,
+                    )?
+                }
+                ArchiveVersion::V4 => unreachable!("Archive V4 uses the 7z backend"),
+            }
         };
 
         self.pipeline()
@@ -256,18 +269,28 @@ impl ServiceContext {
             folder.join(archive_file_name(date, ArchiveFormat::Zip))
         };
         if archive_path.extension().and_then(|value| value.to_str()) == Some("7z") {
-            self.restore_capture_archive(&config, game, &archive_path, &SevenZBackend)
-        } else if ZipBackend.archive_version(&archive_path)? == ArchiveVersion::V3 {
-            self.restore_capture_archive(&config, game, &archive_path, &ZipBackend)
+            self.restore_capture_archive(&config, game, &archive_path, &SevenZBackend, notifier)
         } else {
-            let device = config.devices.get(crate::device::get_current_device_id());
-            ZipBackend.decompress(
-                &game.save_paths,
-                &archive_path,
-                notifier,
-                Some(&game.path_context(device)),
-            )?;
-            Ok(())
+            match ZipBackend.archive_version(&archive_path)? {
+                ArchiveVersion::V2 | ArchiveVersion::V3 => self.restore_capture_archive(
+                    &config,
+                    game,
+                    &archive_path,
+                    &ZipBackend,
+                    notifier,
+                ),
+                ArchiveVersion::Legacy | ArchiveVersion::V1 => {
+                    let device = config.devices.get(crate::device::get_current_device_id());
+                    ZipBackend.decompress(
+                        &game.save_paths,
+                        &archive_path,
+                        notifier,
+                        Some(&game.path_context(device)),
+                    )?;
+                    Ok(())
+                }
+                ArchiveVersion::V4 => unreachable!("Archive V4 uses the 7z backend"),
+            }
         }
     }
 
@@ -277,8 +300,12 @@ impl ServiceContext {
         game: &Game,
         archive_path: &std::path::Path,
         backend: &dyn ArchiveBackend,
+        notifier: Option<&dyn RestoreNotifier>,
     ) -> Result<(), BackupError> {
-        let manifest = backend.read_capture_manifest(archive_path)?;
+        let mut manifest = backend.read_capture_manifest(archive_path)?;
+        if manifest.version == 2 {
+            apply_legacy_v2_save_unit_metadata(&mut manifest.groups, &game.save_paths);
+        }
         let reports = game
             .save_paths
             .iter()
@@ -295,7 +322,25 @@ impl ServiceContext {
             .get(crate::device::get_current_device_id())
             .map(|binding| binding.restore_mappings.as_slice())
             .unwrap_or_default();
-        let plan = RestorePlan::build(&manifest.groups, &reports, rules)?;
+        let plan = if manifest.version == 2 {
+            RestorePlan::build_legacy_v2(&manifest.groups, &reports, rules)?
+        } else {
+            RestorePlan::build(&manifest.groups, &reports, rules)?
+        };
+        if let Some(notifier) = notifier {
+            for save_unit_id in &plan.skipped_inactive_save_unit_ids {
+                notifier.notify(
+                    RestoreNotificationLevel::Warning,
+                    rust_i18n::t!("backend.archive.restore_skipped_title").as_ref(),
+                    rust_i18n::t!(
+                        "backend.archive.restore_unit_skipped",
+                        unit = save_unit_id,
+                        reason = rust_i18n::t!("backend.archive.skip_reason_inactive_save_unit")
+                    )
+                    .as_ref(),
+                );
+            }
+        }
         backend.restore_capture_plan(&plan, archive_path)?;
         Ok(())
     }
@@ -519,9 +564,46 @@ fn retain_first_error(first_error: &mut Option<BackupError>, result: Result<(), 
     }
 }
 
+/// Archive V2 stores stable save-unit IDs but no type metadata. Its entry
+/// shape is only a fallback for dynamic patterns; concrete save units retain
+/// their declared type as the restore authority.
+fn apply_legacy_v2_save_unit_metadata(groups: &mut [ArchiveCaptureGroup], units: &[SaveUnit]) {
+    for group in groups {
+        let Some(unit) = units.iter().find(|unit| unit.id == group.save_unit_id) else {
+            continue;
+        };
+        group.delete_before_apply = unit.delete_before_apply;
+        group.kind = match unit.unit_type() {
+            Some(SaveUnitType::File) => CaptureSourceKind::File,
+            Some(SaveUnitType::Folder) => CaptureSourceKind::Directory,
+            Some(SaveUnitType::WinRegistry) => CaptureSourceKind::Registry,
+            None => group.kind,
+        };
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::backup::SaveUnitSource;
+    use crate::path_pattern::{ManifestPathConstraints, ManifestPathPattern};
+    use crate::path_resolution::CandidateDimensions;
+
+    fn legacy_v2_group(kind: CaptureSourceKind) -> ArchiveCaptureGroup {
+        ArchiveCaptureGroup {
+            id: 0,
+            save_unit_id: 12,
+            candidate_id: "legacy-v2".to_string(),
+            dimensions: CandidateDimensions::default(),
+            relative_path: String::new(),
+            archive_path: "12/registry.reg".to_string(),
+            kind,
+            delete_before_apply: false,
+            source_path_diagnostic: None,
+        }
+    }
 
     #[test]
     fn batch_error_state_retains_the_first_failure() {
@@ -531,5 +613,62 @@ mod tests {
         retain_first_error(&mut first_error, Err(BackupError::NoBackupAvailable));
 
         assert!(matches!(first_error, Some(BackupError::NoDataMatched)));
+    }
+
+    #[test]
+    fn legacy_v2_concrete_type_overrides_archive_filename_inference() {
+        let mut groups = vec![legacy_v2_group(CaptureSourceKind::Registry)];
+        let units = vec![SaveUnit::concrete(
+            12,
+            SaveUnitType::File,
+            HashMap::new(),
+            true,
+            true,
+        )];
+
+        apply_legacy_v2_save_unit_metadata(&mut groups, &units);
+
+        assert_eq!(groups[0].kind, CaptureSourceKind::File);
+        assert!(groups[0].delete_before_apply);
+    }
+
+    #[test]
+    fn legacy_v2_dynamic_pattern_keeps_archive_shape_inference() {
+        let mut groups = vec![legacy_v2_group(CaptureSourceKind::Directory)];
+        let units = vec![SaveUnit {
+            id: 12,
+            source: SaveUnitSource::ManifestPattern {
+                expected_type: None,
+                pattern: ManifestPathPattern::new("<home>/Saves/*"),
+                constraints: ManifestPathConstraints::default(),
+            },
+            delete_before_apply: true,
+            enabled: true,
+        }];
+
+        apply_legacy_v2_save_unit_metadata(&mut groups, &units);
+
+        assert_eq!(groups[0].kind, CaptureSourceKind::Directory);
+        assert!(groups[0].delete_before_apply);
+    }
+
+    #[test]
+    fn legacy_v2_typed_pattern_preserves_declared_folder_kind() {
+        let mut groups = vec![legacy_v2_group(CaptureSourceKind::File)];
+        let units = vec![SaveUnit {
+            id: 12,
+            source: SaveUnitSource::ManifestPattern {
+                expected_type: Some(SaveUnitType::Folder),
+                pattern: ManifestPathPattern::new("<root>/Saved"),
+                constraints: ManifestPathConstraints::default(),
+            },
+            delete_before_apply: true,
+            enabled: true,
+        }];
+
+        apply_legacy_v2_save_unit_metadata(&mut groups, &units);
+
+        assert_eq!(groups[0].kind, CaptureSourceKind::Directory);
+        assert!(groups[0].delete_before_apply);
     }
 }

--- a/crates/rgsm-core/src/updater/migration.rs
+++ b/crates/rgsm-core/src/updater/migration.rs
@@ -224,19 +224,67 @@ fn migrate_path_resource_schema(
                     {
                         continue;
                     }
-                    let SaveUnitSource::Concrete { paths, .. } = &unit.source else {
+                    let SaveUnitSource::Concrete { unit_type, paths } = &unit.source else {
                         continue;
                     };
+                    let expected_type = unit_type.clone();
                     let unique_paths = paths.values().collect::<std::collections::BTreeSet<_>>();
                     let patterns = unique_paths.into_iter().collect::<Vec<_>>();
                     if let [raw_pattern] = patterns.as_slice()
                         && is_dynamic_manifest_path(raw_pattern)
                     {
                         unit.source = SaveUnitSource::ManifestPattern {
+                            expected_type: Some(expected_type),
                             pattern: ManifestPathPattern::new((*raw_pattern).clone()),
                             constraints: ManifestPathConstraints::default(),
                         };
                     }
+                }
+
+                let root_devices = raw_units
+                    .iter()
+                    .filter_map(|unit| unit.get("paths").and_then(Value::as_object))
+                    .flat_map(|paths| paths.iter())
+                    .filter(|(_, path)| {
+                        path.as_str()
+                            .is_some_and(|path| path.to_ascii_lowercase().contains("<root>"))
+                    })
+                    .map(|(device_id, _)| device_id)
+                    .collect::<std::collections::BTreeSet<_>>();
+                for device_id in root_devices {
+                    let unique_legacy_root = raw
+                        .get("devices")
+                        .and_then(Value::as_object)
+                        .and_then(|devices| devices.get(device_id))
+                        .and_then(|device| device.get("game_roots"))
+                        .and_then(Value::as_array)
+                        .and_then(|roots| match roots.as_slice() {
+                            [root] => root.as_str(),
+                            _ => None,
+                        });
+                    let Some(root_id) = unique_legacy_root.and_then(|legacy_root| {
+                        devices.get(device_id).and_then(|device| {
+                            device
+                                .resources
+                                .iter()
+                                .find_map(|resource| match &resource.kind {
+                                    DeviceResourceKind::GameRoot { path, .. }
+                                        if normalized_path_identity(path)
+                                            == normalized_path_identity(legacy_root) =>
+                                    {
+                                        Some(resource.id)
+                                    }
+                                    _ => None,
+                                })
+                        })
+                    }) else {
+                        continue;
+                    };
+                    let binding = game
+                        .device_bindings
+                        .entry(device_id.clone())
+                        .or_insert_with(GameDeviceBinding::default);
+                    binding.root_ids.get_or_insert_with(|| vec![root_id]);
                 }
             }
 
@@ -1150,6 +1198,61 @@ mod tests {
             config.devices["device"].resources[0].kind,
             DeviceResourceKind::GameRoot {
                 store: StoreKind::Steam,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn multiple_legacy_roots_remain_unbound_for_explicit_player_selection() {
+        let device_id = "device".to_string();
+        let mut config = Config::default();
+        config.devices.insert(
+            device_id.clone(),
+            Device {
+                id: device_id.clone(),
+                name: "Test".to_string(),
+                resources: Vec::new(),
+                next_resource_id: 0,
+            },
+        );
+        config.games.push(crate::backup::Game {
+            name: "Legacy".to_string(),
+            storage_key: "legacy".to_string(),
+            save_paths: vec![SaveUnit::concrete(
+                7,
+                SaveUnitType::Folder,
+                std::collections::HashMap::from([(device_id.clone(), "<root>/Saved".to_string())]),
+                false,
+                true,
+            )],
+            game_paths: Default::default(),
+            next_save_unit_id: 8,
+            cloud_sync_enabled: false,
+            auto_backup: None,
+            ludusavi_meta: None,
+            device_bindings: Default::default(),
+        });
+        let raw = serde_json::json!({
+            "devices": {
+                "device": { "game_roots": ["D:/Games", "E:/Games"] }
+            },
+            "games": [{
+                "save_paths": [{
+                    "id": 7,
+                    "unit_type": "Folder",
+                    "paths": { "device": "<root>/Saved" }
+                }]
+            }]
+        });
+
+        migrate_path_resource_schema(&raw.to_string(), &mut config, &device_id, &[]).unwrap();
+
+        assert!(!config.games[0].device_bindings.contains_key(&device_id));
+        assert!(matches!(
+            config.games[0].save_paths[0].source,
+            SaveUnitSource::ManifestPattern {
+                expected_type: Some(SaveUnitType::Folder),
                 ..
             }
         ));

--- a/crates/rgsm-core/tests/config_upgrade_compatibility.rs
+++ b/crates/rgsm-core/tests/config_upgrade_compatibility.rs
@@ -4,20 +4,23 @@
 //! between `MIN_SUPPORTED_VERSION` and the latest release tag. Releases that serialize the
 //! same shape share a fixture; unreleased schemas do not define compatibility promises.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::Write;
+use std::sync::Arc;
 
 use serde_json::Value;
 use zip::{ZipWriter, write::SimpleFileOptions};
 
 use rgsm_core::backup::{
-    ArchiveBackend, ArchiveFormat, CreatedBy, GameSnapshots, SaveUnit, SaveUnitSource,
+    ArchiveBackend, ArchiveFormat, CreatedBy, GameSnapshots, RestorePlan, SaveUnit, SaveUnitSource,
     SaveUnitType, ZipBackend,
 };
 use rgsm_core::config::Config;
 use rgsm_core::device::get_current_device_id;
+use rgsm_core::hooks::HookPipeline;
 use rgsm_core::preclude::UpdaterError;
+use rgsm_core::services::ServiceContext;
 use rgsm_core::updater::migration::update_config;
 use rgsm_core::updater::versions::{CURRENT_VERSION, MIN_SUPPORTED_VERSION};
 
@@ -452,5 +455,67 @@ fn direct_upgrade_contract_rejects_versions_outside_the_supported_range()
         update_config(&config_path).unwrap_err(),
         UpdaterError::Deserialize(_)
     ));
+    Ok(())
+}
+
+#[test]
+fn dynamic_v1_8_folder_restores_its_v2_archive_after_upgrade()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = temp_dir::TempDir::new()?;
+    let config_path = temp.path().join("GameSaveManager.config.json");
+    let backup_path = temp.path().join("save_data");
+    let game_root = temp.path().join("game-root[legacy]");
+    let target = game_root.join("Saved");
+    fs::create_dir_all(&target)?;
+    fs::write(target.join("profile.sav"), b"current-save")?;
+
+    let device_id = get_current_device_id().clone();
+    let mut raw: Value = serde_json::from_str(STABLE_SAVE_UNIT_IDS)?;
+    raw["backup_path"] = Value::String(backup_path.to_string_lossy().into_owned());
+    raw["games"][0]["save_paths"][1]["paths"] =
+        serde_json::json!({(device_id.clone()): "<root>/Saved"});
+    raw["games"][0]["game_paths"] = serde_json::json!({
+        (device_id.clone()): game_root.join("game.exe").to_string_lossy()
+    });
+    raw["devices"] = serde_json::json!({
+        (device_id.clone()): {
+            "id": device_id,
+            "name": "Upgrade device",
+            "game_roots": [game_root.to_string_lossy()]
+        }
+    });
+
+    let game_name = raw["games"][0]["name"].as_str().unwrap();
+    seed_released_save_data(
+        &backup_path,
+        game_name,
+        ReleasedSaveData::V1_8IdPrefixedFolder,
+    )?;
+    fs::write(&config_path, serde_json::to_vec_pretty(&raw)?)?;
+    assert!(update_config(&config_path)?);
+
+    let config: Config = serde_json::from_slice(&fs::read(&config_path)?)?;
+    let game = &config.games[0];
+    let unit = &game.save_paths[1];
+    assert!(matches!(
+        unit.source,
+        SaveUnitSource::ManifestPattern {
+            expected_type: Some(SaveUnitType::Folder),
+            ..
+        }
+    ));
+
+    let service = ServiceContext::new(Arc::new(HookPipeline::new(vec![])));
+    let reports = BTreeMap::from([(unit.id, service.resolve_save_unit(&config, game, unit))]);
+    let archive = backup_path
+        .join(game.backup_dir_name().as_ref())
+        .join(format!("{RELEASED_SNAPSHOT_DATE}.zip"));
+    let mut manifest = ZipBackend.read_capture_manifest(&archive)?;
+    manifest.groups[0].delete_before_apply = unit.delete_before_apply;
+    let plan = RestorePlan::build_legacy_v2(&manifest.groups, &reports, &[])?;
+
+    ZipBackend.restore_capture_plan(&plan, &archive)?;
+
+    assert_eq!(fs::read(target.join("profile.sav"))?, RELEASED_SAVE_CONTENT);
     Ok(())
 }

--- a/docs/adr/0005-require-selection-for-multiple-migrated-roots.md
+++ b/docs/adr/0005-require-selection-for-multiple-migrated-roots.md
@@ -2,8 +2,10 @@
 
 Status: accepted
 
-Legacy game roots migrate into typed Device Resources, but the old resolver's
-implicit use of the first root is not promoted to an explicit Game Device
-Binding. One applicable root remains implicitly unique; multiple roots become
-ambiguous and require the player to choose. This may pause an existing automatic
-backup, but avoids preserving a path the player never explicitly confirmed.
+Legacy game roots migrate into typed Device Resources. When a legacy pattern
+uses `<root>` and its Device declared exactly one game root, migration preserves
+that uniquely implied choice as a Game Device Binding so later auto-detected
+resources cannot make the upgraded path ambiguous. Multiple legacy roots remain
+ambiguous and require the player to choose; the old resolver's implicit use of
+the first root is never promoted. This may pause an existing automatic backup,
+but avoids preserving a path the player never explicitly confirmed.

--- a/docs/adr/0007-preserve-save-unit-type-across-source-migration.md
+++ b/docs/adr/0007-preserve-save-unit-type-across-source-migration.md
@@ -1,0 +1,11 @@
+# Preserve Save Unit type across source migration
+
+Status: accepted
+
+A Save Unit's declared file, folder, or registry type remains independent from
+whether its location is concrete or expressed as a portable Manifest Path
+Pattern. Migrating a legacy concrete path to a pattern preserves the known type;
+manifest imports that provide no type may defer to the kind of each resolved
+location. Dropping the declared type was rejected because Archive V2 restoration
+then has to infer semantics from entry names and shapes that were never intended
+to replace the configuration's type authority.

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -1147,6 +1147,7 @@
             "restore_unit_skipped": "Save unit \"%{unit}\" was skipped: %{reason}",
             "skip_reason_legacy_format": "archive predates the index-prefix format",
             "skip_reason_missing_entry": "not found in archive",
+            "skip_reason_inactive_save_unit": "the save unit is disabled or no longer configured",
             "skip_reason_unsupported_platform": "registry operations not supported on this platform"
         }
     },

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -1147,6 +1147,7 @@
             "restore_unit_skipped": "存档单元「%{unit}」已跳过：%{reason}",
             "skip_reason_legacy_format": "存档格式早于索引前缀格式",
             "skip_reason_missing_entry": "在存档中未找到",
+            "skip_reason_inactive_save_unit": "该存档单元已禁用或不再存在于当前配置中",
             "skip_reason_unsupported_platform": "当前平台不支持注册表操作"
         }
     },


### PR DESCRIPTION
Preserves released 1.8 save-unit type and unique root bindings during migration, then reconstructs V2 archive groups and restores exact targets through the current resolver. Escaped path literals are decoded before extraction; unsafe wildcard targets and missing or inactive groups fail or surface explicitly.

Covers a real 1.8 V2 ZIP upgrade without post-migration edits.