### PR TITLE
fix(config): preserve local games when connecting cloud libraries

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -60,6 +60,7 @@ jobs:
           e2e/cloud-library-two-v1-devices.spec.ts
           e2e/cloud-library-late-game.spec.ts
           e2e/cloud-catalog-read.spec.ts
+          e2e/cloud-local-games.spec.ts
           e2e/cloud-sync-modes.spec.ts
           e2e/cloud-reset-library.spec.ts
 

--- a/apps/rgsm-gui/e2e/cloud-local-games.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-local-games.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test';
+import { readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME } from './support/constants';
+import { cloudPaths, readDeviceProfile, readJson } from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame, writeSave, readSave } from './support/cloud-fixture';
+import {
+  applySnapshot,
+  confirmJoinKeepCloud,
+  createLibrary,
+  openApp,
+  openGame,
+} from './support/gui';
+import {
+  createSnapshotForGame,
+  deleteSnapshotViaUi,
+  getLocalGame,
+  listSnapshotsFor,
+  updateGameViaApi,
+} from './support/local-gui';
+import { createRunRoot, hostPost, newDeviceContext, startRgsmHost } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('connecting cloud keeps local games usable through refresh, offline edits, and restart', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('local-games');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot, { gameOnB: false });
+  const configPath = join(seeded.deviceA.appDataDir, 'GameSaveManager.config.json');
+  const config = JSON.parse(await readFile(configPath, 'utf8'));
+  config.games[0].cloud_sync_enabled = false;
+  config.favorites = [
+    { node_id: 'local-favorite', label: GAME_NAME, is_leaf: true, children: null },
+  ];
+  await writeFile(configPath, JSON.stringify(config));
+  const session = await startDualSession(browser, { ...seeded, runRoot, label: 'local-games' });
+  let failed = false;
+  let restarted: Awaited<ReturnType<typeof startRgsmHost>> | undefined;
+  let restartedContext: Awaited<ReturnType<typeof newDeviceContext>> | undefined;
+  try {
+    await createLibrary(session.pageB);
+    await writeSave(seeded.deviceA, 'local original\n');
+    const original = await createSnapshotForGame(session.hostA, GAME_NAME, 'Before connection');
+    const originalGame = await getLocalGame(session.hostA, GAME_NAME);
+    await confirmJoinKeepCloud(session.pageA);
+    expect(await getLocalGame(session.hostA, GAME_NAME)).toEqual(originalGame);
+    const refresh = await hostPost(session.hostA, '/api/v1/refresh-cloud-archive-library');
+    expect(refresh.ok, refresh.raw).toBe(true);
+    await openGame(session.pageA);
+    await writeSave(seeded.deviceA, 'local later\n');
+    const nonHead = await createSnapshotForGame(session.hostA, GAME_NAME, 'After connection');
+    await session.pageA.reload();
+    await applySnapshot(session.pageA, original);
+    expect(await readSave(seeded.deviceA)).toBe('local original\n');
+    expect((await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary)).games).toEqual([]);
+    expect((await readDeviceProfile(seeded.cloudRoot, DEVICE_A_ID)).games).toEqual({});
+
+    // No page-owned cloud refresh races the isolated offline edit.
+    await session.pageA.goto('about:blank');
+    await session.pageB.goto('about:blank');
+    const settled = await hostPost(session.hostA, '/api/v1/refresh-cloud-archive-library');
+    expect(settled.ok, settled.raw).toBe(true);
+    const offlineRoot = join(runRoot, 'offline-cloud');
+    await rename(seeded.cloudRoot, offlineRoot);
+    await writeFile(seeded.cloudRoot, 'Cloud storage is unavailable');
+    try {
+      const local = await getLocalGame(session.hostA, GAME_NAME);
+      await updateGameViaApi(session.hostA, local.storage_key, { ...local, name: 'Renamed local' });
+      const permanent = await hostPost(session.hostA, '/api/v1/set-snapshot-created-by', {
+        gameName: 'Renamed local',
+        snapshotDate: original,
+        createdBy: 'Manual',
+      });
+      expect(permanent.ok, permanent.raw).toBe(true);
+      const discardedHead = await createSnapshotForGame(
+        session.hostA,
+        'Renamed local',
+        'Discard this local head'
+      );
+      await openGame(session.pageA, 'Renamed local');
+      await deleteSnapshotViaUi(session.pageA, nonHead);
+      await deleteSnapshotViaUi(session.pageA, discardedHead);
+      const apiHead = await createSnapshotForGame(session.hostA, 'Renamed local', 'API deletion');
+      const deletion = {
+        gameId: local.storage_key,
+        snapshotId: apiHead,
+        currentPosition: { type: 'fallback_to_parent' },
+      };
+      const unconfirmed = await hostPost(session.hostA, '/api/v1/delete-v2-snapshot', {
+        ...deletion,
+        confirmed: false,
+      });
+      expect(unconfirmed.ok).toBe(false);
+      const unchanged = await hostPost<{ device_heads: Record<string, string> }>(
+        session.hostA,
+        '/api/v1/get-game-snapshots-info',
+        {
+          game: await getLocalGame(session.hostA, 'Renamed local'),
+        }
+      );
+      expect(unchanged.data.device_heads[DEVICE_A_ID]).toBe(apiHead);
+      const removed = await hostPost(session.hostA, '/api/v1/delete-v2-snapshot', {
+        ...deletion,
+        confirmed: true,
+      });
+      expect(removed.ok, removed.raw).toBe(true);
+      expect(
+        (await listSnapshotsFor(session.hostA, 'Renamed local')).map((snapshot) => snapshot.date)
+      ).toEqual([original]);
+      const current = await hostPost<{ device_heads: Record<string, string> }>(
+        session.hostA,
+        '/api/v1/get-game-snapshots-info',
+        {
+          game: await getLocalGame(session.hostA, 'Renamed local'),
+        }
+      );
+      expect(current.data.device_heads[DEVICE_A_ID]).toBe(original);
+      expect(await readSave(seeded.deviceA)).toBe('local original\n');
+    } finally {
+      await unlink(seeded.cloudRoot);
+      await rename(offlineRoot, seeded.cloudRoot);
+    }
+    await session.hostA.stop();
+    restarted = await startRgsmHost({
+      appDataDir: seeded.deviceA.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: join(runRoot, 'logs', 'local-games-restart.log'),
+    });
+    restartedContext = await newDeviceContext(browser, restarted);
+    await openApp(restartedContext.page);
+    await openGame(restartedContext.page, 'Renamed local');
+    const restoredGame = await getLocalGame(restarted, 'Renamed local');
+    expect(restoredGame.save_paths).toEqual(originalGame.save_paths);
+    const afterRename = await hostPost<{ favorites: Array<{ label: string }> }>(
+      restarted,
+      '/api/v1/get-local-config'
+    );
+    expect(afterRename.data.favorites[0].label).toBe('Renamed local');
+    await createSnapshotForGame(restarted, 'Renamed local', 'After restart');
+    expect((await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary)).games).toEqual([]);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await restartedContext?.context.close();
+    await restarted?.stop();
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/e2e/cloud-protect-retention.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-protect-retention.spec.ts
@@ -15,7 +15,8 @@ import {
   setSharedRetention,
   uploadSnapshot,
 } from './support/gui';
-import { createRunRoot } from './support/rgsm-instance';
+import { createRunRoot, hostPost } from './support/rgsm-instance';
+import { GAME_NAME } from './support/constants';
 import { startDualSession } from './support/session';
 
 test('protect snapshot and set shared retention limit', async ({ browser }) => {
@@ -31,6 +32,12 @@ test('protect snapshot and set shared retention limit', async ({ browser }) => {
   let failed = false;
   try {
     await createLibrary(session.pageA);
+    const provenanceChange = await hostPost(session.hostA, '/api/v1/set-snapshot-created-by', {
+      gameName: GAME_NAME,
+      snapshotDate: keepId,
+      createdBy: 'Manual',
+    });
+    expect(provenanceChange.ok).toBe(false);
     await openGame(session.pageA);
     for (const snapshotId of [keepId, second, third, fourth]) {
       await uploadSnapshot(session.pageA, snapshotId!);

--- a/apps/rgsm-gui/e2e/support/local-gui.ts
+++ b/apps/rgsm-gui/e2e/support/local-gui.ts
@@ -68,7 +68,7 @@ export async function updateGameViaApi(
   game: LocalGame
 ): Promise<void> {
   const result = await hostPost(host, '/api/v1/update-game', {
-    storage_key: storageKey,
+    storageKey,
     game: {
       name: game.name,
       save_paths: game.save_paths,

--- a/apps/rgsm-gui/src-tauri/src/commands.rs
+++ b/apps/rgsm-gui/src-tauri/src/commands.rs
@@ -388,8 +388,9 @@ pub async fn delete_snapshot(
     date: String,
     app_handle: AppHandle,
 ) -> Result<(), String> {
-    if rgsm_core::config::cloud_namespace_generation().map_err(|error| error.to_string())?
-        == CloudNamespaceGeneration::V2
+    if svc(&app_handle)
+        .is_shared_game(game.backup_dir_name().as_ref())
+        .map_err(|error| error.to_string())?
     {
         return Err(ACTIVE_CLOUD_LIBRARY_DELETION_REQUIRES_PERMANENT.into());
     }
@@ -411,8 +412,9 @@ pub async fn batch_delete_snapshots(
     dates: Vec<String>,
     app_handle: AppHandle,
 ) -> Result<(), String> {
-    if rgsm_core::config::cloud_namespace_generation().map_err(|error| error.to_string())?
-        == CloudNamespaceGeneration::V2
+    if svc(&app_handle)
+        .is_shared_game(game.backup_dir_name().as_ref())
+        .map_err(|error| error.to_string())?
     {
         return Err(ACTIVE_CLOUD_LIBRARY_DELETION_REQUIRES_PERMANENT.into());
     }
@@ -1221,13 +1223,6 @@ pub async fn set_snapshot_created_by(
     snapshot_date: String,
     created_by: CreatedBy,
 ) -> Result<GameSnapshots, String> {
-    if rgsm_core::config::cloud_namespace_generation().map_err(|error| error.to_string())?
-        == CloudNamespaceGeneration::V2
-    {
-        return Err(
-            "Use V2 retention protection without changing Snapshot creation provenance".into(),
-        );
-    }
     info!(
         target:"rgsm::commands",
         "Setting created_by for '{game_name}' snapshot '{snapshot_date}' to {created_by:?}"

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -483,6 +483,7 @@ export type Device = {
 export type DeviceGameStatus = {
   game_id: string;
   managed: boolean;
+  shared: boolean;
   visible: boolean;
 };
 

--- a/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
+++ b/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
@@ -223,12 +223,12 @@ export function useSnapshotTransfers(deps: {
 
   async function convertToPermanent(snapshotDate: string) {
     try {
-      const generation = await commands.getCloudNamespaceGeneration();
-      if (generation.status === 'error') {
-        notifyError(generation.error);
+      const ownership = await commands.getCurrentDeviceGameStatuses();
+      if (ownership.status === 'error') {
+        notifyError(ownership.error);
         return;
       }
-      if (generation.data === 'v2') {
+      if (ownership.data.some((status) => status.game_id === gameId() && status.shared)) {
         const nextProtected = !isRetentionProtected(snapshotDate);
         if (nextProtected) {
           await feedback.confirm(

--- a/apps/rgsm-gui/src/composables/useConfig.ts
+++ b/apps/rgsm-gui/src/composables/useConfig.ts
@@ -30,6 +30,7 @@ async function refreshConfig(): Promise<boolean> {
         ? statuses.data
         : config.value.games.map((game) => ({
             game_id: game.storage_key || game.name,
+            shared: false,
             managed: true,
             visible: true,
           }));

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -160,12 +160,14 @@ onBeforeUnmount(() => {
 const pendingDeletions = computed(() => cloudGame.value?.pending_deletions ?? []);
 async function batch_delete() {
   try {
-    const generation = await commands.getCloudNamespaceGeneration();
-    if (generation.status === 'error') {
-      notifyError(generation.error);
+    const ownership = await commands.getCurrentDeviceGameStatuses();
+    if (ownership.status === 'error') {
+      notifyError(ownership.error);
       return;
     }
-    const global = generation.data === 'v2';
+    const global = ownership.data.some(
+      (status) => status.game_id === (game.value.storage_key || game.value.name) && status.shared
+    );
     const promptResult = await feedback.prompt(
       $t(global ? 'manage.batch_delete_global_prompt' : 'manage.batch_delete_prompt'),
       $t('home.hint'),
@@ -561,13 +563,17 @@ async function launch_game() {
 
 async function del_save(date: string) {
   try {
-    const generation = await commands.getCloudNamespaceGeneration();
-    if (generation.status === 'error') {
-      notifyError(generation.error);
+    const ownership = await commands.getCurrentDeviceGameStatuses();
+    if (ownership.status === 'error') {
+      notifyError(ownership.error);
       return;
     }
     let result;
-    if (generation.data === 'v2') {
+    if (
+      ownership.data.some(
+        (status) => status.game_id === (game.value.storage_key || game.value.name) && status.shared
+      )
+    ) {
       const gameId = game.value.storage_key || game.value.name;
       const snapshot = table_data.value.find((item) => item.date === date);
       await feedback.confirm(

--- a/crates/rgsm-core/src/config/app_config.rs
+++ b/crates/rgsm-core/src/config/app_config.rs
@@ -115,6 +115,17 @@ pub struct FavoriteTreeNode {
 }
 
 impl FavoriteTreeNode {
+    pub(crate) fn rename_game_leaves(nodes: &mut [Self], previous: &str, next: &str) {
+        for node in nodes {
+            if node.is_leaf && node.label == previous {
+                node.label = next.to_string();
+            }
+            if let Some(children) = &mut node.children {
+                Self::rename_game_leaves(children, previous, next);
+            }
+        }
+    }
+
     fn remove_deleted_game_leaves(nodes: &mut Vec<Self>, deleted_game: &Game) -> bool {
         Self::remove_game_leaves(nodes, &deleted_game.name)
     }
@@ -211,6 +222,19 @@ mod tests {
         );
         assert_eq!(config.favorites[1].label, "Deleted Game");
         assert!(!config.favorites[1].is_leaf);
+    }
+
+    #[test]
+    fn renaming_game_updates_nested_favorites_without_renaming_folders() {
+        let mut nodes = vec![favorite_folder(
+            "Before",
+            vec![favorite_leaf("Before"), favorite_leaf("Other")],
+        )];
+        FavoriteTreeNode::rename_game_leaves(&mut nodes, "Before", "After");
+        assert_eq!(nodes[0].label, "Before");
+        let children = nodes[0].children.as_ref().unwrap();
+        assert_eq!(children[0].label, "After");
+        assert_eq!(children[1].label, "Other");
     }
 
     #[test]

--- a/crates/rgsm-core/src/config/local_games.rs
+++ b/crates/rgsm-core/src/config/local_games.rs
@@ -1,0 +1,97 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{ConfigurationOwners, DeviceProfile, LocalState, OwnershipError, SharedLibrary};
+use crate::device::DeviceId;
+
+impl ConfigurationOwners {
+    pub(crate) fn validate_local_games(&self) -> Result<(), OwnershipError> {
+        SharedLibrary {
+            schema_version: self.shared_library.schema_version,
+            games: self.local_state.local_games.clone(),
+        }
+        .validate()?;
+        for game in &self.local_state.local_games {
+            if self
+                .shared_library
+                .games
+                .iter()
+                .any(|shared| shared.storage_key == game.storage_key)
+            {
+                return Err(OwnershipError::DuplicateGameOwnership(
+                    game.storage_key.clone(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn preserve_local_scope(&mut self, previous: &LocalState) {
+        let local_ids = previous
+            .local_games
+            .iter()
+            .map(|game| game.storage_key.as_str())
+            .collect::<HashSet<_>>();
+        let (local, shared) = std::mem::take(&mut self.shared_library.games)
+            .into_iter()
+            .partition(|game| local_ids.contains(game.storage_key.as_str()));
+        self.local_state.local_games = local;
+        self.shared_library.games = shared;
+    }
+
+    /// Cloud absence is not a deletion instruction. Retain omitted definitions
+    /// locally, keeping their existing Device settings out of the cloud library.
+    pub(crate) fn accept_library(
+        &mut self,
+        library: &SharedLibrary,
+        profiles: &HashMap<DeviceId, DeviceProfile>,
+    ) {
+        let shared_ids = library
+            .games
+            .iter()
+            .map(|game| game.storage_key.as_str())
+            .collect::<HashSet<_>>();
+        self.local_state.local_games = self
+            .local_state
+            .local_games
+            .iter()
+            .chain(self.shared_library.games.iter())
+            .filter(|game| !shared_ids.contains(game.storage_key.as_str()))
+            .cloned()
+            .collect();
+        for (device_id, accepted) in profiles {
+            let mut profile = accepted.clone();
+            if let Some(previous) = self.device_profiles.get(device_id) {
+                for game in &self.local_state.local_games {
+                    if let Some(settings) = previous.games.get(&game.storage_key) {
+                        profile
+                            .games
+                            .insert(game.storage_key.clone(), settings.clone());
+                    }
+                }
+            }
+            self.device_profiles.insert(device_id.clone(), profile);
+        }
+        // A definition retained from a previously connected library must not
+        // continue publishing snapshots to the new library automatically.
+        for profile in self.device_profiles.values_mut() {
+            for game in &self.local_state.local_games {
+                if let Some(settings) = profile.games.get_mut(&game.storage_key) {
+                    settings.cloud_sync_enabled = false;
+                }
+            }
+        }
+        self.shared_library = library.clone();
+    }
+}
+
+impl DeviceProfile {
+    /// Explicit projection used by application services before publication.
+    /// Local paths and shortcuts for unshared Games stay in the owner store.
+    pub(crate) fn without_local_games(&self, local: &LocalState) -> Self {
+        let mut profile = self.clone();
+        for game in &local.local_games {
+            profile.remove_game_state(&game.storage_key, &game.name);
+        }
+        profile
+    }
+}

--- a/crates/rgsm-core/src/config/local_games_tests.rs
+++ b/crates/rgsm-core/src/config/local_games_tests.rs
@@ -1,0 +1,228 @@
+use super::*;
+use crate::backup::{Game, SaveUnit, SaveUnitType};
+use crate::device::Device;
+
+fn fixture() -> (temp_dir::TempDir, OwnerStore, ConfigurationOwners) {
+    let root = temp_dir::TempDir::new().unwrap();
+    let store = OwnerStore::new(root.path().to_path_buf());
+    let config = Config {
+        games: vec![Game {
+            name: "Local adventure".into(),
+            storage_key: "local-game".into(),
+            save_paths: vec![SaveUnit::concrete(
+                7,
+                SaveUnitType::Folder,
+                HashMap::from([("pc".into(), "D:/Saves[Main]".into())]),
+                true,
+                false,
+            )],
+            next_save_unit_id: 8,
+            game_paths: HashMap::from([("pc".into(), "D:/Games/game.exe".into())]),
+            cloud_sync_enabled: false,
+            auto_backup: None,
+            ludusavi_meta: None,
+            device_bindings: HashMap::new(),
+        }],
+        devices: HashMap::from([(
+            "pc".into(),
+            Device {
+                id: "pc".into(),
+                name: "My PC".into(),
+                resources: vec![],
+                next_resource_id: 0,
+            },
+        )]),
+        ..Default::default()
+    };
+    let owners = ConfigurationOwners::from_legacy(&config, &"pc".into());
+    store.write(&owners).unwrap();
+    (root, store, owners)
+}
+
+fn remote_library(before: &ConfigurationOwners) -> SharedLibrary {
+    let mut library = before.shared_library.clone();
+    library.games[0].name = "Cloud adventure".into();
+    library.games[0].storage_key = "cloud-game".into();
+    library
+}
+
+fn assert_local_preserved(store: &OwnerStore, before: &ConfigurationOwners) {
+    let effective = store.load_effective().unwrap();
+    let original = before.assemble_effective().unwrap();
+    let local = effective
+        .games
+        .iter()
+        .find(|game| game.storage_key == "local-game")
+        .expect("accepting cloud definitions must retain the local game");
+    assert_eq!(
+        serde_json::to_value(local).unwrap(),
+        serde_json::to_value(&original.games[0]).unwrap()
+    );
+    assert!(
+        effective
+            .games
+            .iter()
+            .any(|game| game.storage_key == "cloud-game")
+    );
+    assert_eq!(store.load().unwrap().shared_library.games.len(), 1);
+}
+
+#[test]
+fn joining_cloud_retains_local_only_games_and_their_settings() {
+    let (_root, store, before) = fixture();
+    let remote = remote_library(&before);
+    let profile = &before.device_profiles["pc"];
+    store
+        .activate_join_v2(
+            &before.shared_library,
+            profile,
+            &remote,
+            &profile.for_shared_library(&remote),
+            "library-a",
+        )
+        .unwrap();
+    assert_local_preserved(&store, &before);
+    let effective = store.load_effective().unwrap();
+    store.merge_effective(&effective).unwrap();
+    assert_local_preserved(&store, &before);
+    store.replace_effective(&effective).unwrap();
+    assert_local_preserved(&store, &before);
+    let mut edited = effective;
+    edited
+        .games
+        .iter_mut()
+        .find(|game| game.storage_key == "local-game")
+        .unwrap()
+        .name = "Renamed local".into();
+    store.merge_effective(&edited).unwrap();
+    assert_eq!(
+        store.load().unwrap().local_state.local_games[0].name,
+        "Renamed local"
+    );
+}
+
+#[test]
+fn cutover_retains_local_games_omitted_from_the_remote_library() {
+    let (_root, store, before) = fixture();
+    let remote = remote_library(&before);
+    let profile = &before.device_profiles["pc"];
+    let profiles = HashMap::from([("pc".into(), profile.for_shared_library(&remote))]);
+    store
+        .activate_cutover_v2(
+            &before.shared_library,
+            profile,
+            &remote,
+            &profiles,
+            "library-a",
+        )
+        .unwrap();
+    assert_local_preserved(&store, &before);
+}
+
+#[test]
+fn local_profile_projection_and_explicit_deletion_keep_the_boundary() {
+    let (_root, store, before) = fixture();
+    let remote = remote_library(&before);
+    let profile = &before.device_profiles["pc"];
+    store
+        .activate_join_v2(
+            &before.shared_library,
+            profile,
+            &remote,
+            &profile.for_shared_library(&remote),
+            "library-a",
+        )
+        .unwrap();
+    let current = store.load().unwrap();
+    let published = current.device_profiles["pc"].without_local_games(&current.local_state);
+    assert!(!published.games.contains_key("local-game"));
+    assert!(published.games.contains_key("cloud-game"));
+    assert!(
+        current.device_profiles["pc"]
+            .games
+            .contains_key("local-game")
+    );
+
+    store
+        .remove_shared_game("local-game", "Local adventure")
+        .unwrap();
+    let after = store.load().unwrap();
+    assert!(after.local_state.local_games.is_empty());
+    assert!(!after.device_profiles["pc"].games.contains_key("local-game"));
+    assert!(
+        !after
+            .assemble_effective()
+            .unwrap()
+            .games
+            .iter()
+            .any(|game| game.storage_key == "local-game")
+    );
+}
+
+#[test]
+fn accepted_local_identity_is_not_duplicated_and_preserves_its_paths() {
+    let (_root, store, before) = fixture();
+    let remote = remote_library(&before);
+    let profile = &before.device_profiles["pc"];
+    store
+        .activate_join_v2(
+            &before.shared_library,
+            profile,
+            &remote,
+            &profile.for_shared_library(&remote),
+            "library-a",
+        )
+        .unwrap();
+    let current = store.load().unwrap();
+    let mut accepted = remote.clone();
+    accepted.games.extend(before.shared_library.games.clone());
+    let current_profile = &current.device_profiles["pc"];
+    store
+        .accept_remote_shared_library(
+            &remote,
+            current_profile,
+            &accepted,
+            &current_profile.for_shared_library(&accepted),
+            "library-a",
+        )
+        .unwrap();
+    let after = store.load().unwrap();
+    assert!(after.local_state.local_games.is_empty());
+    assert_eq!(after.assemble_effective().unwrap().games.len(), 2);
+    assert_eq!(
+        after.device_profiles["pc"].games["local-game"].save_units,
+        profile.games["local-game"].save_units
+    );
+}
+
+#[test]
+fn reconnect_and_refresh_retain_local_games_without_publishing_them() {
+    let (_root, store, before) = fixture();
+    let profile = &before.device_profiles["pc"];
+    store
+        .activate_v2(&before.shared_library, profile, "library-a")
+        .unwrap();
+    let remote = remote_library(&before);
+    store
+        .accept_remote_shared_library(
+            &before.shared_library,
+            profile,
+            &remote,
+            &profile.for_shared_library(&remote),
+            "library-b",
+        )
+        .unwrap();
+    assert_local_preserved(&store, &before);
+    let current = store.load().unwrap();
+    let current_profile = &current.device_profiles["pc"];
+    store
+        .accept_remote_shared_library(
+            &remote,
+            current_profile,
+            &remote,
+            &current_profile.for_shared_library(&remote),
+            "library-b",
+        )
+        .unwrap();
+    assert_local_preserved(&store, &before);
+}

--- a/crates/rgsm-core/src/config/mod.rs
+++ b/crates/rgsm-core/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod app_config;
 pub mod backup;
+mod local_games;
 pub(crate) mod owner_store;
 mod ownership;
 #[cfg(test)]

--- a/crates/rgsm-core/src/config/owner_store.rs
+++ b/crates/rgsm-core/src/config/owner_store.rs
@@ -103,6 +103,7 @@ impl OwnerStore {
         );
         let mut owners = ConfigurationOwners::from_legacy(config, &current_device_id);
         if let Some(existing) = existing {
+            owners.preserve_local_scope(&existing.local_state);
             owners.local_state.cloud_namespace_generation =
                 existing.local_state.cloud_namespace_generation;
             owners.local_state.cloud_library_id = existing.local_state.cloud_library_id;
@@ -197,20 +198,10 @@ impl OwnerStore {
             return Err(OwnerStoreError::JoinInputsChanged);
         }
 
-        let accepted_ids = accepted_library
-            .games
-            .iter()
-            .map(|game| game.storage_key.as_str())
-            .collect::<std::collections::HashSet<_>>();
-        for profile in owners.device_profiles.values_mut() {
-            profile
-                .games
-                .retain(|id, _| accepted_ids.contains(id.as_str()));
-        }
-        owners.shared_library = accepted_library.clone();
-        owners
-            .device_profiles
-            .insert(current_device_id, accepted_profile.clone());
+        owners.accept_library(
+            accepted_library,
+            &HashMap::from([(current_device_id, accepted_profile.clone())]),
+        );
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
         owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
@@ -239,11 +230,9 @@ impl OwnerStore {
         }
 
         let accepted_current_profile = current_profile.for_shared_library(accepted_library);
-        owners.shared_library = accepted_library.clone();
-        owners.device_profiles = accepted_profiles.clone();
-        owners
-            .device_profiles
-            .insert(current_device_id, accepted_current_profile);
+        let mut profiles = accepted_profiles.clone();
+        profiles.insert(current_device_id, accepted_current_profile);
+        owners.accept_library(accepted_library, &profiles);
         owners.local_state.cloud_namespace_generation = CloudNamespaceGeneration::V2;
         owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
@@ -310,10 +299,10 @@ impl OwnerStore {
             return Err(OwnerStoreError::SharedLibraryInputsChanged);
         }
         accepted_library.validate()?;
-        owners.shared_library = accepted_library.clone();
-        owners
-            .device_profiles
-            .insert(current_device_id, accepted_profile.clone());
+        owners.accept_library(
+            accepted_library,
+            &HashMap::from([(current_device_id, accepted_profile.clone())]),
+        );
         owners.local_state.cloud_library_id = Some(library_id.to_string());
         self.write(&owners)
     }
@@ -345,6 +334,12 @@ impl OwnerStore {
             .games
             .retain(|game| game.storage_key != game_id);
         let mut changed = owners.shared_library.games.len() != previous_game_count;
+        let previous_local_count = owners.local_state.local_games.len();
+        owners
+            .local_state
+            .local_games
+            .retain(|game| game.storage_key != game_id);
+        changed |= owners.local_state.local_games.len() != previous_local_count;
         for profile in owners.device_profiles.values_mut() {
             changed |= profile.remove_game_state(game_id, game_name);
         }
@@ -597,6 +592,10 @@ fn profile_file_name(device_id: &str) -> String {
     encoded.push_str(".json");
     encoded
 }
+
+#[cfg(test)]
+#[path = "local_games_tests.rs"]
+mod local_games_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -33,6 +33,8 @@ pub enum OwnershipError {
     ProfileIdentityMismatch { key: DeviceId, embedded: DeviceId },
     #[error("Shared Library contains duplicate Game identity: {0}")]
     DuplicateSharedGame(String),
+    #[error("Game belongs to both local and shared configuration: {0}")]
+    DuplicateGameOwnership(String),
     #[error("Shared Library contains an empty Game identity")]
     EmptySharedGameId,
     #[error("Shared Game {game_id} contains duplicate Save Unit ID {save_unit_id}")]
@@ -271,6 +273,8 @@ pub struct LocalState {
     pub cloud_namespace_generation: CloudNamespaceGeneration,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cloud_library_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub local_games: Vec<SharedGame>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Type, utoipa::ToSchema)]
@@ -366,6 +370,7 @@ impl ConfigurationOwners {
                 cloud_settings: config.settings.cloud_settings.clone(),
                 cloud_namespace_generation: CloudNamespaceGeneration::LegacyV1,
                 cloud_library_id: None,
+                local_games: Vec::new(),
             },
         }
     }
@@ -373,6 +378,7 @@ impl ConfigurationOwners {
     pub fn validate(&self) -> Result<(), OwnershipError> {
         validate_schema("Configuration Owners", self.schema_version)?;
         self.shared_library.validate()?;
+        self.validate_local_games()?;
         validate_schema("Local State", self.local_state.schema_version)?;
         if self.local_state.cloud_namespace_generation == CloudNamespaceGeneration::V2
             && self
@@ -439,6 +445,7 @@ impl ConfigurationOwners {
             .shared_library
             .games
             .iter()
+            .chain(self.local_state.local_games.iter())
             .map(|game| (game.storage_key.as_str(), game.snapshot_retention))
             .collect::<HashMap<_, _>>();
         for game in &mut incoming.shared_library.games {
@@ -458,6 +465,7 @@ impl ConfigurationOwners {
                 !previously_shared.contains(game_id)
             }
         });
+        incoming.preserve_local_scope(&self.local_state);
         self.shared_library = incoming.shared_library;
         incoming.local_state.cloud_namespace_generation =
             self.local_state.cloud_namespace_generation;
@@ -476,6 +484,7 @@ impl ConfigurationOwners {
             .shared_library
             .games
             .iter()
+            .chain(self.local_state.local_games.iter())
             .map(|game| game.storage_key.as_str())
             .collect::<HashSet<_>>();
         for profile in self.device_profiles.values_mut() {
@@ -499,6 +508,7 @@ impl ConfigurationOwners {
             .shared_library
             .games
             .iter()
+            .chain(self.local_state.local_games.iter())
             .map(|shared| self.assemble_game(shared, current_device_id))
             .collect();
         let devices = self

--- a/crates/rgsm-core/src/preclude/errors.rs
+++ b/crates/rgsm-core/src/preclude/errors.rs
@@ -94,6 +94,8 @@ impl From<BackupError> for BackendError {
 /// 备份或恢复快照时可能产生的错误
 #[derive(Debug, Error)]
 pub enum BackupError {
+    #[error("Use retention protection without changing shared Snapshot creation provenance")]
+    SharedSnapshotProvenance,
     #[error("Backup for {name} not exists: {date}")]
     BackupNotExist { name: String, date: String },
     #[error("No backups available")]

--- a/crates/rgsm-core/src/services/device_game_lifecycle.rs
+++ b/crates/rgsm-core/src/services/device_game_lifecycle.rs
@@ -12,11 +12,28 @@ use super::{CloudLibraryServiceError, ServiceContext, cloud_library_target::boun
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct DeviceGameStatus {
     pub game_id: String,
+    pub shared: bool,
     pub managed: bool,
     pub visible: bool,
 }
 
 impl ServiceContext {
+    pub fn is_shared_game(&self, identity: &str) -> Result<bool, CloudLibraryServiceError> {
+        let config = get_config()?;
+        let Some(index) = config.position_game_by_identity(identity) else {
+            return Ok(false);
+        };
+        let game_id = &config.games[index].storage_key;
+        let (library, _, local_state) = cloud_bootstrap_inputs()?;
+        Ok(
+            local_state.cloud_namespace_generation == CloudNamespaceGeneration::V2
+                && library
+                    .games
+                    .iter()
+                    .any(|game| &game.storage_key == game_id),
+        )
+    }
+
     pub fn current_device_game_statuses(
         &self,
     ) -> Result<Vec<DeviceGameStatus>, CloudLibraryServiceError> {
@@ -27,17 +44,25 @@ impl ServiceContext {
                 .into_iter()
                 .map(|game| DeviceGameStatus {
                     game_id: game.storage_key,
+                    shared: false,
                     managed: true,
                     visible: true,
                 })
                 .collect());
         }
+        let local_ids = local_state
+            .local_games
+            .iter()
+            .map(|game| game.storage_key.clone())
+            .collect::<std::collections::HashSet<_>>();
         Ok(library
             .games
             .into_iter()
+            .chain(local_state.local_games)
             .map(|game| {
                 let settings = profile.games.get(&game.storage_key);
                 DeviceGameStatus {
+                    shared: !local_ids.contains(&game.storage_key),
                     game_id: game.storage_key,
                     managed: settings.is_some(),
                     visible: settings.is_some_and(|settings| settings.visible),
@@ -66,6 +91,7 @@ impl ServiceContext {
         publish_profile(&local_state, &expected, &accepted).await?;
         Ok(DeviceGameStatus {
             game_id: game_id.to_string(),
+            shared: true,
             managed: true,
             visible,
         })
@@ -114,6 +140,7 @@ impl ServiceContext {
         publish_profile(&local_state, &expected, &accepted).await?;
         Ok(DeviceGameStatus {
             game_id: game_id.to_string(),
+            shared: true,
             managed,
             visible: managed,
         })
@@ -185,8 +212,104 @@ async fn publish_profile(
     accepted: &crate::config::DeviceProfile,
 ) -> Result<(), CloudLibraryServiceError> {
     DeviceProfileRepository::new(bound_v2_operator(local_state).await?, 3)
-        .publish(&local_state.current_device_id, accepted)
+        .publish(
+            &local_state.current_device_id,
+            &accepted.without_local_games(local_state),
+        )
         .await?;
     replace_current_device_profile(expected, accepted)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::config::{
+        Config, ConfigTestStateGuard, activate_joined_cloud_library, set_config_local,
+    };
+    use crate::hooks::HookPipeline;
+
+    #[test]
+    fn shared_ownership_resolves_local_ids_before_cloud_display_names() {
+        let _config_lock = crate::config::lock_config_test_file();
+        let archives = temp_dir::TempDir::new().unwrap();
+        let config = Config {
+            backup_path: archives.path().to_string_lossy().into_owned(),
+            games: serde_json::from_value(serde_json::json!([
+                {"name": "Renamed Local", "storage_key": "Old Name", "save_paths": []},
+                {"name": "Old Name", "storage_key": "remote-key", "save_paths": []}
+            ]))
+            .unwrap(),
+            ..Config::default()
+        };
+        let _config_state = ConfigTestStateGuard::replace_with(&config).unwrap();
+        set_config_local(&config).unwrap();
+        let (before, profile, _) = cloud_bootstrap_inputs().unwrap();
+        let mut remote = before.clone();
+        remote.games.retain(|game| game.storage_key == "remote-key");
+        activate_joined_cloud_library(
+            &before,
+            &profile,
+            &remote,
+            &profile.for_shared_library(&remote),
+            "11111111-1111-4111-8111-111111111111",
+        )
+        .unwrap();
+
+        let service = ServiceContext::new(Arc::new(HookPipeline::new(vec![])));
+        assert!(!service.is_shared_game("Old Name").unwrap());
+        assert!(!service.is_shared_game("Renamed Local").unwrap());
+        assert!(service.is_shared_game("remote-key").unwrap());
+        assert!(!service.is_shared_game("missing").unwrap());
+
+        for game in &config.games {
+            let mut snapshots = crate::backup::GameSnapshots::new(&game.name);
+            snapshots.backups.push(
+                serde_json::from_value(serde_json::json!({
+                    "date": "2026-09-05_12-00-00", "describe": "", "path": "test.zip",
+                    "created_by": "Timer"
+                }))
+                .unwrap(),
+            );
+            game.set_game_snapshots_info(&snapshots).unwrap();
+        }
+        // This legacy endpoint accepts display names. Its ownership check must
+        // protect the same resolved Game that the metadata operation modifies.
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            assert!(
+                service
+                    .set_snapshot_created_by(
+                        "Old Name",
+                        "2026-09-05_12-00-00",
+                        crate::backup::CreatedBy::Manual,
+                        crate::hooks::HookSource::UserManual,
+                    )
+                    .await
+                    .is_err()
+            );
+            service
+                .set_snapshot_created_by(
+                    "Renamed Local",
+                    "2026-09-05_12-00-00",
+                    crate::backup::CreatedBy::Manual,
+                    crate::hooks::HookSource::UserManual,
+                )
+                .await
+                .unwrap();
+        });
+        assert_eq!(
+            config.games[0].get_game_snapshots_info().unwrap().backups[0].created_by,
+            crate::backup::CreatedBy::Manual
+        );
+        assert_eq!(
+            config.games[1].get_game_snapshots_info().unwrap().backups[0].created_by,
+            crate::backup::CreatedBy::Timer
+        );
+    }
 }

--- a/crates/rgsm-core/src/services/game.rs
+++ b/crates/rgsm-core/src/services/game.rs
@@ -92,6 +92,11 @@ impl ServiceContext {
         config
             .quick_action
             .sync_updated_game_reference(&previous_game, &updated_game);
+        crate::config::FavoriteTreeNode::rename_game_leaves(
+            &mut config.favorites,
+            &previous_game.name,
+            &updated_game.name,
+        );
         set_config(&config).await?;
         if let Some(expected) = v2_change
             && let Err(error) = publish_v2_game_change(expected).await
@@ -342,6 +347,12 @@ async fn publish_v2_game_change(expected: ExpectedV2GameChange) -> Result<()> {
         bail!("Cloud Library ownership changed while the Game was being saved");
     }
 
+    let accepted_profile = accepted_profile.without_local_games(&accepted_state);
+    let expected_profile = expected.profile.without_local_games(&expected.local_state);
+    // Editing a local-only Game remains usable while the cloud is unavailable.
+    if expected.library == accepted_library && expected_profile == accepted_profile {
+        return Ok(());
+    }
     let operator = bound_v2_operator(&expected.local_state).await?;
     let shared = SharedLibraryRepository::new(operator.clone(), 3);
     let committed_library = shared
@@ -354,7 +365,7 @@ async fn publish_v2_game_change(expected: ExpectedV2GameChange) -> Result<()> {
         .await
     {
         let profile_rollback = profiles
-            .publish(&accepted_state.current_device_id, &expected.profile)
+            .publish(&accepted_state.current_device_id, &expected_profile)
             .await;
         let library_rollback = shared
             .compare_replace(&committed_library, &expected.library)
@@ -393,7 +404,7 @@ async fn publish_v2_game_change(expected: ExpectedV2GameChange) -> Result<()> {
             .await
         {
             let profile_rollback = profiles
-                .publish(&accepted_state.current_device_id, &expected.profile)
+                .publish(&accepted_state.current_device_id, &expected_profile)
                 .await;
             let library_rollback = shared
                 .compare_replace(&committed_library, &expected.library)

--- a/crates/rgsm-core/src/services/snapshot.rs
+++ b/crates/rgsm-core/src/services/snapshot.rs
@@ -466,6 +466,15 @@ impl ServiceContext {
                 date: snapshot_date.to_string(),
             })?;
 
+        // Resolve the name-only legacy endpoint once before checking ownership.
+        // An unrelated local ID may be identical to this Game's display name.
+        if self
+            .is_shared_game(&game.storage_key)
+            .map_err(|error| BackupError::Unexpected(error.into()))?
+        {
+            return Err(BackupError::SharedSnapshotProvenance);
+        }
+
         let mut snapshots = game.get_game_snapshots_info()?;
         let snapshot = snapshots
             .backups

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -629,6 +629,26 @@ impl ServiceContext {
         confirmed: bool,
         current_position: Option<CurrentPositionDecision>,
     ) -> Result<(), CloudLibraryServiceError> {
+        let (_, _, local_state) = cloud_bootstrap_inputs()?;
+        if local_state
+            .local_games
+            .iter()
+            .any(|game| game.storage_key == game_id)
+        {
+            if !confirmed {
+                return Err(CloudLibraryServiceError::ConfirmationRequired);
+            }
+            let game = get_config()?
+                .games
+                .into_iter()
+                .find(|game| game.storage_key == game_id)
+                .ok_or_else(|| {
+                    CloudLibraryServiceError::GameProfileNotFound(game_id.to_string())
+                })?;
+            return Ok(self
+                .delete_snapshot(&game, snapshot_id, HookSource::UserManual)
+                .await?);
+        }
         // Only execute the Current Position decision when the caller has
         // confirmed deletion. Unconfirmed requests must not have destructive
         // side effects (Apply restores files, Capture creates a snapshot).
@@ -765,7 +785,10 @@ impl ServiceContext {
         }
 
         DeviceProfileRepository::new(operator.clone(), 3)
-            .publish(&local_state.current_device_id, &accepted_profile)
+            .publish(
+                &local_state.current_device_id,
+                &accepted_profile.without_local_games(&local_state),
+            )
             .await?;
         replace_current_device_profile(&expected_profile, &accepted_profile)?;
 
@@ -1070,7 +1093,10 @@ pub(super) async fn set_multi_device_sync_suspended(
     }
     settings.multi_device_sync_suspended = suspended;
     DeviceProfileRepository::new(bound_v2_operator(&local_state).await?, 3)
-        .publish(&local_state.current_device_id, &accepted)
+        .publish(
+            &local_state.current_device_id,
+            &accepted.without_local_games(&local_state),
+        )
         .await?;
     replace_current_device_profile(&expected, &accepted)?;
     Ok(())

--- a/docs/sync-model.md
+++ b/docs/sync-model.md
@@ -22,6 +22,8 @@ The player keeps automatic local capture enabled for rollback and corruption rec
 
 The player owns multiple Devices, but only some Games overlap. Cloud sync must be enabled independently per Game and Device; one Device must not be forced to synchronize the full Shared Library.
 
+Connecting, migrating, or refreshing a cloud library preserves Games that exist only locally, including their save paths and backups. Absence from a cloud directory is not a deletion request. Local-only definitions remain separate from the accepted Shared Library, so ordinary local edits do not publish them or require a working cloud connection. Explicit shared deletion records still remove the matching identity.
+
 ## Domain model
 
 Synchronization has one per-Game on/off switch plus a remembered cloud preset. Capture, Archive transfer, remote Apply, visibility, local Archive presence, and deletion remain distinct concepts even when presets keep the ordinary UI simple.
@@ -183,4 +185,3 @@ Matching positions on other Devices do not block deletion. They are cleared when
 - Global Snapshot Deletion moves the initiating Device's Current Position to the deleted Snapshot's parent (or clears it if no parent exists). Other Devices' positions are cleared without automatic ancestor fallback.
 - Local and Cloud Archive eviction use consequence warnings rather than requiring a verified replacement copy.
 - Evicting the last known Archive leaves the Snapshot visible but unavailable; it is not Global Snapshot Deletion.
-


### PR DESCRIPTION
Depends on #527

Connecting, refreshing, or switching cloud libraries no longer removes games missing from the remote library

- Retain local-only definitions alongside the accepted cloud library, with existing device paths and settings
- Keep local edits, favorites, backup/restore, deletion, and permanent-snapshot conversion usable when the cloud is offline
- Route snapshot actions by each game's ownership, preserving shared-snapshot restrictions even when a legacy ID matches another game's name

This does not change the connection or definition-conflict UI; those follow separately
