### PR TITLE
fix(sync): restore live descendants of deleted snapshots

### DIFF
--- a/apps/rgsm-gui/e2e/cloud-deleted-ancestor.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-deleted-ancestor.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import { GAME_NAME, STORAGE_KEY } from './support/constants';
+import { cloudArchivePath, cloudPaths, readJson } from './support/cloud-assertions';
+import { seedEmptyCloudWithLocalGame, readSave, writeSave } from './support/cloud-fixture';
+import {
+  applySnapshot,
+  connectLibrary,
+  createLibrary,
+  createPublishedSnapshot,
+  downloadSnapshot,
+  evictCloudCopy,
+  openGame,
+  snapshotRow,
+  uploadSnapshot,
+} from './support/gui';
+import { snapshotMeta, readBackupsJson } from './support/local-assertions';
+import { createRunRoot, hostPost } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+
+test('a live descendant remains downloadable and restorable after deleting an ancestor', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('deleted-ancestor');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  const session = await startDualSession(browser, {
+    ...seeded,
+    runRoot,
+    label: 'deleted-ancestor',
+  });
+  let failed = false;
+  try {
+    await createLibrary(session.pageA);
+    const first = await createPublishedSnapshot(session.pageA, session.hostA, 'Original');
+    const ancestor = await createPublishedSnapshot(session.pageA, session.hostA, 'Old progress');
+    await writeSave(seeded.deviceA, 'surviving progress\n');
+    const child = await createPublishedSnapshot(session.pageA, session.hostA, 'Surviving progress');
+    const deletion = await hostPost(session.hostA, '/api/v1/delete-v2-snapshot', {
+      gameId: STORAGE_KEY,
+      snapshotId: ancestor,
+      confirmed: true,
+      currentPosition: null,
+    });
+    expect(deletion.ok, deletion.raw).toBe(true);
+    expect(existsSync(cloudArchivePath(seeded.cloudRoot, ancestor))).toBe(false);
+
+    await connectLibrary(session.pageB);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, child);
+    await applySnapshot(session.pageB, child);
+    expect(await readSave(seeded.deviceB)).toBe('surviving progress\n');
+    expect((await snapshotMeta(seeded.deviceB.appDataDir, child)).parent).toBe(ancestor);
+    expect((await readBackupsJson(seeded.deviceB.appDataDir)).backups.map((s) => s.date)).toEqual([
+      first,
+      child,
+    ]);
+    // Uploading an imported copy must not resurrect or rewrite the deleted parent.
+    await evictCloudCopy(session.pageB, child);
+    await uploadSnapshot(session.pageB, child);
+    await writeSave(seeded.deviceB, 'continued on B\n');
+    const continued = await createPublishedSnapshot(session.pageB, session.hostB, 'Continued on B');
+    expect((await snapshotMeta(seeded.deviceB.appDataDir, continued)).parent).toBe(child);
+    await openGame(session.pageA);
+    await downloadSnapshot(session.pageA, continued);
+    await applySnapshot(session.pageA, continued);
+    expect(await readSave(seeded.deviceA)).toBe('continued on B\n');
+    await expect(snapshotRow(session.pageA, ancestor)).toHaveCount(0);
+    const manifest = await readJson(cloudPaths(seeded.cloudRoot).manifest);
+    const game = (
+      manifest.games as Record<
+        string,
+        { snapshots: Record<string, { parent?: string; state: { type: string } }> }
+      >
+    )[GAME_NAME];
+    expect(game.snapshots[ancestor].state.type).toBe('final_tombstone');
+    expect(game.snapshots[child].parent).toBe(ancestor);
+    expect(game.snapshots[continued].parent).toBe(child);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/manifest.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::ArchiveIntegrity;
-use crate::backup::{ArchiveFormat, CreatedBy, Snapshot};
+use crate::backup::{ArchiveFormat, CreatedBy, Snapshot, archive_path};
 use crate::device::DeviceId;
 
 pub const CLOUD_MANIFEST_SCHEMA_VERSION: u32 = 2;
@@ -65,6 +65,43 @@ impl GameManifest {
 
     pub fn clear_head(&mut self, device_id: &DeviceId) {
         self.device_heads.remove(device_id);
+    }
+
+    /// Import the live rows of a selected history without rewriting its parent links.
+    /// Deleted ancestors remain part of cloud ancestry but must not reappear locally.
+    pub(crate) fn local_lineage(
+        &self,
+        selected_snapshot_id: &str,
+        archive_root: &std::path::Path,
+    ) -> Result<Vec<Snapshot>, ManifestError> {
+        let mut lineage = Vec::new();
+        let mut visited = HashSet::new();
+        let mut cursor = selected_snapshot_id;
+        loop {
+            if !visited.insert(cursor) {
+                return Err(ManifestError::ParentCycle(cursor.to_string()));
+            }
+            let node = self
+                .snapshots
+                .get(cursor)
+                .ok_or_else(|| ManifestError::MissingSnapshot(cursor.to_string()))?;
+            if cursor == selected_snapshot_id && !node.state.is_live() {
+                return Err(ManifestError::ExpectedLive(cursor.to_string()));
+            }
+            if let Some(snapshot) = node.local_snapshot(archive_path(
+                archive_root,
+                &node.snapshot_id,
+                node.archive_format,
+            )) {
+                lineage.push(snapshot);
+            }
+            let Some(parent) = node.parent.as_deref() else {
+                break;
+            };
+            cursor = parent;
+        }
+        lineage.reverse();
+        Ok(lineage)
     }
 
     pub fn report_local_archive(

--- a/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/materialization.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use opendal::Operator;
@@ -448,34 +448,9 @@ impl CloudArchiveMaterializer {
             .games
             .get(game_id)
             .ok_or_else(|| MaterializationError::GameNotFound(game_id.to_string()))?;
-        let mut lineage = Vec::new();
-        let mut visited = HashSet::new();
-        let mut cursor = snapshot_id;
-        loop {
-            if !visited.insert(cursor.to_string()) {
-                return Err(MaterializationError::SnapshotUnavailable(
-                    cursor.to_string(),
-                ));
-            }
-            let node = game
-                .snapshots
-                .get(cursor)
-                .ok_or_else(|| MaterializationError::SnapshotNotFound(cursor.to_string()))?;
-            lineage.push(
-                node.local_snapshot(self.local_path(
-                    game_id,
-                    &node.snapshot_id,
-                    node.archive_format,
-                ))
-                .ok_or_else(|| MaterializationError::SnapshotUnavailable(cursor.to_string()))?,
-            );
-            let Some(parent) = node.parent.as_deref() else {
-                break;
-            };
-            cursor = parent;
-        }
-        lineage.reverse();
-        Ok(lineage)
+        Ok(game
+            .local_lineage(snapshot_id, &self.local_archive_root.join(game_id))
+            .map_err(ManifestRepositoryError::from)?)
     }
 
     pub async fn imported_local_catalog(

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -24,6 +24,8 @@ mod repository;
 mod retention;
 mod shared_library_repository;
 #[cfg(test)]
+mod snapshot_lineage_tests;
+#[cfg(test)]
 mod snapshot_metadata_tests;
 mod snapshot_sync;
 

--- a/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/remote_resolution.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::PathBuf;
 
 use opendal::Operator;
@@ -131,12 +130,7 @@ impl V2RemoteProgressResolver {
         ensure_remote_candidate(game, &self.current_device_id, selected_snapshot_id, false)?;
         Ok(PreparedRemoteProgress {
             selected_snapshot_id: selected_snapshot_id.to_string(),
-            lineage: remote_lineage(
-                game_id,
-                game,
-                selected_snapshot_id,
-                &self.local_archive_root,
-            )?,
+            lineage: game.local_lineage(selected_snapshot_id, &game_archive_root)?,
         })
     }
 
@@ -220,44 +214,6 @@ fn ensure_remote_candidate(
     Ok(())
 }
 
-/// Build one selected parent chain in parent-first order.
-///
-/// Each node is visited once. The cycle guard makes the traversal O(V) time
-/// and O(V) additional space for V Snapshots on the selected lineage.
-fn remote_lineage(
-    game_id: &str,
-    game: &super::GameManifest,
-    selected_snapshot_id: &str,
-    local_archive_root: &std::path::Path,
-) -> Result<Vec<Snapshot>, AcceptRemoteProgressError> {
-    let mut lineage = Vec::new();
-    let mut visited = HashSet::new();
-    let mut cursor = selected_snapshot_id;
-    loop {
-        if !visited.insert(cursor.to_string()) {
-            return Err(AcceptRemoteProgressError::ParentCycle(cursor.to_string()));
-        }
-        let node = game
-            .snapshots
-            .get(cursor)
-            .ok_or_else(|| ManifestError::MissingSnapshot(cursor.to_string()))?;
-        lineage.push(
-            node.local_snapshot(archive_path(
-                &local_archive_root.join(game_id),
-                &node.snapshot_id,
-                node.archive_format,
-            ))
-            .ok_or_else(|| AcceptRemoteProgressError::TombstonedLineage(cursor.to_string()))?,
-        );
-        let Some(parent) = node.parent.as_deref() else {
-            break;
-        };
-        cursor = parent;
-    }
-    lineage.reverse();
-    Ok(lineage)
-}
-
 #[derive(Debug, Error)]
 pub enum AcceptRemoteProgressError {
     #[error("Cloud progress review is stale: expected revision {expected}, found {actual}")]
@@ -275,10 +231,6 @@ pub enum AcceptRemoteProgressError {
     SelectedArchiveUnavailable(String),
     #[error("A different Local Archive already uses the selected Snapshot identity: {0}")]
     LocalArchiveConflict(String),
-    #[error("Selected progress contains a deleted ancestor: {0}")]
-    TombstonedLineage(String),
-    #[error("Cloud Snapshot parent cycle contains {0}")]
-    ParentCycle(String),
     #[error(transparent)]
     Manifest(#[from] ManifestError),
     #[error(transparent)]

--- a/crates/rgsm-core/src/cloud_sync/v2/snapshot_lineage_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/snapshot_lineage_tests.rs
@@ -1,0 +1,173 @@
+use opendal::{Operator, services};
+
+use super::*;
+use crate::backup::{ArchiveFormat, CreatedBy, GameSnapshots};
+
+async fn fixture() -> (Operator, temp_dir::TempDir, CloudManifest) {
+    let operator = Operator::new(services::Memory::default()).unwrap().finish();
+    let root = temp_dir::TempDir::new().unwrap();
+    let source = root.path().join("source.zip");
+    std::fs::write(&source, b"live descendant").unwrap();
+    let integrity = ArchiveIntegrity::from_file(&source).unwrap();
+    let mut game = GameManifest::new("game");
+    for (id, parent) in [
+        ("root", None),
+        ("deleted-a", Some("root")),
+        ("deleted-b", Some("deleted-a")),
+        ("leaf", Some("deleted-b")),
+    ] {
+        let mut node = SnapshotNode::live(
+            id,
+            parent.map(str::to_owned),
+            integrity.clone(),
+            CreatedBy::Manual,
+        );
+        if let SnapshotState::Live(live) = &mut node.state {
+            live.cloud_archive_verified = true;
+        }
+        game.upsert_live(node).unwrap();
+    }
+    game.snapshots.get_mut("deleted-a").unwrap().state = SnapshotState::FinalTombstone {
+        kind: DeletionKind::User,
+    };
+    game.snapshots.get_mut("deleted-b").unwrap().state =
+        SnapshotState::PendingTombstone(PendingTombstone {
+            kind: DeletionKind::Retention,
+            acting_device: "source".into(),
+            acting_local_removed: false,
+            cloud_archive_absent: true,
+        });
+    game.set_head("source".into(), "leaf".into());
+    let manifest = CloudManifest {
+        games: [("game".into(), game)].into(),
+        ..Default::default()
+    };
+    operator
+        .write(CLOUD_MANIFEST_PATH, serde_json::to_vec(&manifest).unwrap())
+        .await
+        .unwrap();
+    operator
+        .write(
+            &cloud_archive_path("game", "leaf", ArchiveFormat::Zip).unwrap(),
+            b"live descendant".to_vec(),
+        )
+        .await
+        .unwrap();
+    (operator, root, manifest)
+}
+
+#[tokio::test]
+async fn deleted_ancestor_download_and_reupload_preserve_identity_without_resurrection() {
+    let (operator, root, _) = fixture().await;
+    let materializer = CloudArchiveMaterializer::new(
+        operator.clone(),
+        root.path().join("receiver"),
+        "receiver".into(),
+        root.path().join("download.json"),
+        2,
+    );
+    let imported = materializer.download("game", "leaf").await.unwrap();
+    assert_eq!(
+        imported
+            .iter()
+            .map(|s| (s.date.as_str(), s.parent.as_deref()))
+            .collect::<Vec<_>>(),
+        vec![("root", None), ("leaf", Some("deleted-b"))]
+    );
+    assert_eq!(
+        std::fs::read(&imported[1].path).unwrap(),
+        b"live descendant"
+    );
+    assert!(!root.path().join("receiver/game/deleted-b.zip").exists());
+    let mut local = GameSnapshots::new("Game");
+    local.backups = imported;
+    local.set_head_for_device("receiver".into(), Some("leaf".into()));
+    let coordinator = SnapshotSyncCoordinator::new(
+        operator.clone(),
+        root.path().join("receiver"),
+        "receiver".into(),
+        root.path().join("sync.json"),
+        2,
+    );
+    coordinator
+        .upload_local_snapshot("game", &local.backups[1], &local)
+        .await
+        .unwrap();
+    let manifest = CloudManifestRepository::new(operator, CLOUD_MANIFEST_PATH, 2)
+        .load()
+        .await
+        .unwrap();
+    let game = &manifest.games["game"];
+    assert_eq!(game.snapshots.len(), 4);
+    assert!(!game.snapshots["deleted-a"].state.is_live());
+    assert!(!game.snapshots["deleted-b"].state.is_live());
+    assert_eq!(game.snapshots["leaf"].parent.as_deref(), Some("deleted-b"));
+    assert!(game.is_ancestor_or_equal("root", "leaf").unwrap());
+    game.validate().unwrap();
+}
+
+#[tokio::test]
+async fn deleted_ancestor_does_not_block_explicit_remote_progress() {
+    let (operator, root, manifest) = fixture().await;
+    let resolver = V2RemoteProgressResolver::new(
+        operator,
+        root.path().join("receiver"),
+        "receiver".into(),
+        root.path().join("progress.json"),
+        2,
+    );
+    let prepared = resolver
+        .prepare(
+            "game",
+            manifest.revision,
+            None,
+            "leaf",
+            &GameSnapshots::new("Game"),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        prepared
+            .lineage
+            .iter()
+            .map(|s| s.date.as_str())
+            .collect::<Vec<_>>(),
+        vec!["root", "leaf"]
+    );
+    assert_eq!(prepared.lineage[1].parent.as_deref(), Some("deleted-b"));
+    assert_eq!(
+        std::fs::read(&prepared.lineage[1].path).unwrap(),
+        b"live descendant"
+    );
+}
+
+#[tokio::test]
+async fn lineage_retains_live_metadata_without_an_archive_and_rejects_invalid_chains() {
+    let (_, root, manifest) = fixture().await;
+    let mut game = manifest.games["game"].clone();
+    game.snapshots.insert(
+        "root".into(),
+        SnapshotNode::unavailable("root", None, CreatedBy::Manual),
+    );
+    let imported = game.local_lineage("leaf", root.path()).unwrap();
+    assert_eq!(imported[0].date, "root");
+    assert_eq!(imported[0].archive_hash, None);
+    assert!(matches!(
+        game.local_lineage("deleted-a", root.path()),
+        Err(ManifestError::ExpectedLive(_))
+    ));
+    game.snapshots.get_mut("deleted-a").unwrap().parent = Some("leaf".into());
+    assert!(matches!(
+        game.local_lineage("leaf", root.path()),
+        Err(ManifestError::ParentCycle(_))
+    ));
+    game.snapshots.get_mut("deleted-a").unwrap().parent = Some("missing".into());
+    assert!(matches!(
+        game.local_lineage("leaf", root.path()),
+        Err(ManifestError::MissingSnapshot(_))
+    ));
+    assert!(matches!(
+        game.local_lineage("missing", root.path()),
+        Err(ManifestError::MissingSnapshot(_))
+    ));
+}


### PR DESCRIPTION
Builds on #533

Deleting an old snapshot could prevent downloading or applying its surviving descendants

Download and Apply now share one history-import rule: omit deleted records while preserving the original parent IDs. Re-uploading a descendant keeps the same ancestry and does not resurrect deleted snapshots

Deleted selections, missing parents and cycles are still rejected
