### PR TITLE
fix(backup): allow retry after partial snapshot deletion

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -48,6 +48,7 @@ jobs:
           pnpm --dir apps/rgsm-gui exec playwright test
           e2e/desktop-window-lifecycle.spec.ts
           e2e/local-main-path.spec.ts
+          e2e/local-delete-recovery.spec.ts
           e2e/local-compression.spec.ts
           e2e/local-legacy-archive.spec.ts
           e2e/local-v1-8-upgrade.spec.ts

--- a/apps/rgsm-gui/e2e/local-branch-tree.spec.ts
+++ b/apps/rgsm-gui/e2e/local-branch-tree.spec.ts
@@ -10,7 +10,11 @@ import {
   localArchiveExists,
   readBackupsJson,
 } from './support/local-assertions';
-import { applySnapshotViaApi, createSnapshotForGame } from './support/local-gui';
+import {
+  applySnapshotViaApi,
+  confirmSnapshotDeletion,
+  createSnapshotForGame,
+} from './support/local-gui';
 import { openGame } from './support/gui';
 import { createRunRoot } from './support/rgsm-instance';
 
@@ -83,10 +87,7 @@ test('snapshot tree: branch on apply-then-create, set head, delete head fallback
 
     // Deleting a childless head falls back to its parent.
     await branchNodeAction(page, fourthId, 'Delete');
-    const deleteDialog = page.getByRole('dialog');
-    await expect(deleteDialog.getByText('Are you sure you want to delete?')).toBeVisible();
-    await deleteDialog.getByRole('button', { name: 'Delete', exact: true }).click();
-    await expect(page.getByText('Successfully deleted').first()).toBeVisible({ timeout: 15_000 });
+    await confirmSnapshotDeletion(page, fourthId);
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, secondId);
     expect(localArchiveExists(device.appDataDir, fourthId)).toBe(false);
 
@@ -95,9 +96,7 @@ test('snapshot tree: branch on apply-then-create, set head, delete head fallback
     await branchNodeAction(page, firstId, 'Continue from here');
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, firstId);
     await branchNodeAction(page, firstId, 'Delete');
-    await expect(deleteDialog.getByText('Are you sure you want to delete?')).toBeVisible();
-    await deleteDialog.getByRole('button', { name: 'Delete', exact: true }).click();
-    await expect(page.getByText('Successfully deleted').first()).toBeVisible({ timeout: 15_000 });
+    await confirmSnapshotDeletion(page, firstId);
     // branchedId sorts after secondId, so it becomes the new position.
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, branchedId);
     await expectSnapshotParent(device.appDataDir, secondId, null);
@@ -106,9 +105,7 @@ test('snapshot tree: branch on apply-then-create, set head, delete head fallback
 
     // Deleting a root head without children falls back to the newest remaining.
     await branchNodeAction(page, branchedId, 'Delete');
-    await expect(deleteDialog.getByText('Are you sure you want to delete?')).toBeVisible();
-    await deleteDialog.getByRole('button', { name: 'Delete', exact: true }).click();
-    await expect(page.getByText('Successfully deleted').first()).toBeVisible({ timeout: 15_000 });
+    await confirmSnapshotDeletion(page, branchedId);
     await expectLocalHead(device.appDataDir, DEVICE_A_ID, secondId);
     await expectSnapshotDates(device.appDataDir, [secondId]);
 

--- a/apps/rgsm-gui/e2e/local-delete-recovery.spec.ts
+++ b/apps/rgsm-gui/e2e/local-delete-recovery.spec.ts
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { test, expect } from '@playwright/test';
+import { chmod, readFile, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME } from './support/constants';
+import { seedLocalConfig, writeSaveText } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+import {
+  archiveFileName,
+  expectLocalHead,
+  expectSnapshotDates,
+  expectSnapshotParent,
+  localArchiveExists,
+  localSnapshotsDir,
+} from './support/local-assertions';
+import { createSnapshotForGame, deleteSnapshotViaUi } from './support/local-gui';
+import { openGame } from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+
+for (const denyCatalogWrite of [false, true]) {
+  test(`delete snapshot: ${denyCatalogWrite ? 'retry a denied catalog write on Windows' : 'remove a missing archive record'}`, async ({
+    browser,
+  }) => {
+    test.skip(denyCatalogWrite && process.platform !== 'win32', 'Windows read-only replacement');
+    const runRoot = await createRunRoot('local-delete-recovery');
+    const device = await seedLocalConfig(runRoot);
+    await writeSaveText(device.savePath, 'live save\n');
+    const session = await startLocalSession(browser, { runRoot, device, label: 'delete-recovery' });
+    let failed = false;
+    try {
+      const parent = await createSnapshotForGame(session.host, GAME_NAME, 'parent');
+      const child = await createSnapshotForGame(session.host, GAME_NAME, 'child');
+      await openGame(session.page);
+      const snapshotsDir = localSnapshotsDir(device.appDataDir);
+      if (denyCatalogWrite) {
+        const catalog = join(snapshotsDir, 'Backups.json');
+        const mode = (await stat(catalog)).mode;
+        await chmod(catalog, 0o444);
+        try {
+          await assert.rejects(
+            deleteSnapshotViaUi(session.page, child),
+            /delete-snapshot failed \(400\)/
+          );
+        } finally {
+          await chmod(catalog, mode);
+        }
+        expect(localArchiveExists(device.appDataDir, child)).toBe(false);
+        await expectSnapshotDates(device.appDataDir, [parent, child]);
+        await expectLocalHead(device.appDataDir, DEVICE_A_ID, child);
+      } else {
+        await rm(join(snapshotsDir, archiveFileName(child)));
+      }
+
+      await deleteSnapshotViaUi(session.page, child);
+
+      await expectSnapshotDates(device.appDataDir, [parent]);
+      await expectLocalHead(device.appDataDir, DEVICE_A_ID, parent);
+      await expectSnapshotParent(device.appDataDir, parent, null);
+      expect(localArchiveExists(device.appDataDir, parent)).toBe(true);
+      expect(await readFile(device.savePath, 'utf8')).toBe('live save\n');
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      await session.close(failed);
+    }
+  });
+}

--- a/apps/rgsm-gui/e2e/support/command-result.test.mjs
+++ b/apps/rgsm-gui/e2e/support/command-result.test.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { waitForCommand } from './command-result.ts';
+
+function response(status, date = 'selected') {
+  return {
+    url: () => 'http://127.0.0.1:1234/api/v1/delete-snapshot',
+    request: () => ({ method: () => 'POST', postDataJSON: () => ({ date }) }),
+    ok: () => status === 200,
+    status: () => status,
+    text: async () => (status === 200 ? 'null' : 'catalog access denied'),
+  };
+}
+
+test('registers response observation before clicking and ignores another snapshot', async () => {
+  let receive;
+  let matches;
+  const page = {
+    waitForResponse: (predicate) => {
+      matches = predicate;
+      return new Promise((resolve) => {
+        receive = resolve;
+      });
+    },
+  };
+  let read = false;
+  const selected = response(200);
+  selected.text = async () => {
+    read = true;
+    return 'null';
+  };
+  await waitForCommand(page, '/api/v1/delete-snapshot', 'selected', async () => {
+    assert.ok(receive);
+    assert.equal(matches(response(200, 'older')), false);
+    assert.equal(matches(selected), true);
+    receive(selected);
+  });
+  assert.equal(read, true);
+});
+
+test('a failed current request cannot be mistaken for a previous successful notification', async () => {
+  const page = { waitForResponse: async () => response(400) };
+  await assert.rejects(
+    waitForCommand(page, '/api/v1/delete-snapshot', 'selected', async () => {}),
+    /delete-snapshot failed \(400\): catalog access denied/
+  );
+});
+
+test('a failed click is propagated instead of waiting for a request that was never sent', async () => {
+  const page = { waitForResponse: () => new Promise(() => {}) };
+  await assert.rejects(
+    waitForCommand(page, '/api/v1/delete-snapshot', 'selected', async () => {
+      throw new Error('click failed');
+    }),
+    /click failed/
+  );
+});

--- a/apps/rgsm-gui/e2e/support/command-result.ts
+++ b/apps/rgsm-gui/e2e/support/command-result.ts
@@ -1,0 +1,24 @@
+import type { Page } from '@playwright/test';
+
+/** Observe this operation, not a notification left by an earlier request. */
+export async function waitForCommand(
+  page: Page,
+  path: string,
+  snapshotId: string,
+  action: () => Promise<unknown>
+): Promise<void> {
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === path &&
+        response.request().method() === 'POST' &&
+        response.request().postDataJSON()?.date === snapshotId,
+      { timeout: 15_000 }
+    ),
+    action(),
+  ]);
+  const body = await response.text();
+  if (!response.ok()) {
+    throw new Error(`${path} failed (${response.status()}): ${body}`);
+  }
+}

--- a/apps/rgsm-gui/e2e/support/local-gui.ts
+++ b/apps/rgsm-gui/e2e/support/local-gui.ts
@@ -2,6 +2,7 @@ import { expect, type Page } from '@playwright/test';
 import { DEVICE_A_ID } from './constants';
 import { hostPost, type RgsmHost } from './rgsm-instance';
 import { waitForFreshSnapshotSecond } from './gui';
+import { waitForCommand } from './command-result';
 
 export type LocalUnitInput = {
   type: 'File' | 'Folder';
@@ -164,9 +165,15 @@ export async function updateSettings(
 export async function deleteSnapshotViaUi(page: Page, snapshotId: string): Promise<void> {
   const row = page.getByRole('row').filter({ hasText: snapshotId });
   await row.getByRole('button', { name: 'Delete' }).click();
+  await confirmSnapshotDeletion(page, snapshotId);
+}
+
+export async function confirmSnapshotDeletion(page: Page, snapshotId: string): Promise<void> {
   const dialog = page.getByRole('dialog');
   await expect(dialog.getByText('Are you sure you want to delete?')).toBeVisible();
-  await dialog.getByRole('button', { name: 'Delete', exact: true }).click();
+  await waitForCommand(page, '/api/v1/delete-snapshot', snapshotId, () =>
+    dialog.getByRole('button', { name: 'Delete', exact: true }).click()
+  );
   await expect(page.getByText('Successfully deleted').first()).toBeVisible({ timeout: 15_000 });
 }
 

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/shards.test.mjs",
+    "web:test": "node --test src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
     "web:e2e": "playwright test --project=browser",
     "web:e2e:desktop": "playwright test --project=desktop",
     "dev": "tauri dev -- --locked",

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -788,7 +788,7 @@ impl Game {
             })?;
         let backup_dir = get_backup_path()?.join(self.backup_dir_name().as_ref());
         let archive_path = crate::backup::snapshot_archive_path(&backup_dir, deleted);
-        fs::remove_file(&archive_path)?;
+        remove_snapshot_archive(&archive_path)?;
         let remote_archive_path = crate::backup::remote_archive_path(
             self.backup_dir_name().as_ref(),
             date,
@@ -901,9 +901,7 @@ impl Game {
                     BackupError::Unexpected(anyhow::anyhow!("Snapshot '{date}' was not found"))
                 })?;
             let archive_path = crate::backup::snapshot_archive_path(&backup_dir, snapshot);
-            if archive_path.exists() {
-                fs::remove_file(&archive_path)?;
-            }
+            remove_snapshot_archive(&archive_path)?;
             deleted_remote_paths.push(
                 crate::backup::remote_archive_path(
                     self.backup_dir_name().as_ref(),
@@ -1019,6 +1017,15 @@ impl Game {
         saves.backups[pos].describe = describe.to_string();
         self.set_game_snapshots_info(&saves)?;
         Ok(saves)
+    }
+}
+
+fn remove_snapshot_archive(path: &Path) -> std::io::Result<()> {
+    match fs::remove_file(path) {
+        // The catalog can outlive its archive after an interrupted deletion or
+        // a failed catalog write. Retrying must still finish catalog cleanup.
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        result => result,
     }
 }
 

--- a/crates/rgsm-core/src/backup/tests/game.rs
+++ b/crates/rgsm-core/src/backup/tests/game.rs
@@ -461,6 +461,113 @@ fn make_test_game_with_storage_key(
 }
 
 #[test]
+fn delete_snapshot_finishes_catalog_cleanup_when_archive_is_already_missing() -> TestResult {
+    let _config_lock = lock_config_file();
+    run_async_test(async {
+        let root = temp_dir::TempDir::new()?;
+        let config = Config {
+            backup_path: root.path().to_string_lossy().into_owned(),
+            ..Config::default()
+        };
+        let _config_guard = restore_config_guard(&config)?;
+        let game = make_test_game("delete_missing", root.path())?;
+        insert_snapshot(&game, root.path(), "parent", None)?;
+        insert_v4_snapshot(&game, root.path(), "child", Some("parent"))?;
+        fs::remove_file(root.path().join("delete_missing/child.7z"))?;
+
+        let deleted = game.delete_snapshot("child").await?;
+
+        assert_eq!(deleted.snapshots.backups.len(), 1);
+        assert_eq!(
+            deleted.snapshots.current_device_head().map(String::as_str),
+            Some("parent")
+        );
+        assert_eq!(game.get_game_snapshots_info()?.backups.len(), 1);
+        assert_eq!(
+            deleted.remote_archive_path,
+            "save_data/delete_missing/child.7z"
+        );
+        Ok(())
+    })
+}
+
+#[cfg(windows)]
+#[test]
+fn delete_snapshot_can_retry_after_catalog_write_was_denied() -> TestResult {
+    let _config_lock = lock_config_file();
+    run_async_test(async {
+        let root = temp_dir::TempDir::new()?;
+        let config = Config {
+            backup_path: root.path().to_string_lossy().into_owned(),
+            ..Config::default()
+        };
+        let _config_guard = restore_config_guard(&config)?;
+        let game = make_test_game("delete_retry", root.path())?;
+        insert_snapshot(&game, root.path(), "parent", None)?;
+        insert_v4_snapshot(&game, root.path(), "child", Some("parent"))?;
+        let catalog = root.path().join("delete_retry/Backups.json");
+        let original_permissions = fs::metadata(&catalog)?.permissions();
+        let mut readonly = original_permissions.clone();
+        readonly.set_readonly(true);
+        fs::set_permissions(&catalog, readonly)?;
+
+        let failed_delete = game.delete_snapshot("child").await;
+        fs::set_permissions(&catalog, original_permissions)?;
+        assert!(failed_delete.is_err());
+        assert!(!root.path().join("delete_retry/child.7z").exists());
+        assert_eq!(game.get_game_snapshots_info()?.backups.len(), 2);
+
+        game.delete_snapshot("child").await?;
+
+        let saved = game.get_game_snapshots_info()?;
+        assert_eq!(saved.backups.len(), 1);
+        assert_eq!(
+            saved.current_device_head().map(String::as_str),
+            Some("parent")
+        );
+        Ok(())
+    })
+}
+
+#[test]
+fn snapshot_deletion_keeps_catalog_on_an_archive_removal_error() -> TestResult {
+    let _config_lock = lock_config_file();
+    run_async_test(async {
+        for batch in [false, true] {
+            let root = temp_dir::TempDir::new()?;
+            let config = Config {
+                backup_path: root.path().to_string_lossy().into_owned(),
+                ..Config::default()
+            };
+            let _config_guard = restore_config_guard(&config)?;
+            let game = make_test_game("delete_error", root.path())?;
+            insert_v4_snapshot(&game, root.path(), "child", None)?;
+            let archive = root.path().join("delete_error/child.7z");
+            fs::remove_file(&archive)?;
+            fs::create_dir(&archive)?;
+
+            let failed = if batch {
+                game.batch_delete_snapshots(&["child".into()])
+                    .await
+                    .is_err()
+            } else {
+                game.delete_snapshot("child").await.is_err()
+            };
+
+            assert!(failed);
+            assert!(archive.is_dir());
+            let saved = game.get_game_snapshots_info()?;
+            assert_eq!(saved.backups.len(), 1);
+            assert_eq!(
+                saved.current_device_head().map(String::as_str),
+                Some("child")
+            );
+        }
+        Ok(())
+    })
+}
+
+#[test]
 fn batch_delete_removes_snapshots_and_returns_remote_paths() -> TestResult {
     let _config_lock = lock_config_file();
     run_async_test(async {


### PR DESCRIPTION
If archive removal succeeds but writing `Backups.json` fails, retrying deletion previously stopped at the now-missing archive and left the snapshot record behind.

Treat only a missing archive as an already-completed removal, then finish the existing catalog/head update. Single and batch deletion share this rule; other filesystem errors still stop deletion. This makes the partial failure recoverable without changing restore behavior or adding rollback machinery.

Regression coverage reproduces a denied catalog write on Windows and retries through the UI. Deletion E2E assertions now await their own HTTP response instead of accepting an earlier success notification.
