### PR TITLE
test(upgrade): cover unchanged legacy restore configurations

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -52,6 +52,7 @@ jobs:
           e2e/local-compression.spec.ts
           e2e/local-legacy-archive.spec.ts
           e2e/local-v1-8-upgrade.spec.ts
+          e2e/local-released-upgrade.spec.ts
           e2e/local-failure-surface.spec.ts
           e2e/local-extra-backup.spec.ts
           e2e/local-restore-permissions.spec.ts

--- a/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type BrowserContext } from '@playwright/test';
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME, PARENT_SNAPSHOT_ID, CHILD_SNAPSHOT_ID } from './support/constants';
+import { openApp, openGame, snapshotRow } from './support/gui';
+import { getLocalGame, getSettings, getExtraBackups, listSnapshotsFor } from './support/local-gui';
+import { waitForCommand } from './support/command-result';
+import { seedReleasedUpgrade } from './support/released-upgrade';
+import {
+  createRunRoot,
+  hostPost,
+  newDeviceContext,
+  removeRunRoot,
+  startRgsmHost,
+  startTestWeb,
+  type RgsmHost,
+} from './support/rgsm-instance';
+
+for (const version of ['1.7.0', '1.8.0'] as const) {
+  test(`${version} concrete paths upgrade without configuration repair and retain restore semantics`, async ({
+    browser,
+  }) => {
+    const runRoot = await createRunRoot(`released-${version}`);
+    const scene = await seedReleasedUpgrade(runRoot, version);
+    const web = await startTestWeb();
+    let host: RgsmHost | undefined;
+    let context: BrowserContext | undefined;
+    let failed = false;
+    const readCatalog = async () => {
+      const game = await getLocalGame(host!, GAME_NAME);
+      const result = await hostPost<{ device_heads: Record<string, string> }>(
+        host!,
+        '/api/v1/get-game-snapshots-info',
+        { game }
+      );
+      expect(result.ok, result.raw).toBe(true);
+      return result.data;
+    };
+    try {
+      host = await startRgsmHost({
+        appDataDir: scene.appDataDir,
+        deviceId: DEVICE_A_ID,
+        logPath: join(runRoot, 'host.log'),
+      });
+      const game = await getLocalGame(host, GAME_NAME);
+      expect(game.save_paths.map((unit) => unit.id)).toEqual(scene.ids);
+      expect(game.save_paths.map((unit) => unit.source)).toEqual([
+        expect.objectContaining({ type: 'concrete', unit_type: 'Folder' }),
+        expect.objectContaining({ type: 'concrete', unit_type: 'File' }),
+        expect.objectContaining({ type: 'concrete', unit_type: 'Folder' }),
+      ]);
+      expect((await getSettings(host)).extra_backup_when_apply).toBe(true);
+      expect((await readCatalog()).device_heads[DEVICE_A_ID]).toBe(PARENT_SNAPSHOT_ID);
+      expect(
+        (await listSnapshotsFor(host, GAME_NAME)).find((s) => s.date === CHILD_SNAPSHOT_ID)?.parent
+      ).toBe(PARENT_SNAPSHOT_ID);
+      ({ context } = await newDeviceContext(browser, host));
+      let page = context.pages()[0]!;
+      await openApp(page);
+      await openGame(page);
+      await page.getByPlaceholder('New backup description').fill('Created after upgrade');
+      await page.getByRole('button', { name: 'Create new snapshot' }).click();
+      await expect.poll(async () => (await listSnapshotsFor(host!, GAME_NAME)).length).toBe(3);
+      const created = (await listSnapshotsFor(host, GAME_NAME)).find(
+        (s) => s.describe === 'Created after upgrade'
+      )!;
+      expect(created.parent).toBe(PARENT_SNAPSHOT_ID);
+
+      await snapshotRow(page, PARENT_SNAPSHOT_ID).getByRole('button', { name: 'Apply' }).click();
+      await waitForCommand(page, '/api/v1/restore-snapshot', PARENT_SNAPSHOT_ID, () =>
+        page
+          .getByRole('dialog', { name: 'Warning' })
+          .getByRole('button', { name: 'Confirm' })
+          .click()
+      );
+      for (const path of scene.savePaths) {
+        expect(await readFile(path, 'utf8')).toBe(`saved-${PARENT_SNAPSHOT_ID}`);
+      }
+      expect(await readFile(join(scene.gameRoot, 'Saves', 'new-only.txt'), 'utf8')).toBe(
+        'keep-unless-replaced'
+      );
+      await expect(access(join(scene.gameRoot, 'Replaced', 'new-only.txt'))).rejects.toThrow();
+      expect(await getExtraBackups(host, GAME_NAME)).toHaveLength(1);
+
+      await context.close();
+      context = undefined;
+      await host.stop();
+      host = await startRgsmHost({
+        appDataDir: scene.appDataDir,
+        deviceId: DEVICE_A_ID,
+        logPath: join(runRoot, 'restart.log'),
+      });
+      ({ context } = await newDeviceContext(browser, host));
+      page = context.pages()[0]!;
+      await openApp(page);
+      await openGame(page);
+      await expect(snapshotRow(page, created.date)).toBeVisible();
+      expect((await readCatalog()).device_heads[DEVICE_A_ID]).toBe(PARENT_SNAPSHOT_ID);
+      for (const [path, bytes] of scene.originalArchives)
+        expect(await readFile(path)).toEqual(bytes);
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      await context?.close();
+      await host?.stop();
+      await web.stop();
+      if (!failed) await removeRunRoot(runRoot);
+    }
+  });
+}

--- a/apps/rgsm-gui/e2e/support/released-upgrade.ts
+++ b/apps/rgsm-gui/e2e/support/released-upgrade.ts
@@ -1,0 +1,91 @@
+import AdmZip from 'adm-zip';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME, PARENT_SNAPSHOT_ID, CHILD_SNAPSHOT_ID } from './constants';
+import { workspacePath } from './rgsm-instance';
+
+export async function seedReleasedUpgrade(runRoot: string, version: '1.7.0' | '1.8.0') {
+  const config = JSON.parse(
+    await readFile(
+      workspacePath(
+        'crates',
+        'rgsm-core',
+        'tests',
+        'fixtures',
+        'config-upgrade',
+        `config_v${version.replaceAll('.', '_')}.json`
+      ),
+      'utf8'
+    )
+  );
+  const appDataDir = join(runRoot, 'app-data');
+  const archiveDir = join(appDataDir, 'save_data', GAME_NAME);
+  const gameRoot = join(runRoot, 'Games[Main]');
+  const units = [
+    { name: 'Saves', type: 'Folder', replace: false },
+    { name: '[prefs].json', type: 'File', replace: true },
+    { name: 'Replaced', type: 'Folder', replace: true },
+  ];
+  const ids = version === '1.8.0' ? [7, 11, 12] : [0, 1, 2];
+  config.backup_path = join(appDataDir, 'save_data').replaceAll('\\', '/');
+  config.games[0].name = GAME_NAME;
+  config.games[0].save_paths = units.map((unit, index) => ({
+    ...(version === '1.8.0' ? { id: ids[index] } : {}),
+    unit_type: unit.type,
+    paths: { [DEVICE_A_ID]: join(gameRoot, unit.name).replaceAll('\\', '/') },
+    delete_before_apply: unit.replace,
+  }));
+  config.games[0].game_paths = { [DEVICE_A_ID]: join(gameRoot, 'game.exe').replaceAll('\\', '/') };
+  if (version === '1.8.0') config.games[0].next_save_unit_id = 13;
+  // Isolate the historical configuration before startup, without supplying
+  // roots/bindings or changing restoration and extra-backup defaults.
+  config.devices = { [DEVICE_A_ID]: { id: DEVICE_A_ID, name: 'Upgrade device' } };
+  config.quick_action.enable_sound = false;
+  config.quick_action.enable_notification = false;
+  await mkdir(archiveDir, { recursive: true });
+  await writeFile(join(appDataDir, 'GameSaveManager.config.json'), JSON.stringify(config));
+  const savePaths: string[] = [];
+  for (const unit of units) {
+    const path = join(gameRoot, unit.name);
+    await mkdir(unit.type === 'Folder' ? path : gameRoot, { recursive: true });
+    const file = unit.type === 'Folder' ? join(path, 'profile.sav') : path;
+    savePaths.push(file);
+    await writeFile(file, 'live-before-upgrade');
+    if (unit.type === 'Folder') await writeFile(join(path, 'new-only.txt'), 'keep-unless-replaced');
+  }
+  const backups = [];
+  const originalArchives = new Map<string, Buffer>();
+  for (const date of [PARENT_SNAPSHOT_ID, CHILD_SNAPSHOT_ID]) {
+    const zip = new AdmZip();
+    if (version === '1.8.0') {
+      zip.addZipComment('RGSM_ARCHIVE_V2\n{"version":2,"compression":"zstd:3"}');
+    }
+    for (const [index, unit] of units.entries()) {
+      const entry = `${version === '1.8.0' ? `${ids[index]}/` : ''}${unit.name}${unit.type === 'Folder' ? '/profile.sav' : ''}`;
+      zip.addFile(entry, Buffer.from(`saved-${date}`));
+    }
+    const bytes = zip.toBuffer();
+    const path = join(archiveDir, `${date}.zip`);
+    await writeFile(path, bytes);
+    originalArchives.set(path, bytes);
+    backups.push({
+      date,
+      describe: `Original ${date}`,
+      path,
+      size: bytes.length,
+      parent: date === CHILD_SNAPSHOT_ID ? PARENT_SNAPSHOT_ID : null,
+      ...(version === '1.8.0' ? { device_id: DEVICE_A_ID } : {}),
+    });
+  }
+  await writeFile(
+    join(archiveDir, 'Backups.json'),
+    JSON.stringify({
+      name: GAME_NAME,
+      backups,
+      ...(version === '1.8.0'
+        ? { device_heads: { [DEVICE_A_ID]: PARENT_SNAPSHOT_ID }, sync_version: 3 }
+        : { head: PARENT_SNAPSHOT_ID }),
+    })
+  );
+  return { appDataDir, archiveDir, gameRoot, savePaths, originalArchives, ids };
+}

--- a/crates/rgsm-core/tests/config_upgrade_compatibility.rs
+++ b/crates/rgsm-core/tests/config_upgrade_compatibility.rs
@@ -2,7 +2,8 @@
 //!
 //! Keep one realistic fixture for every materially different schema shipped in a release
 //! between `MIN_SUPPORTED_VERSION` and the latest release tag. Releases that serialize the
-//! same shape share a fixture; unreleased schemas do not define compatibility promises.
+//! same shape share a fixture. The historical 1.7.0 source fixture additionally covers
+//! its single-head branch graph, without claiming a published release package.
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
@@ -28,6 +29,7 @@ const LEGACY_SINGLE_DEVICE: &str = include_str!("fixtures/config-upgrade/config_
 const LEGACY_SINGLE_DEVICE_WITH_REFERENCES: &str =
     include_str!("fixtures/config-upgrade/config_v1_4_0.json");
 const DEVICE_KEYED: &str = include_str!("fixtures/config-upgrade/config_v1_5_6.json");
+const HISTORICAL_BRANCHING: &str = include_str!("fixtures/config-upgrade/config_v1_7_0.json");
 const STABLE_SAVE_UNIT_IDS: &str = include_str!("fixtures/config-upgrade/config_v1_8_0.json");
 const RELEASED_SNAPSHOT_DATE: &str = "2025-01-02_03-04-05";
 const RELEASED_SAVE_CONTENT: &[u8] = b"released-save-content";
@@ -36,13 +38,14 @@ const RELEASED_SAVE_CONTENT: &[u8] = b"released-save-content";
 enum ReleasedSaveData {
     V1_0FlatFile,
     V1_5FlatFolder,
+    V1_7FlatFolder,
     V1_8IdPrefixedFolder,
 }
 
 impl ReleasedSaveData {
     fn save_unit_index(self) -> usize {
         match self {
-            Self::V1_0FlatFile | Self::V1_5FlatFolder => 0,
+            Self::V1_0FlatFile | Self::V1_5FlatFolder | Self::V1_7FlatFolder => 0,
             Self::V1_8IdPrefixedFolder => 1,
         }
     }
@@ -50,7 +53,7 @@ impl ReleasedSaveData {
     fn target_name(self) -> &'static str {
         match self {
             Self::V1_0FlatFile => "slot1.sav",
-            Self::V1_5FlatFolder => "Saves",
+            Self::V1_5FlatFolder | Self::V1_7FlatFolder => "Saves",
             Self::V1_8IdPrefixedFolder => "Saved",
         }
     }
@@ -58,7 +61,7 @@ impl ReleasedSaveData {
     fn archive_entry(self) -> &'static str {
         match self {
             Self::V1_0FlatFile => "slot1.sav",
-            Self::V1_5FlatFolder => "Saves/profile.sav",
+            Self::V1_5FlatFolder | Self::V1_7FlatFolder => "Saves/profile.sav",
             Self::V1_8IdPrefixedFolder => "11/Saved/profile.sav",
         }
     }
@@ -66,14 +69,14 @@ impl ReleasedSaveData {
     fn compression_method(self) -> zip::CompressionMethod {
         match self {
             Self::V1_0FlatFile => zip::CompressionMethod::Stored,
-            Self::V1_5FlatFolder => zip::CompressionMethod::Bzip2,
+            Self::V1_5FlatFolder | Self::V1_7FlatFolder => zip::CompressionMethod::Bzip2,
             Self::V1_8IdPrefixedFolder => zip::CompressionMethod::Zstd,
         }
     }
 
     fn archive_comment(self) -> Option<&'static str> {
         match self {
-            Self::V1_0FlatFile | Self::V1_5FlatFolder => None,
+            Self::V1_0FlatFile | Self::V1_5FlatFolder | Self::V1_7FlatFolder => None,
             Self::V1_8IdPrefixedFolder => {
                 Some("RGSM_ARCHIVE_V2\n{\"version\":2,\"compression\":\"zstd:3\"}")
             }
@@ -122,6 +125,12 @@ fn seed_released_save_data(
             "device_heads": {"released-device": RELEASED_SNAPSHOT_DATE},
             "sync_version": 3,
             "last_sync_device": "released-device"
+        })
+    } else if matches!(shape, ReleasedSaveData::V1_7FlatFolder) {
+        serde_json::json!({
+            "name": game_name,
+            "backups": [snapshot],
+            "head": RELEASED_SNAPSHOT_DATE
         })
     } else {
         serde_json::json!({
@@ -372,6 +381,86 @@ fn device_keyed_config_upgrades_and_preserves_multi_device_save_units()
     assert!(config.settings.save_list_last_expanded);
     assert_eq!(config.settings.max_auto_backup_count, 7);
     assert_eq!(config.settings.cloud_settings.max_concurrency, 1);
+    Ok(())
+}
+
+#[test]
+fn historical_1_7_config_assigns_ids_without_changing_save_unit_types()
+-> Result<(), Box<dyn std::error::Error>> {
+    let migrated = migrate_fixture(HISTORICAL_BRANCHING, ReleasedSaveData::V1_7FlatFolder)?;
+    let game = &migrated.config.games[0];
+    assert_eq!(game.next_save_unit_id, 2);
+    assert_concrete_unit(
+        &game.save_paths[0],
+        0,
+        SaveUnitType::Folder,
+        &[(
+            "desktop-alpha",
+            "C:/Users/Player/Saved Games/Branching Adventure/Saves",
+        )],
+        false,
+        true,
+    );
+    assert_concrete_unit(
+        &game.save_paths[1],
+        1,
+        SaveUnitType::File,
+        &[(
+            "desktop-alpha",
+            "D:/Games/Branching Adventure/settings.json",
+        )],
+        true,
+        true,
+    );
+    assert!(migrated.config.settings.extra_backup_when_apply);
+    Ok(())
+}
+
+#[test]
+fn historical_1_7_upgrade_preserves_a_branch_head_older_than_the_newest_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let temp = temp_dir::TempDir::new()?;
+    let config_path = temp.path().join("GameSaveManager.config.json");
+    let backup_path = temp.path().join("save_data");
+    let mut raw: Value = serde_json::from_str(HISTORICAL_BRANCHING)?;
+    raw["backup_path"] = serde_json::json!(backup_path);
+    let game_dir = backup_path.join(raw["games"][0]["name"].as_str().unwrap());
+    fs::create_dir_all(&game_dir)?;
+    let catalog_path = game_dir.join("Backups.json");
+    let dates = [
+        "2025-01-01_00-00-00",
+        "2025-01-02_00-00-00",
+        "2025-01-03_00-00-00",
+    ];
+    let backups: Vec<_> = dates
+        .iter()
+        .enumerate()
+        .map(|(index, date)| {
+            serde_json::json!({
+                "date": date,
+                "describe": "Historical branch",
+                "path": format!("{date}.zip"),
+                "parent": (index > 0).then_some(dates[0])
+            })
+        })
+        .collect();
+    fs::write(
+        &catalog_path,
+        serde_json::to_vec(&serde_json::json!({
+            "name": "Branching Adventure", "backups": backups, "head": dates[1]
+        }))?,
+    )?;
+    fs::write(&config_path, serde_json::to_vec(&raw)?)?;
+    assert!(update_config(&config_path)?);
+    let mut catalog: GameSnapshots = serde_json::from_slice(&fs::read(&catalog_path)?)?;
+    catalog.normalize_heads();
+    assert_eq!(
+        catalog.current_device_head().map(String::as_str),
+        Some(dates[1])
+    );
+    assert_eq!(catalog.backups[1].parent.as_deref(), Some(dates[0]));
+    assert_eq!(catalog.backups[2].parent.as_deref(), Some(dates[0]));
+    assert!(!update_config(&config_path)?);
     Ok(())
 }
 

--- a/crates/rgsm-core/tests/fixtures/config-upgrade/README.md
+++ b/crates/rgsm-core/tests/fixtures/config-upgrade/README.md
@@ -1,0 +1,8 @@
+# Upgrade fixtures
+
+These are synthetic player configurations using historical serialized schemas, not player data.
+
+- `config_v1_7_0.json` follows commit `b549dc0` (the 1.7.0 version bump). This is historical source coverage, not a claim that a 1.7.0 release package was published. Save Units have no IDs; ZIP entries use file/folder names without ID prefixes. `Backups.json` already supports parents and a single `head`
+- `config_v1_8_0.json` follows release tag `v1.8.0`. Save Units have stable IDs; V2 ZIP entries use those IDs as prefixes, and snapshot metadata supports per-device heads
+
+The Rust compatibility tests exercise the historical compression methods. Browser upgrade tests seed isolated absolute paths before startup and never repair the migrated configuration or device bindings to make restoration pass.

--- a/crates/rgsm-core/tests/fixtures/config-upgrade/config_v1_7_0.json
+++ b/crates/rgsm-core/tests/fixtures/config-upgrade/config_v1_7_0.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.7.0",
+  "backup_path": "save_data",
+  "games": [
+    {
+      "name": "Branching Adventure",
+      "save_paths": [
+        {
+          "unit_type": "Folder",
+          "paths": {
+            "desktop-alpha": "C:/Users/Player/Saved Games/Branching Adventure/Saves"
+          },
+          "delete_before_apply": false
+        },
+        {
+          "unit_type": "File",
+          "paths": {
+            "desktop-alpha": "D:/Games/Branching Adventure/settings.json"
+          },
+          "delete_before_apply": true
+        }
+      ],
+      "game_paths": { "desktop-alpha": "D:/Games/Branching Adventure/game.exe" }
+    }
+  ],
+  "settings": {
+    "prompt_when_not_described": true,
+    "extra_backup_when_apply": true,
+    "show_edit_button": true,
+    "prompt_when_auto_backup": false,
+    "exit_to_tray": true,
+    "cloud_settings": {
+      "auto_sync_interval": 15,
+      "root_path": "/rgsm-fixtures",
+      "backend": { "type": "Disabled" },
+      "always_sync": true
+    },
+    "locale": "en_US",
+    "default_delete_before_apply": false,
+    "default_expend_favorites_tree": false,
+    "home_page": "/",
+    "log_to_file": true,
+    "add_new_to_favorites": false,
+    "save_list_expand_behavior": "remember_last",
+    "save_list_last_expanded": true,
+    "max_auto_backup_count": 7
+  },
+  "favorites": [],
+  "quick_action": {
+    "quick_action_game": null,
+    "hotkeys": { "apply": ["", "", ""], "backup": ["", "", ""] },
+    "enable_sound": false,
+    "enable_notification": false,
+    "sounds": {
+      "success": { "kind": "default" },
+      "failure": { "kind": "default" }
+    }
+  },
+  "devices": {
+    "desktop-alpha": { "id": "desktop-alpha", "name": "Windows Desktop" }
+  }
+}


### PR DESCRIPTION
Cover startup upgrades from the historical 1.7 configuration and the released 1.8 schema without repairing migrated configuration or adding device bindings.

The scenarios retain an older selected head, create a new branch, restore file/folder units with extra backup enabled, and verify both overwrite policies, restart persistence, and unchanged old archives. Rust fixtures exercise historical Bzip2/Zstd decoding; browser fixtures exercise the full startup and restore flow.

The 1.7 fixture follows source commit `b549dc0`, not a claimed published package. No production behavior changes are needed for these cases.
