### PR TITLE
fix(sync): require explicit game definition choices

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -61,6 +61,7 @@ jobs:
           e2e/cloud-library-late-game.spec.ts
           e2e/cloud-catalog-read.spec.ts
           e2e/cloud-local-games.spec.ts
+          e2e/cloud-definition-choices.spec.ts
           e2e/cloud-sync-modes.spec.ts
           e2e/cloud-reset-library.spec.ts
 

--- a/apps/rgsm-gui/e2e/cloud-definition-choices.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-definition-choices.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from '@playwright/test';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import { cloudPaths, readJson } from './support/cloud-assertions';
+import { GAME_NAME, STORAGE_KEY } from './support/constants';
+import { createLibrary, expectLibraryKind } from './support/gui';
+import { getLocalGame, updateGameViaApi } from './support/local-gui';
+import { createRunRoot, hostPost } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+for (const choice of ['cloud', 'local'] as const) {
+  test(`a genuine definition conflict requires an explicit ${choice} choice`, async ({
+    browser,
+  }) => {
+    const runRoot = await createRunRoot(`definition-${choice}`);
+    const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+    const storageKey = choice === 'cloud' ? 'constructor' : '__proto__';
+    for (const device of [seeded.deviceA, seeded.deviceB]) {
+      const configPath = join(device.appDataDir, 'GameSaveManager.config.json');
+      const config = JSON.parse(await readFile(configPath, 'utf8'));
+      config.games[0].storage_key = storageKey;
+      config.games[0].cloud_sync_enabled = false;
+      if (device === seeded.deviceA) config.games[0].name = 'Local title';
+      await writeFile(configPath, JSON.stringify(config));
+      await mkdir(join(device.archiveRoot, storageKey));
+      await copyFile(
+        join(device.archiveRoot, STORAGE_KEY, 'Backups.json'),
+        join(device.archiveRoot, storageKey, 'Backups.json')
+      );
+    }
+    const session = await startDualSession(browser, { ...seeded, runRoot, label: 'definition' });
+    let failed = false;
+    try {
+      await createLibrary(session.pageB);
+      const before = await getLocalGame(session.hostA, 'Local title');
+      const omitted = await hostPost<{ kind: string }>(
+        session.hostA,
+        '/api/v1/join-cloud-library',
+        {
+          decisions: [],
+          confirmedReplacements: false,
+        }
+      );
+      expect(omitted.ok, omitted.raw).toBe(true);
+      expect(omitted.data.kind).toBe('review_changed');
+      expect(await getLocalGame(session.hostA, 'Local title')).toEqual(before);
+      await session.pageA.goto('/SyncSettings');
+      await expectLibraryKind(session.pageA, 'join');
+      await session.pageA.getByRole('button', { name: 'Join library' }).first().click();
+      const dialog = session.pageA.getByRole('dialog', { name: 'Confirm Cloud Library join' });
+      await expect(dialog).toBeVisible();
+      const submit = dialog.getByRole('button', { name: 'Join library', exact: true });
+      await expect(submit).toBeDisabled();
+      const option = dialog.getByRole('button', {
+        name: choice === 'cloud' ? 'Keep the cloud version' : 'Replace the shared game definition',
+        exact: true,
+      });
+      await expect(option).toHaveAttribute('aria-pressed', 'false');
+      await option.click();
+      await expect(submit).toBeEnabled();
+      await submit.click();
+      if (choice === 'local') {
+        await session.pageA.getByRole('button', { name: 'Replace and join', exact: true }).click();
+      }
+      await expect(dialog).toBeHidden();
+      const expectedName = choice === 'cloud' ? GAME_NAME : 'Local title';
+      const accepted = await getLocalGame(session.hostA, expectedName);
+      expect(accepted.storage_key).toBe(storageKey);
+      expect(accepted.save_paths).toEqual(before.save_paths);
+      const remote = await readJson(cloudPaths(seeded.cloudRoot).sharedLibrary);
+      expect(remote.games).toEqual([
+        expect.objectContaining({ storage_key: storageKey, name: expectedName }),
+      ]);
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      await session.close(failed);
+    }
+  });
+}
+
+test('a definition changed after an equal review reloads the pending choice', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('definition-changed');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, {
+    ...seeded,
+    runRoot,
+    label: 'definition-changed',
+  });
+  let failed = false;
+  try {
+    await createLibrary(session.pageB);
+    await session.pageA.goto('/SyncSettings');
+    await expectLibraryKind(session.pageA, 'join');
+    await session.pageA.getByRole('button', { name: 'Join library' }).first().click();
+    const original = session.pageA.getByRole('dialog', { name: 'Join Cloud Library', exact: true });
+    await expect(original.getByRole('button', { name: 'Join library', exact: true })).toBeEnabled();
+    const game = await getLocalGame(session.hostB, GAME_NAME);
+    await updateGameViaApi(session.hostB, STORAGE_KEY, { ...game, name: 'Changed cloud title' });
+    const remoteBefore = await readFile(cloudPaths(seeded.cloudRoot).sharedLibrary);
+    await original.getByRole('button', { name: 'Join library', exact: true }).click();
+    const changed = session.pageA.getByRole('dialog', { name: 'Confirm Cloud Library join' });
+    await expect(changed).toBeVisible();
+    await expect(changed.getByText('Changed cloud title', { exact: true })).toBeVisible();
+    await expect(changed.getByRole('button', { name: 'Join library', exact: true })).toBeDisabled();
+    expect(await readFile(cloudPaths(seeded.cloudRoot).sharedLibrary)).toEqual(remoteBefore);
+    expect((await getLocalGame(session.hostA, GAME_NAME)).name).toBe(GAME_NAME);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/src/components/CloudLibraryJoinDialog.vue
+++ b/apps/rgsm-gui/src/components/CloudLibraryJoinDialog.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
 
 const feedback = useFeedback();
 const review = ref<CloudLibraryJoinReview | null>(null);
-const actions = ref<Record<string, JoinGameAction>>({});
+const actions = ref(new Map<string, JoinGameAction>());
 const selectedId = ref('');
 const loading = ref(false);
 const joining = ref(false);
@@ -38,13 +38,20 @@ const selected = computed(
   () => review.value?.items.find((item) => item.local_game_id === selectedId.value) ?? null
 );
 const replacementCount = computed(
-  () => Object.values(actions.value).filter((action) => action === 'replace_cloud').length
+  () => [...actions.value.values()].filter((action) => action === 'replace_cloud').length
 );
 const changedCount = computed(
   () => review.value?.items.filter((item) => item.classification !== 'same').length ?? 0
 );
 const reviewItems = computed(
   () => review.value?.items.filter((item) => item.classification !== 'same') ?? []
+);
+const unresolvedCount = computed(
+  () =>
+    review.value?.items.filter(
+      (item) =>
+        item.classification === 'game_definition_conflict' && !actions.value.has(item.local_game_id)
+    ).length ?? 0
 );
 
 function classificationLabel(item: CloudLibraryJoinItem) {
@@ -77,8 +84,10 @@ async function loadReview() {
       return;
     }
     review.value = result.data;
-    actions.value = Object.fromEntries(
-      result.data.items.map((item) => [item.local_game_id, 'keep_cloud'])
+    actions.value = new Map<string, JoinGameAction>(
+      result.data.items
+        .filter((item) => item.classification !== 'game_definition_conflict')
+        .map((item) => [item.local_game_id, 'keep_cloud'])
     );
     selectedId.value =
       result.data.items.find((item) => item.classification !== 'same')?.local_game_id ??
@@ -108,16 +117,23 @@ function decisionOptions(item: CloudLibraryJoinItem): { value: JoinGameAction; l
 function decisions(): JoinGameDecision[] {
   return (review.value?.items ?? [])
     .filter((item) => item.classification !== 'same')
-    .map((item) => ({
-      local_game_id: item.local_game_id,
-      local_fingerprint: item.local_fingerprint,
-      cloud_fingerprint: item.cloud_fingerprint,
-      action: actions.value[item.local_game_id] ?? 'keep_cloud',
-    }));
+    .flatMap((item) => {
+      const action = actions.value.get(item.local_game_id);
+      return action
+        ? [
+            {
+              local_game_id: item.local_game_id,
+              local_fingerprint: item.local_fingerprint,
+              cloud_fingerprint: item.cloud_fingerprint,
+              action,
+            },
+          ]
+        : [];
+    });
 }
 
 async function submit() {
-  if (!review.value || joining.value) return;
+  if (!review.value || joining.value || unresolvedCount.value) return;
   if (replacementCount.value > 0) {
     try {
       await feedback.confirm(
@@ -293,15 +309,15 @@ watch(
                 type="button"
                 class="flex cursor-pointer items-center gap-2 rounded-sm border px-2.5 py-1.5 text-left text-sm transition-colors focus-visible:outline-2 focus-visible:outline-accent"
                 :class="
-                  actions[selected.local_game_id] === option.value
+                  actions.get(selected.local_game_id) === option.value
                     ? 'border-accent bg-accent-soft text-text'
                     : 'border-border bg-surface text-text-dim hover:border-border-strong hover:text-text'
                 "
-                :aria-pressed="actions[selected.local_game_id] === option.value"
-                @click="actions[selected.local_game_id] = option.value"
+                :aria-pressed="actions.get(selected.local_game_id) === option.value"
+                @click="actions.set(selected.local_game_id, option.value)"
               >
                 <CheckCircle2
-                  v-if="actions[selected.local_game_id] === option.value"
+                  v-if="actions.get(selected.local_game_id) === option.value"
                   :size="14"
                   class="shrink-0 text-accent"
                   aria-hidden="true"
@@ -324,8 +340,16 @@ watch(
     </template>
 
     <template #footer>
+      <span v-if="unresolvedCount" class="mr-auto text-xs text-text-dim">
+        {{ $t('sync_settings.library.join.choice_required', { count: unresolvedCount }) }}
+      </span>
       <KButton @click="visible = false">{{ $t('sync_settings.cancel') }}</KButton>
-      <KButton variant="primary" :loading="joining" :disabled="loading || !review" @click="submit">
+      <KButton
+        variant="primary"
+        :loading="joining"
+        :disabled="loading || !review || unresolvedCount > 0"
+        @click="submit"
+      >
         {{ $t('sync_settings.library.join.join_action') }}
       </KButton>
     </template>

--- a/crates/rgsm-core/src/cloud_sync/v2/join.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join.rs
@@ -187,7 +187,10 @@ fn build_review(
                     .iter()
                     .map(|game| game.name.clone())
                     .collect(),
-                cloud_fingerprint: cloud.map(|game| game.portable_fingerprint()).transpose()?,
+                cloud_fingerprint: cloud
+                    .filter(|game| game.storage_key == candidate.local.storage_key)
+                    .map(|game| game.portable_fingerprint())
+                    .transpose()?,
                 classification: candidate.classification,
                 difference: difference(&candidate.local, cloud),
             })
@@ -250,6 +253,20 @@ fn apply_decisions(
         .iter()
         .map(|game| (game.storage_key.as_str(), game))
         .collect::<HashMap<_, _>>();
+    // A missing decision is not permission to replace a local definition.
+    // Only the same stable identity can require a choice; titles are not IDs.
+    for cloud_game in &latest.games {
+        if let Some(local_game) = local_by_id.get(cloud_game.storage_key.as_str())
+            && local_game.normalized_portable() != cloud_game.normalized_portable()
+            && !decisions
+                .iter()
+                .any(|decision| decision.local_game_id == local_game.storage_key)
+        {
+            return Err(CloudLibraryJoinError::DecisionRequired(
+                local_game.name.clone(),
+            ));
+        }
+    }
     for decision in decisions {
         let local_game = local_by_id[decision.local_game_id.as_str()];
         if local_game.portable_fingerprint()? != decision.local_fingerprint {
@@ -262,7 +279,16 @@ fn apply_decisions(
             .iter()
             .position(|game| game.storage_key == decision.local_game_id);
         match decision.action {
-            JoinGameAction::KeepCloud => {}
+            JoinGameAction::KeepCloud => {
+                let actual = cloud_index
+                    .map(|index| latest.games[index].portable_fingerprint())
+                    .transpose()?;
+                if actual != decision.cloud_fingerprint {
+                    return Err(CloudLibraryJoinError::TargetChanged(
+                        local_game.name.clone(),
+                    ));
+                }
+            }
             JoinGameAction::AddLocal => match cloud_index {
                 None => latest.games.push(local_game.clone()),
                 Some(_) => {
@@ -315,6 +341,8 @@ pub enum CloudLibraryJoinError {
     JoinUnavailable(&'static str),
     #[error("Invalid join decision for Game: {0}")]
     InvalidDecision(String),
+    #[error("Choose the local or cloud definition for Game: {0}")]
+    DecisionRequired(String),
     #[error("Local Game changed during join review: {0}")]
     LocalGameChanged(String),
     #[error("Cloud Game changed during join review: {0}")]
@@ -326,244 +354,5 @@ pub enum CloudLibraryJoinError {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Mutex as StdMutex;
-
-    use async_trait::async_trait;
-
-    use super::*;
-    use crate::cloud_sync::v2::{
-        CLOUD_MANIFEST_PATH, CloudManifest, CloudNamespaceDescriptor, NamespaceTransport,
-        V2_NAMESPACE_DESCRIPTOR_PATH,
-    };
-    use crate::config::{
-        ConfigurationOwners, SharedSaveUnit, SharedSaveUnitSource, SharedSnapshotRetentionPolicy,
-        V2_CONFIG_SCHEMA_VERSION,
-    };
-
-    const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
-
-    #[derive(Default)]
-    struct FakeTransport {
-        objects: StdMutex<BTreeMap<String, Vec<u8>>>,
-        writes: StdMutex<Vec<String>>,
-    }
-
-    #[async_trait]
-    impl NamespaceTransport for FakeTransport {
-        async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
-            Ok(self.objects.lock().unwrap().get(path).cloned())
-        }
-
-        async fn list_sample(
-            &self,
-            prefix: &str,
-            limit: usize,
-        ) -> Result<Vec<String>, opendal::Error> {
-            Ok(self
-                .objects
-                .lock()
-                .unwrap()
-                .keys()
-                .filter(|path| prefix == "/" || path.starts_with(prefix))
-                .take(limit)
-                .cloned()
-                .collect())
-        }
-    }
-
-    #[async_trait]
-    impl CloudLibraryTransport for FakeTransport {
-        async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error> {
-            self.writes.lock().unwrap().push(path.to_string());
-            self.objects
-                .lock()
-                .unwrap()
-                .insert(path.to_string(), bytes.to_vec());
-            Ok(())
-        }
-    }
-
-    fn game(id: &str, name: &str, unit_id: u32) -> SharedGame {
-        SharedGame {
-            name: name.into(),
-            storage_key: id.into(),
-            save_units: vec![SharedSaveUnit {
-                id: unit_id,
-                source: SharedSaveUnitSource::Concrete {
-                    unit_type: crate::backup::SaveUnitType::Folder,
-                },
-            }],
-            next_save_unit_id: unit_id + 1,
-            ludusavi_meta: None,
-            snapshot_retention: None,
-        }
-    }
-
-    fn library(games: Vec<SharedGame>) -> SharedLibrary {
-        SharedLibrary {
-            schema_version: V2_CONFIG_SCHEMA_VERSION,
-            games,
-        }
-    }
-
-    fn transport(cloud: &SharedLibrary) -> FakeTransport {
-        let transport = FakeTransport::default();
-        let mut objects = transport.objects.lock().unwrap();
-        objects.insert(
-            V2_NAMESPACE_DESCRIPTOR_PATH.into(),
-            serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id(LIBRARY_ID)).unwrap(),
-        );
-        objects.insert(
-            CLOUD_MANIFEST_PATH.into(),
-            serde_json::to_vec(&CloudManifest::default()).unwrap(),
-        );
-        objects.insert(
-            SHARED_LIBRARY_PATH.into(),
-            serde_json::to_vec(cloud).unwrap(),
-        );
-        drop(objects);
-        transport
-    }
-
-    fn profile(local: &SharedLibrary) -> DeviceProfile {
-        let config = crate::config::Config {
-            games: local
-                .games
-                .iter()
-                .map(|game| crate::backup::Game {
-                    name: game.name.clone(),
-                    storage_key: game.storage_key.clone(),
-                    save_paths: Vec::new(),
-                    game_paths: HashMap::new(),
-                    next_save_unit_id: game.next_save_unit_id,
-                    cloud_sync_enabled: false,
-                    auto_backup: None,
-                    ludusavi_meta: None,
-                    device_bindings: HashMap::new(),
-                })
-                .collect(),
-            ..Default::default()
-        };
-        let owners = ConfigurationOwners::from_legacy(&config, &"device".into());
-        owners.device_profiles["device"].clone()
-    }
-
-    #[tokio::test]
-    async fn review_is_read_only_and_classifies_all_local_games() {
-        let mut conflict = game("conflict", "Conflict", 1);
-        let cloud_conflict = conflict.clone();
-        conflict.name = "Local Conflict".into();
-        let local = library(vec![
-            game("same", "Same", 1),
-            game("local", "Local", 1),
-            game("duplicate", "Duplicate", 1),
-            conflict,
-        ]);
-        let cloud = library(vec![
-            game("same", "Same", 1),
-            game("remote-duplicate", "Duplicate", 1),
-            cloud_conflict,
-        ]);
-        let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
-
-        let review = join.review(&local).await.unwrap();
-
-        assert_eq!(review.items.len(), 4);
-        assert_eq!(
-            review
-                .items
-                .iter()
-                .map(|item| item.classification)
-                .collect::<Vec<_>>(),
-            vec![
-                GameJoinClassification::GameDefinitionConflict,
-                GameJoinClassification::PossibleDuplicate,
-                GameJoinClassification::LocalOnly,
-                GameJoinClassification::Same,
-            ]
-        );
-        assert!(join.transport.writes.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn join_adds_and_replaces_whole_games_then_publishes_profile() {
-        let local_only = game("local", "Local", 1);
-        let replacement = game("conflict", "Local Conflict", 2);
-        let mut cloud_conflict = game("conflict", "Cloud Conflict", 1);
-        cloud_conflict.snapshot_retention = Some(SharedSnapshotRetentionPolicy {
-            automatic_snapshots_per_branch: 4,
-        });
-        let local = library(vec![local_only.clone(), replacement.clone()]);
-        let cloud = library(vec![cloud_conflict.clone(), game("remote", "Remote", 1)]);
-        let review = build_review(&local, &cloud).unwrap();
-        let decisions = review
-            .items
-            .iter()
-            .map(|item| JoinGameDecision {
-                local_game_id: item.local_game_id.clone(),
-                local_fingerprint: item.local_fingerprint.clone(),
-                cloud_fingerprint: item.cloud_fingerprint.clone(),
-                action: if item.local_game_id == "local" {
-                    JoinGameAction::AddLocal
-                } else {
-                    JoinGameAction::ReplaceCloud
-                },
-            })
-            .collect::<Vec<_>>();
-        let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
-
-        let result = join
-            .join(&local, &profile(&local), &decisions, true)
-            .await
-            .unwrap();
-        assert_eq!(result.library_id, LIBRARY_ID);
-        let accepted = result.shared_library;
-
-        assert!(accepted.games.contains(&local_only));
-        let accepted_replacement = accepted
-            .games
-            .iter()
-            .find(|game| game.storage_key == "conflict")
-            .unwrap();
-        assert_eq!(accepted_replacement.name, replacement.name);
-        assert_eq!(accepted_replacement.save_units, replacement.save_units);
-        assert_eq!(
-            accepted_replacement.snapshot_retention,
-            cloud_conflict.snapshot_retention
-        );
-        assert!(
-            accepted
-                .games
-                .iter()
-                .any(|game| game.storage_key == "remote")
-        );
-        assert_eq!(
-            join.transport.writes.lock().unwrap().as_slice(),
-            [SHARED_LIBRARY_PATH, device_profile_path("device").as_str()]
-        );
-    }
-
-    #[tokio::test]
-    async fn stale_replacement_does_not_write() {
-        let local = library(vec![game("game", "Local", 2)]);
-        let reviewed_cloud = library(vec![game("game", "Cloud", 1)]);
-        let review = build_review(&local, &reviewed_cloud).unwrap();
-        let decision = JoinGameDecision {
-            local_game_id: "game".into(),
-            local_fingerprint: review.items[0].local_fingerprint.clone(),
-            cloud_fingerprint: review.items[0].cloud_fingerprint.clone(),
-            action: JoinGameAction::ReplaceCloud,
-        };
-        let changed_cloud = library(vec![game("game", "Changed Again", 3)]);
-        let join = CloudLibraryJoin::with_transport(transport(&changed_cloud), 2);
-
-        assert!(matches!(
-            join.join(&local, &profile(&local), &[decision], true)
-                .await,
-            Err(CloudLibraryJoinError::TargetChanged(name)) if name == "Local"
-        ));
-        assert!(join.transport.writes.lock().unwrap().is_empty());
-    }
-}
+#[path = "join_tests.rs"]
+mod tests;

--- a/crates/rgsm-core/src/cloud_sync/v2/join_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/join_tests.rs
@@ -1,0 +1,358 @@
+use std::collections::BTreeMap;
+use std::sync::Mutex as StdMutex;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::cloud_sync::v2::{
+    CLOUD_MANIFEST_PATH, CloudManifest, CloudNamespaceDescriptor, NamespaceTransport,
+    V2_NAMESPACE_DESCRIPTOR_PATH,
+};
+use crate::config::{
+    ConfigurationOwners, SharedSaveUnit, SharedSaveUnitSource, SharedSnapshotRetentionPolicy,
+    V2_CONFIG_SCHEMA_VERSION,
+};
+
+const LIBRARY_ID: &str = "11111111-1111-4111-8111-111111111111";
+
+#[tokio::test]
+async fn conflicting_definitions_require_a_choice_before_any_write() {
+    let local = library(vec![game("same-id", "Local", 2)]);
+    let cloud = library(vec![game("same-id", "Cloud", 1)]);
+    let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+    assert!(matches!(
+        join.join(&local, &profile(&local), &[], false).await,
+        Err(CloudLibraryJoinError::DecisionRequired(_))
+    ));
+    assert!(join.transport.writes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn keep_cloud_rejects_a_definition_changed_after_review() {
+    let local = library(vec![game("same-id", "Local", 2)]);
+    let reviewed = library(vec![game("same-id", "Cloud", 1)]);
+    let review = build_review(&local, &reviewed).unwrap();
+    let changed = library(vec![game("same-id", "Changed later", 3)]);
+    let join = CloudLibraryJoin::with_transport(transport(&changed), 2);
+    let decision = JoinGameDecision {
+        local_game_id: "same-id".into(),
+        local_fingerprint: review.items[0].local_fingerprint.clone(),
+        cloud_fingerprint: review.items[0].cloud_fingerprint.clone(),
+        action: JoinGameAction::KeepCloud,
+    };
+    assert!(matches!(
+        join.join(&local, &profile(&local), &[decision], false)
+            .await,
+        Err(CloudLibraryJoinError::TargetChanged(_))
+    ));
+    assert!(join.transport.writes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn equal_definitions_and_same_titles_with_different_ids_do_not_require_a_choice() {
+    let local = library(vec![
+        game("same-id", "Same", 1),
+        game("local-id", "Title", 2),
+    ]);
+    let cloud = library(vec![
+        game("cloud-id", "Title", 3),
+        game("same-id", "Same", 1),
+    ]);
+    let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+    let result = join
+        .join(&local, &profile(&local), &[], false)
+        .await
+        .unwrap();
+    assert_eq!(result.shared_library, cloud);
+    assert_eq!(
+        join.transport.writes.lock().unwrap().as_slice(),
+        [device_profile_path("device")]
+    );
+}
+
+#[tokio::test]
+async fn unrelated_cloud_edits_do_not_invalidate_a_reviewed_choice() {
+    let local = library(vec![game("same-id", "Local", 2)]);
+    let reviewed = library(vec![game("same-id", "Cloud", 1)]);
+    let review = build_review(&local, &reviewed).unwrap();
+    let mut changed = reviewed;
+    changed.games.push(game("other-id", "Added later", 3));
+    changed
+        .games
+        .sort_by(|left, right| left.storage_key.cmp(&right.storage_key));
+    let join = CloudLibraryJoin::with_transport(transport(&changed), 2);
+    let decision = JoinGameDecision {
+        local_game_id: "same-id".into(),
+        local_fingerprint: review.items[0].local_fingerprint.clone(),
+        cloud_fingerprint: review.items[0].cloud_fingerprint.clone(),
+        action: JoinGameAction::KeepCloud,
+    };
+    let result = join
+        .join(&local, &profile(&local), &[decision], false)
+        .await
+        .unwrap();
+    assert_eq!(result.shared_library, changed);
+}
+
+#[tokio::test]
+async fn keep_cloud_rejects_a_definition_removed_after_review() {
+    let local = library(vec![game("same-id", "Local", 2)]);
+    let reviewed = library(vec![game("same-id", "Cloud", 1)]);
+    let item = build_review(&local, &reviewed).unwrap().items.remove(0);
+    let join = CloudLibraryJoin::with_transport(transport(&library(vec![])), 2);
+    let decision = JoinGameDecision {
+        local_game_id: item.local_game_id,
+        local_fingerprint: item.local_fingerprint,
+        cloud_fingerprint: item.cloud_fingerprint,
+        action: JoinGameAction::KeepCloud,
+    };
+    assert!(matches!(
+        join.join(&local, &profile(&local), &[decision], false)
+            .await,
+        Err(CloudLibraryJoinError::TargetChanged(_))
+    ));
+    assert!(join.transport.writes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn same_title_does_not_supply_an_unrelated_definition_fingerprint() {
+    let local = library(vec![game("local-id", "Title", 2)]);
+    let cloud = library(vec![game("remote-id", "Title", 1)]);
+    let item = build_review(&local, &cloud).unwrap().items.remove(0);
+    assert_eq!(
+        item.classification,
+        GameJoinClassification::PossibleDuplicate
+    );
+    assert!(item.cloud_fingerprint.is_none());
+    let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+    let decision = JoinGameDecision {
+        local_game_id: item.local_game_id,
+        local_fingerprint: item.local_fingerprint,
+        cloud_fingerprint: item.cloud_fingerprint,
+        action: JoinGameAction::KeepCloud,
+    };
+    let result = join
+        .join(&local, &profile(&local), &[decision], false)
+        .await
+        .unwrap();
+    assert_eq!(result.shared_library, cloud);
+}
+
+#[derive(Default)]
+struct FakeTransport {
+    objects: StdMutex<BTreeMap<String, Vec<u8>>>,
+    writes: StdMutex<Vec<String>>,
+}
+
+#[async_trait]
+impl NamespaceTransport for FakeTransport {
+    async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+        Ok(self.objects.lock().unwrap().get(path).cloned())
+    }
+
+    async fn list_sample(&self, prefix: &str, limit: usize) -> Result<Vec<String>, opendal::Error> {
+        Ok(self
+            .objects
+            .lock()
+            .unwrap()
+            .keys()
+            .filter(|path| prefix == "/" || path.starts_with(prefix))
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+}
+
+#[async_trait]
+impl CloudLibraryTransport for FakeTransport {
+    async fn write(&self, path: &str, bytes: &[u8]) -> Result<(), opendal::Error> {
+        self.writes.lock().unwrap().push(path.to_string());
+        self.objects
+            .lock()
+            .unwrap()
+            .insert(path.to_string(), bytes.to_vec());
+        Ok(())
+    }
+}
+
+fn game(id: &str, name: &str, unit_id: u32) -> SharedGame {
+    SharedGame {
+        name: name.into(),
+        storage_key: id.into(),
+        save_units: vec![SharedSaveUnit {
+            id: unit_id,
+            source: SharedSaveUnitSource::Concrete {
+                unit_type: crate::backup::SaveUnitType::Folder,
+            },
+        }],
+        next_save_unit_id: unit_id + 1,
+        ludusavi_meta: None,
+        snapshot_retention: None,
+    }
+}
+
+fn library(games: Vec<SharedGame>) -> SharedLibrary {
+    SharedLibrary {
+        schema_version: V2_CONFIG_SCHEMA_VERSION,
+        games,
+    }
+}
+
+fn transport(cloud: &SharedLibrary) -> FakeTransport {
+    let transport = FakeTransport::default();
+    let mut objects = transport.objects.lock().unwrap();
+    objects.insert(
+        V2_NAMESPACE_DESCRIPTOR_PATH.into(),
+        serde_json::to_vec(&CloudNamespaceDescriptor::with_library_id(LIBRARY_ID)).unwrap(),
+    );
+    objects.insert(
+        CLOUD_MANIFEST_PATH.into(),
+        serde_json::to_vec(&CloudManifest::default()).unwrap(),
+    );
+    objects.insert(
+        SHARED_LIBRARY_PATH.into(),
+        serde_json::to_vec(cloud).unwrap(),
+    );
+    drop(objects);
+    transport
+}
+
+fn profile(local: &SharedLibrary) -> DeviceProfile {
+    let config = crate::config::Config {
+        games: local
+            .games
+            .iter()
+            .map(|game| crate::backup::Game {
+                name: game.name.clone(),
+                storage_key: game.storage_key.clone(),
+                save_paths: Vec::new(),
+                game_paths: HashMap::new(),
+                next_save_unit_id: game.next_save_unit_id,
+                cloud_sync_enabled: false,
+                auto_backup: None,
+                ludusavi_meta: None,
+                device_bindings: HashMap::new(),
+            })
+            .collect(),
+        ..Default::default()
+    };
+    let owners = ConfigurationOwners::from_legacy(&config, &"device".into());
+    owners.device_profiles["device"].clone()
+}
+
+#[tokio::test]
+async fn review_is_read_only_and_classifies_all_local_games() {
+    let mut conflict = game("conflict", "Conflict", 1);
+    let cloud_conflict = conflict.clone();
+    conflict.name = "Local Conflict".into();
+    let local = library(vec![
+        game("same", "Same", 1),
+        game("local", "Local", 1),
+        game("duplicate", "Duplicate", 1),
+        conflict,
+    ]);
+    let cloud = library(vec![
+        game("same", "Same", 1),
+        game("remote-duplicate", "Duplicate", 1),
+        cloud_conflict,
+    ]);
+    let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+
+    let review = join.review(&local).await.unwrap();
+
+    assert_eq!(review.items.len(), 4);
+    assert_eq!(
+        review
+            .items
+            .iter()
+            .map(|item| item.classification)
+            .collect::<Vec<_>>(),
+        vec![
+            GameJoinClassification::GameDefinitionConflict,
+            GameJoinClassification::PossibleDuplicate,
+            GameJoinClassification::LocalOnly,
+            GameJoinClassification::Same,
+        ]
+    );
+    assert!(join.transport.writes.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn join_adds_and_replaces_whole_games_then_publishes_profile() {
+    let local_only = game("local", "Local", 1);
+    let replacement = game("conflict", "Local Conflict", 2);
+    let mut cloud_conflict = game("conflict", "Cloud Conflict", 1);
+    cloud_conflict.snapshot_retention = Some(SharedSnapshotRetentionPolicy {
+        automatic_snapshots_per_branch: 4,
+    });
+    let local = library(vec![local_only.clone(), replacement.clone()]);
+    let cloud = library(vec![cloud_conflict.clone(), game("remote", "Remote", 1)]);
+    let review = build_review(&local, &cloud).unwrap();
+    let decisions = review
+        .items
+        .iter()
+        .map(|item| JoinGameDecision {
+            local_game_id: item.local_game_id.clone(),
+            local_fingerprint: item.local_fingerprint.clone(),
+            cloud_fingerprint: item.cloud_fingerprint.clone(),
+            action: if item.local_game_id == "local" {
+                JoinGameAction::AddLocal
+            } else {
+                JoinGameAction::ReplaceCloud
+            },
+        })
+        .collect::<Vec<_>>();
+    let join = CloudLibraryJoin::with_transport(transport(&cloud), 2);
+
+    let result = join
+        .join(&local, &profile(&local), &decisions, true)
+        .await
+        .unwrap();
+    assert_eq!(result.library_id, LIBRARY_ID);
+    let accepted = result.shared_library;
+
+    assert!(accepted.games.contains(&local_only));
+    let accepted_replacement = accepted
+        .games
+        .iter()
+        .find(|game| game.storage_key == "conflict")
+        .unwrap();
+    assert_eq!(accepted_replacement.name, replacement.name);
+    assert_eq!(accepted_replacement.save_units, replacement.save_units);
+    assert_eq!(
+        accepted_replacement.snapshot_retention,
+        cloud_conflict.snapshot_retention
+    );
+    assert!(
+        accepted
+            .games
+            .iter()
+            .any(|game| game.storage_key == "remote")
+    );
+    assert_eq!(
+        join.transport.writes.lock().unwrap().as_slice(),
+        [SHARED_LIBRARY_PATH, device_profile_path("device").as_str()]
+    );
+}
+
+#[tokio::test]
+async fn stale_replacement_does_not_write() {
+    let local = library(vec![game("game", "Local", 2)]);
+    let reviewed_cloud = library(vec![game("game", "Cloud", 1)]);
+    let review = build_review(&local, &reviewed_cloud).unwrap();
+    let decision = JoinGameDecision {
+        local_game_id: "game".into(),
+        local_fingerprint: review.items[0].local_fingerprint.clone(),
+        cloud_fingerprint: review.items[0].cloud_fingerprint.clone(),
+        action: JoinGameAction::ReplaceCloud,
+    };
+    let changed_cloud = library(vec![game("game", "Changed Again", 3)]);
+    let join = CloudLibraryJoin::with_transport(transport(&changed_cloud), 2);
+
+    assert!(matches!(
+        join.join(&local, &profile(&local), &[decision], true)
+            .await,
+        Err(CloudLibraryJoinError::TargetChanged(name)) if name == "Local"
+    ));
+    assert!(join.transport.writes.lock().unwrap().is_empty());
+}

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -443,6 +443,7 @@ impl ServiceContext {
         let joined = match joined {
             Ok(joined) => joined,
             Err(CloudLibraryJoinError::TargetChanged(game_name))
+            | Err(CloudLibraryJoinError::DecisionRequired(game_name))
             | Err(CloudLibraryJoinError::LocalGameChanged(game_name)) => {
                 return Ok(CloudLibraryJoinOutcome::ReviewChanged { game_name });
             }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -976,6 +976,7 @@
                 "add_local": "Add this game to Cloud Library",
                 "replace_cloud": "Replace the shared game definition",
                 "join_action": "Join library",
+                "choice_required": "Choose a version for {count} conflicting game(s)",
                 "replace_title": "Replace shared definitions",
                 "replace_warning": "{count} shared game definitions will be replaced for participating devices. Device-specific paths are not uploaded",
                 "replace_confirm": "Replace and join",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -976,6 +976,7 @@
                 "add_local": "将此游戏加入云端资料库",
                 "replace_cloud": "替换共享游戏定义",
                 "join_action": "加入资料库",
+                "choice_required": "请为 {count} 个冲突游戏选择版本",
                 "replace_title": "替换共享定义",
                 "replace_warning": "将替换 {count} 个共享游戏定义，并影响参与同步的设备，设备专属路径不会上传",
                 "replace_confirm": "替换并加入",


### PR DESCRIPTION
Depends on #529

Require an explicit local/cloud choice when the same game ID has different definitions

- Do not preselect a conflicting definition or accept an omitted choice
- Recheck the chosen cloud definition and reload the review if it changed, disappeared, or became conflicting after the dialog opened
- Keep same-title games with different IDs separate; changes to unrelated games do not invalidate a choice

Automatic connection and discovery follow separately
