### PR TITLE
fix(gui): :bug: unify snapshot availability

### DIFF
--- a/apps/rgsm-gui/e2e/local-main-path.spec.ts
+++ b/apps/rgsm-gui/e2e/local-main-path.spec.ts
@@ -46,8 +46,10 @@ test('main path: create, apply latest, apply old snapshot, confirmations, delete
       .poll(async () => (await listSnapshotsFor(host, GAME_NAME)).length, { timeout: 30_000 })
       .toBe(1);
     const firstId = (await listSnapshotsFor(host, GAME_NAME))[0]!.date;
+    const firstRow = page.getByRole('row').filter({ hasText: firstId });
     expect((await snapshotMeta(device.appDataDir, firstId)).describe).toBe('');
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, firstId);
+    await expect(firstRow.getByText('This device', { exact: true })).toBeVisible();
 
     // Second snapshot with a description, over newer save content.
     await writeSaveText(device.savePath, CONTENT_V2);
@@ -79,7 +81,6 @@ test('main path: create, apply latest, apply old snapshot, confirmations, delete
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, secondId);
 
     // In-row Apply on an older snapshot restores that exact content.
-    const firstRow = page.getByRole('row').filter({ hasText: firstId });
     await firstRow.getByRole('button', { name: 'Apply' }).click();
     await confirmDialog.getByRole('button', { name: 'Cancel' }).click();
     expect(await readFile(device.savePath, 'utf8')).toBe(CONTENT_V2);

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs",
+    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/components/management/snapshotAvailability.test.mjs",
     "web:e2e": "playwright test",
     "dev": "tauri dev -- --locked",
     "build": "tauri build",

--- a/apps/rgsm-gui/src/api/generated/index.ts
+++ b/apps/rgsm-gui/src/api/generated/index.ts
@@ -443,6 +443,7 @@ export type {
   ListRunningProcessesResponse,
   ListRunningProcessesResponses,
   LiveSaveSyncOptions,
+  LocalArchiveEvidence,
   LocalProgressView,
   LudusaviManifestStatus,
   LudusaviMeta,

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -192,7 +192,7 @@ export type CloudArchiveSnapshotView = {
   cloud_verified: boolean;
   created_by: CreatedBy;
   description: string;
-  local_verified: boolean;
+  local_evidence: LocalArchiveEvidence;
   parent?: string | null;
   reported_on_devices: Array<String>;
   retention_protected: boolean;
@@ -780,6 +780,13 @@ export type LiveSaveSyncOptions = {
   process_name: string;
   snapshot_on_exit: boolean;
 };
+
+/**
+ * Evidence available while building the cloud catalog view of a local archive.
+ * This intentionally does not claim content verification: catalog views use a
+ * cheap metadata check, while transfer operations perform the full hash check.
+ */
+export type LocalArchiveEvidence = 'unknown' | 'present' | 'mismatch';
 
 export type LocalProgressView = {
   cloud_available: boolean;

--- a/apps/rgsm-gui/src/components/CloudArchivePanel.vue
+++ b/apps/rgsm-gui/src/components/CloudArchivePanel.vue
@@ -18,7 +18,7 @@ const materializing = ref(false);
 
 const allSnapshots = computed(() => library.value?.games.flatMap((game) => game.snapshots) ?? []);
 const localSnapshots = computed(
-  () => allSnapshots.value.filter((snapshot) => snapshot.local_verified).length
+  () => allSnapshots.value.filter((snapshot) => snapshot.local_evidence === 'present').length
 );
 const cloudSnapshots = computed(
   () => allSnapshots.value.filter((snapshot) => snapshot.cloud_verified).length

--- a/apps/rgsm-gui/src/components/management/SnapshotTable.vue
+++ b/apps/rgsm-gui/src/components/management/SnapshotTable.vue
@@ -26,7 +26,7 @@ import {
   isRetentionProtectedDate,
   isSnapshotInCloud,
   isSnapshotOnDevice,
-  snapshotLocationLabel,
+  snapshotLocationKey,
 } from './snapshotAvailability';
 
 const props = defineProps<{
@@ -97,16 +97,22 @@ function isAutomaticSnapshot(snapshot: Snapshot): boolean {
   );
 }
 
-const isOnDevice = (date: string) => isSnapshotOnDevice(props.cloudGame, date);
-const isInCloud = (date: string) => isSnapshotInCloud(props.cloudGame, date);
-const canUpload = (date: string) => canUploadSnapshot(props.cloudGame, date);
-const canDownload = (date: string) => canDownloadSnapshot(props.cloudGame, date);
-const canEvict = (date: string) => canEvictSnapshot(props.cloudGame, date);
-const canEvictCloud = (date: string) => canEvictCloudSnapshot(props.cloudGame, date);
+const isOnDevice = (date: string) =>
+  isSnapshotOnDevice(props.localCatalogDates, props.cloudGame, date);
+const isInCloud = (date: string) =>
+  isSnapshotInCloud(props.localCatalogDates, props.cloudGame, date);
+const canUpload = (date: string) =>
+  canUploadSnapshot(props.localCatalogDates, props.cloudGame, date);
+const canDownload = (date: string) =>
+  canDownloadSnapshot(props.localCatalogDates, props.cloudGame, date);
+const canEvict = (date: string) => canEvictSnapshot(props.localCatalogDates, props.cloudGame, date);
+const canEvictCloud = (date: string) =>
+  canEvictCloudSnapshot(props.localCatalogDates, props.cloudGame, date);
 const canApply = (date: string) => canApplySnapshot(props.localCatalogDates, props.cloudGame, date);
 const isProtected = (date: string) =>
   isRetentionProtectedDate(props.retentionProtectedDates, props.cloudGame, date);
-const locationLabel = (date: string) => snapshotLocationLabel(props.cloudGame, date);
+const locationLabel = (date: string) =>
+  $t(snapshotLocationKey(props.localCatalogDates, props.cloudGame, date));
 </script>
 
 <template>

--- a/apps/rgsm-gui/src/components/management/snapshotAvailability.test.mjs
+++ b/apps/rgsm-gui/src/components/management/snapshotAvailability.test.mjs
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  canApplySnapshot,
+  canEvictSnapshot,
+  canUploadSnapshot,
+  snapshotAvailability,
+  snapshotLocationKey,
+} from './snapshotAvailability.ts';
+
+function cloudGame(snapshots) {
+  return { snapshots };
+}
+
+function cloudSnapshot(snapshotId, overrides = {}) {
+  return {
+    snapshot_id: snapshotId,
+    local_evidence: 'unknown',
+    cloud_verified: false,
+    reported_on_devices: [],
+    ...overrides,
+  };
+}
+
+test('local-only snapshot is available on this device without a cloud catalog', () => {
+  const localDates = new Set(['local']);
+
+  assert.deepEqual(snapshotAvailability(localDates, null, 'local'), {
+    onDevice: true,
+    inCloud: false,
+    onOtherDevice: false,
+  });
+  assert.equal(canApplySnapshot(localDates, null, 'local'), true);
+  assert.equal(canEvictSnapshot(localDates, null, 'local'), false);
+  assert.equal(snapshotLocationKey(localDates, null, 'local'), 'manage.location_local');
+});
+
+test('local catalog remains authoritative when the cloud catalog has no row yet', () => {
+  const localDates = new Set(['local']);
+  const game = cloudGame([]);
+
+  assert.equal(snapshotAvailability(localDates, game, 'local').onDevice, true);
+  assert.equal(canUploadSnapshot(localDates, game, 'local'), true);
+  assert.equal(canEvictSnapshot(localDates, game, 'local'), true);
+  assert.equal(snapshotLocationKey(localDates, game, 'local'), 'manage.location_local');
+});
+
+test('unknown cloud metadata does not override a local catalog row', () => {
+  const localDates = new Set(['legacy']);
+  const game = cloudGame([cloudSnapshot('legacy')]);
+
+  assert.equal(snapshotAvailability(localDates, game, 'legacy').onDevice, true);
+  assert.equal(canApplySnapshot(localDates, game, 'legacy'), true);
+  assert.equal(snapshotLocationKey(localDates, game, 'legacy'), 'manage.location_local');
+});
+
+test('local mismatch evidence overrides a stale local catalog row', () => {
+  const localDates = new Set(['corrupt']);
+  const game = cloudGame([cloudSnapshot('corrupt', { local_evidence: 'mismatch' })]);
+
+  assert.equal(snapshotAvailability(localDates, game, 'corrupt').onDevice, false);
+  assert.equal(canApplySnapshot(localDates, game, 'corrupt'), false);
+  assert.equal(snapshotLocationKey(localDates, game, 'corrupt'), 'manage.location_missing');
+});
+
+test('location key represents verified local, cloud, and other-device copies', () => {
+  const localDates = new Set(['both']);
+  const game = cloudGame([
+    cloudSnapshot('both', { local_evidence: 'present', cloud_verified: true }),
+    cloudSnapshot('cloud', { cloud_verified: true }),
+    cloudSnapshot('elsewhere', { reported_on_devices: ['device-b'] }),
+  ]);
+
+  assert.equal(snapshotLocationKey(localDates, game, 'both'), 'manage.location_both');
+  assert.equal(snapshotLocationKey(localDates, game, 'cloud'), 'manage.location_cloud');
+  assert.equal(
+    snapshotLocationKey(localDates, game, 'elsewhere'),
+    'sync_settings.archives.available_other_device'
+  );
+});

--- a/apps/rgsm-gui/src/components/management/snapshotAvailability.ts
+++ b/apps/rgsm-gui/src/components/management/snapshotAvailability.ts
@@ -1,5 +1,4 @@
 import type { CloudArchiveGameView, CloudArchiveSnapshotView } from '../../api/commands';
-import { $t } from '../../i18n';
 
 /**
  * Snapshot availability predicates shared by the management page and its
@@ -13,33 +12,75 @@ export function cloudSnapshotOf(
   return cloudGame?.snapshots.find((snapshot) => snapshot.snapshot_id === date) ?? null;
 }
 
-export function isSnapshotOnDevice(cloudGame: CloudArchiveGameView | null, date: string) {
-  return Boolean(cloudSnapshotOf(cloudGame, date)?.local_verified);
+export type SnapshotAvailability = {
+  onDevice: boolean;
+  inCloud: boolean;
+  onOtherDevice: boolean;
+};
+
+export function snapshotAvailability(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+): SnapshotAvailability {
+  const snapshot = cloudSnapshotOf(cloudGame, date);
+  return {
+    onDevice: localCatalogDates.has(date) && snapshot?.local_evidence !== 'mismatch',
+    inCloud: Boolean(snapshot?.cloud_verified),
+    onOtherDevice: (snapshot?.reported_on_devices.length ?? 0) > 0,
+  };
 }
 
-export function isSnapshotInCloud(cloudGame: CloudArchiveGameView | null, date: string) {
-  return Boolean(cloudSnapshotOf(cloudGame, date)?.cloud_verified);
+export function isSnapshotOnDevice(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  return snapshotAvailability(localCatalogDates, cloudGame, date).onDevice;
 }
 
-export function canUploadSnapshot(cloudGame: CloudArchiveGameView | null, date: string) {
+export function isSnapshotInCloud(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  return snapshotAvailability(localCatalogDates, cloudGame, date).inCloud;
+}
+
+export function canUploadSnapshot(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
   if (!cloudGame) return false;
-  const snapshot = cloudSnapshotOf(cloudGame, date);
-  if (!snapshot) return true;
-  return snapshot.local_verified && !snapshot.cloud_verified;
+  const availability = snapshotAvailability(localCatalogDates, cloudGame, date);
+  return availability.onDevice && !availability.inCloud;
 }
 
-export function canDownloadSnapshot(cloudGame: CloudArchiveGameView | null, date: string) {
-  const snapshot = cloudSnapshotOf(cloudGame, date);
-  return Boolean(snapshot?.cloud_verified && !snapshot.local_verified);
+export function canDownloadSnapshot(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  const availability = snapshotAvailability(localCatalogDates, cloudGame, date);
+  return availability.inCloud && !availability.onDevice;
 }
 
-export function canEvictSnapshot(cloudGame: CloudArchiveGameView | null, date: string) {
-  const snapshot = cloudSnapshotOf(cloudGame, date);
-  return Boolean(snapshot?.local_verified);
+export function canEvictSnapshot(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  if (!cloudGame) return false;
+  return snapshotAvailability(localCatalogDates, cloudGame, date).onDevice;
 }
 
-export function canEvictCloudSnapshot(cloudGame: CloudArchiveGameView | null, date: string) {
-  return Boolean(cloudSnapshotOf(cloudGame, date)?.cloud_verified);
+export function canEvictCloudSnapshot(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  return snapshotAvailability(localCatalogDates, cloudGame, date).inCloud;
 }
 
 export function canApplySnapshot(
@@ -47,9 +88,7 @@ export function canApplySnapshot(
   cloudGame: CloudArchiveGameView | null,
   date: string
 ) {
-  if (!localCatalogDates.has(date)) return false;
-  const snapshot = cloudSnapshotOf(cloudGame, date);
-  return !snapshot || snapshot.local_verified;
+  return snapshotAvailability(localCatalogDates, cloudGame, date).onDevice;
 }
 
 export function isRetentionProtectedDate(
@@ -63,13 +102,15 @@ export function isRetentionProtectedDate(
   );
 }
 
-export function snapshotLocationLabel(cloudGame: CloudArchiveGameView | null, date: string) {
-  const local = isSnapshotOnDevice(cloudGame, date);
-  const cloud = isSnapshotInCloud(cloudGame, date);
-  if (local && cloud) return $t('manage.location_both');
-  if (local) return $t('manage.location_local');
-  if (cloud) return $t('manage.location_cloud');
-  const elsewhere = cloudSnapshotOf(cloudGame, date)?.reported_on_devices.length ?? 0;
-  if (elsewhere > 0) return $t('sync_settings.archives.available_other_device');
-  return $t('manage.location_missing');
+export function snapshotLocationKey(
+  localCatalogDates: Set<string>,
+  cloudGame: CloudArchiveGameView | null,
+  date: string
+) {
+  const availability = snapshotAvailability(localCatalogDates, cloudGame, date);
+  if (availability.onDevice && availability.inCloud) return 'manage.location_both';
+  if (availability.onDevice) return 'manage.location_local';
+  if (availability.inCloud) return 'manage.location_cloud';
+  if (availability.onOtherDevice) return 'sync_settings.archives.available_other_device';
+  return 'manage.location_missing';
 }

--- a/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
+++ b/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
@@ -7,6 +7,7 @@ import {
   canUploadSnapshot,
   cloudSnapshotOf,
   isRetentionProtectedDate,
+  isSnapshotOnDevice,
 } from './snapshotAvailability';
 
 /**
@@ -18,6 +19,7 @@ import {
 export function useSnapshotTransfers(deps: {
   game: Ref<Game>;
   cloudGame: Ref<CloudArchiveGameView | null>;
+  localCatalogDates: Ref<Set<string>>;
   activeTransfer: Ref<string>;
   retentionProtectedDates: Ref<Set<string>>;
   /** Currently selected rows (drives batch availability). */
@@ -29,6 +31,7 @@ export function useSnapshotTransfers(deps: {
   const {
     game,
     cloudGame,
+    localCatalogDates,
     activeTransfer,
     retentionProtectedDates,
     selected,
@@ -38,13 +41,19 @@ export function useSnapshotTransfers(deps: {
   const feedback = useFeedback();
 
   const selectedUploadable = computed(() =>
-    selected().filter((snapshot) => canUploadSnapshot(cloudGame.value, snapshot.date))
+    selected().filter((snapshot) =>
+      canUploadSnapshot(localCatalogDates.value, cloudGame.value, snapshot.date)
+    )
   );
   const selectedDownloadable = computed(() =>
-    selected().filter((snapshot) => canDownloadSnapshot(cloudGame.value, snapshot.date))
+    selected().filter((snapshot) =>
+      canDownloadSnapshot(localCatalogDates.value, cloudGame.value, snapshot.date)
+    )
   );
   const selectedEvictable = computed(() =>
-    selected().filter((snapshot) => canEvictSnapshot(cloudGame.value, snapshot.date))
+    selected().filter((snapshot) =>
+      canEvictSnapshot(localCatalogDates.value, cloudGame.value, snapshot.date)
+    )
   );
 
   function gameId() {
@@ -92,7 +101,9 @@ export function useSnapshotTransfers(deps: {
     const snapshot = cloudSnapshotOf(cloudGame.value, date);
     const prefix = cloud ? 'sync_settings.archives.evict_cloud' : 'sync_settings.archives.evict';
     if (!snapshot) return `${prefix}.confirm_last`;
-    const hasReplacement = cloud ? snapshot.local_verified : snapshot.cloud_verified;
+    const hasReplacement = cloud
+      ? isSnapshotOnDevice(localCatalogDates.value, cloudGame.value, date)
+      : snapshot.cloud_verified;
     if (hasReplacement) return `${prefix}.confirm`;
     if (snapshot.reported_on_devices.length > 0) return `${prefix}.confirm_other_device`;
     return `${prefix}.confirm_last`;

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -331,6 +331,7 @@ const {
 } = useSnapshotTransfers({
   game,
   cloudGame,
+  localCatalogDates,
   activeTransfer,
   retentionProtectedDates,
   selected: () => selected_game_snapshots.value,

--- a/apps/rgsm-gui/src/utils/cloudArchivePresentation.ts
+++ b/apps/rgsm-gui/src/utils/cloudArchivePresentation.ts
@@ -14,7 +14,9 @@ export function cloudArchiveTransferKey(gameId: string, snapshotId: string) {
 
 export function cloudArchiveCatchUpPreview(game: CloudArchiveGameView | null) {
   const snapshots =
-    game?.snapshots.filter((snapshot) => snapshot.cloud_verified && !snapshot.local_verified) ?? [];
+    game?.snapshots.filter(
+      (snapshot) => snapshot.cloud_verified && snapshot.local_evidence !== 'present'
+    ) ?? [];
   return {
     count: snapshots.length,
     size: snapshots.reduce((total, snapshot) => total + (snapshot.size ?? 0), 0),
@@ -22,10 +24,10 @@ export function cloudArchiveCatchUpPreview(game: CloudArchiveGameView | null) {
 }
 
 export function cloudArchiveAvailabilityLabel(snapshot: CloudArchiveSnapshotView) {
-  if (snapshot.local_verified && snapshot.cloud_verified) {
+  if (snapshot.local_evidence === 'present' && snapshot.cloud_verified) {
     return $t('sync_settings.archives.available_both');
   }
-  if (snapshot.local_verified) return $t('sync_settings.archives.available_local');
+  if (snapshot.local_evidence === 'present') return $t('sync_settings.archives.available_local');
   if (snapshot.cloud_verified) return $t('sync_settings.archives.available_cloud');
   if (snapshot.reported_on_devices.length > 0) {
     return $t('sync_settings.archives.available_other_device');
@@ -34,8 +36,8 @@ export function cloudArchiveAvailabilityLabel(snapshot: CloudArchiveSnapshotView
 }
 
 export function cloudArchiveAvailabilityType(snapshot: CloudArchiveSnapshotView) {
-  if (snapshot.local_verified && snapshot.cloud_verified) return 'success';
-  if (snapshot.local_verified || snapshot.cloud_verified) return 'primary';
+  if (snapshot.local_evidence === 'present' && snapshot.cloud_verified) return 'success';
+  if (snapshot.local_evidence === 'present' || snapshot.cloud_verified) return 'primary';
   if (snapshot.reported_on_devices.length > 0) return 'warning';
   return 'info';
 }

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
@@ -59,12 +59,34 @@ pub struct CloudArchiveSnapshotView {
     pub snapshot_id: String,
     pub description: String,
     pub size: Option<u64>,
-    pub local_verified: bool,
+    pub local_evidence: LocalArchiveEvidence,
     pub cloud_verified: bool,
     pub reported_on_devices: Vec<DeviceId>,
     pub created_by: CreatedBy,
     pub retention_protected: bool,
     pub parent: Option<String>,
+}
+
+/// Evidence available while building the cloud catalog view of a local archive.
+/// This intentionally does not claim content verification: catalog views use a
+/// cheap metadata check, while transfer operations perform the full hash check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Type, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum LocalArchiveEvidence {
+    /// Cloud metadata cannot confirm or reject the local catalog entry.
+    Unknown,
+    /// A regular file with the expected size is present at the local archive
+    /// path.
+    Present,
+    /// The local file is missing, is not a regular file, or has a different
+    /// size.
+    Mismatch,
+}
+
+impl LocalArchiveEvidence {
+    fn is_present(self) -> bool {
+        self == Self::Present
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -135,13 +157,10 @@ impl CloudArchiveMaterializer {
                 let SnapshotState::Live(live) = &node.state else {
                     unreachable!("live filter guarantees a live Snapshot")
                 };
-                let local_verified = live.integrity.as_ref().is_some_and(|integrity| {
-                    self.is_locally_reported(game, &node.snapshot_id)
-                        && local_size_matches(
-                            &self.local_path(game_id, &node.snapshot_id, node.archive_format),
-                            integrity.size,
-                        )
-                });
+                let local_evidence = classify_local_archive_evidence(
+                    live.integrity.as_ref(),
+                    &self.local_path(game_id, &node.snapshot_id, node.archive_format),
+                );
                 let reported_on_devices = game
                     .local_archives
                     .iter()
@@ -154,7 +173,7 @@ impl CloudArchiveMaterializer {
                     snapshot_id: node.snapshot_id.clone(),
                     description: node.description.clone(),
                     size: live.integrity.as_ref().map(|integrity| integrity.size),
-                    local_verified,
+                    local_evidence,
                     cloud_verified: live.cloud_archive_verified,
                     reported_on_devices,
                     created_by: live.created_by.clone(),
@@ -221,7 +240,7 @@ impl CloudArchiveMaterializer {
                 },
                 local_count: snapshots
                     .iter()
-                    .filter(|snapshot| snapshot.local_verified)
+                    .filter(|snapshot| snapshot.local_evidence.is_present())
                     .count(),
                 cloud_count: snapshots
                     .iter()
@@ -229,20 +248,26 @@ impl CloudArchiveMaterializer {
                     .count(),
                 local_only_count: snapshots
                     .iter()
-                    .filter(|snapshot| snapshot.local_verified && !snapshot.cloud_verified)
+                    .filter(|snapshot| {
+                        snapshot.local_evidence.is_present() && !snapshot.cloud_verified
+                    })
                     .count(),
                 cloud_only_count: snapshots
                     .iter()
-                    .filter(|snapshot| !snapshot.local_verified && snapshot.cloud_verified)
+                    .filter(|snapshot| {
+                        !snapshot.local_evidence.is_present() && snapshot.cloud_verified
+                    })
                     .count(),
                 both_available_count: snapshots
                     .iter()
-                    .filter(|snapshot| snapshot.local_verified && snapshot.cloud_verified)
+                    .filter(|snapshot| {
+                        snapshot.local_evidence.is_present() && snapshot.cloud_verified
+                    })
                     .count(),
                 other_device_only_count: snapshots
                     .iter()
                     .filter(|snapshot| {
-                        !snapshot.local_verified
+                        !snapshot.local_evidence.is_present()
                             && !snapshot.cloud_verified
                             && !snapshot.reported_on_devices.is_empty()
                     })
@@ -250,7 +275,7 @@ impl CloudArchiveMaterializer {
                 unavailable_count: snapshots
                     .iter()
                     .filter(|snapshot| {
-                        !snapshot.local_verified
+                        !snapshot.local_evidence.is_present()
                             && !snapshot.cloud_verified
                             && snapshot.reported_on_devices.is_empty()
                     })
@@ -867,6 +892,84 @@ pub(super) async fn verify_file(
 fn local_size_matches(path: &Path, expected_size: u64) -> bool {
     path.metadata()
         .is_ok_and(|metadata| metadata.is_file() && metadata.len() == expected_size)
+}
+
+fn classify_local_archive_evidence(
+    integrity: Option<&ArchiveIntegrity>,
+    local_path: &Path,
+) -> LocalArchiveEvidence {
+    let Some(integrity) = integrity else {
+        return LocalArchiveEvidence::Unknown;
+    };
+    if local_size_matches(local_path, integrity.size) {
+        LocalArchiveEvidence::Present
+    } else {
+        LocalArchiveEvidence::Mismatch
+    }
+}
+
+#[cfg(test)]
+mod local_archive_evidence_tests {
+    use super::*;
+
+    fn integrity(size: u64) -> ArchiveIntegrity {
+        ArchiveIntegrity {
+            size,
+            xxh3_64: "0000000000000000".to_string(),
+        }
+    }
+
+    #[test]
+    fn metadata_without_integrity_is_unknown() {
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("snapshot.7z");
+        std::fs::write(&archive, b"save").unwrap();
+
+        assert_eq!(
+            classify_local_archive_evidence(None, &archive),
+            LocalArchiveEvidence::Unknown
+        );
+    }
+
+    #[test]
+    fn file_evidence_does_not_depend_on_manifest_ownership() {
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("snapshot.7z");
+        std::fs::write(&archive, b"save").unwrap();
+
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(4)), &archive),
+            LocalArchiveEvidence::Present
+        );
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(5)), &archive),
+            LocalArchiveEvidence::Mismatch
+        );
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(4)), &temp.path().join("missing.7z")),
+            LocalArchiveEvidence::Mismatch
+        );
+    }
+
+    #[test]
+    fn reported_archive_size_distinguishes_presence_from_mismatch() {
+        let temp = temp_dir::TempDir::new().unwrap();
+        let archive = temp.path().join("snapshot.7z");
+        std::fs::write(&archive, b"save").unwrap();
+
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(4)), &archive),
+            LocalArchiveEvidence::Present
+        );
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(5)), &archive),
+            LocalArchiveEvidence::Mismatch
+        );
+        assert_eq!(
+            classify_local_archive_evidence(Some(&integrity(4)), &temp.path().join("missing.7z")),
+            LocalArchiveEvidence::Mismatch
+        );
+    }
 }
 
 async fn remove_file_if_exists(path: &Path) -> Result<(), std::io::Error> {

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization_tests.rs
@@ -5,8 +5,8 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     ArchiveIntegrity, CLOUD_MANIFEST_PATH, CloudArchiveMaterializer, CloudManifest, DeletionKind,
-    GameManifest, LocalArchiveEviction, MaterializationError, SnapshotDeletionLifecycleError,
-    SnapshotNode, SnapshotState, cloud_archive_path,
+    GameManifest, LocalArchiveEviction, LocalArchiveEvidence, MaterializationError,
+    SnapshotDeletionLifecycleError, SnapshotNode, SnapshotState, cloud_archive_path,
 };
 use crate::backup::{ArchiveFormat, CreatedBy, archive_path};
 
@@ -89,7 +89,7 @@ async fn view_keeps_catalog_cloud_and_device_availability_separate() {
         .iter()
         .find(|snapshot| snapshot.snapshot_id == "deck-only")
         .unwrap();
-    assert!(!deck_only.local_verified);
+    assert_eq!(deck_only.local_evidence, LocalArchiveEvidence::Mismatch);
     assert!(!deck_only.cloud_verified);
     assert_eq!(deck_only.reported_on_devices, vec!["deck"]);
     assert_eq!(deck_only.parent, None);

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -63,7 +63,7 @@ pub use manifest::{
 };
 pub use materialization::{
     CloudArchiveGameView, CloudArchiveLibraryView, CloudArchiveMaterializer,
-    CloudArchiveSnapshotView, MaterializationError,
+    CloudArchiveSnapshotView, LocalArchiveEvidence, MaterializationError,
 };
 pub use materialization_models::{
     CloudArchiveDeletionView, MaterializationOutcome, MaterializationPreview,


### PR DESCRIPTION
Depends on #520.

Uses one availability model for snapshot actions and locations. Local Backups.json entries remain usable when cloud integrity is unavailable; when integrity exists, the actual archive file decides whether the local copy is present or mismatched. Sync ownership is not used as filesystem evidence.