### PR TITLE
perf(e2e): isolate and reuse owned test processes

### DIFF
--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm --dir apps/rgsm-gui exec playwright install chromium --with-deps
 
-      # The debug "host" is the full Tauri app in host-only mode; GTK and the
-      # tray stack still initialize, so the suite needs a virtual display.
+      # HTTP-only hosts still initialize GTK, so they need a virtual display.
+      # The harness gives each Linux host its own temporary D-Bus session.
       - name: Run GUI Cloud Fs E2E
         run: xvfb-run -a pnpm web:e2e --shard=${{ matrix.shard }}/2
 

--- a/apps/rgsm-gui/e2e/README.md
+++ b/apps/rgsm-gui/e2e/README.md
@@ -11,11 +11,15 @@ pnpm web:test
 pnpm web:e2e local-main-path.spec.ts
 ```
 
-运行前请停止占用 5173 端口的开发服务器。E2E 使用临时配置和本地 Fs 云目录，不需要个人存档或云账号。默认的 `pnpm web:e2e` 只运行 browser 项目，通过真实 Rust HTTP API 验证业务，不打开桌面窗口。
+运行前请停止占用 5173 端口的开发服务器。端口被占用时，测试会报错，不会接管或关闭原有进程。E2E 使用临时配置和本地 Fs 云目录，不需要个人存档或云账号。默认的 `pnpm web:e2e` 只运行 browser 项目，通过真实 Rust HTTP API 验证业务，不打开桌面窗口，也不注册托盘或全局快捷键。配置迁移本身不发送系统通知，升级提示由正常桌面启动负责，HTTP-only 宿主保持静默。
 
 实际窗口生命周期测试单独使用 `pnpm web:e2e:desktop`，会启动和关闭隔离配置的桌面窗口，请在允许弹窗时运行。Windows CI 使用 Playwright 的完整项目集合，仍包含此桌面覆盖。
 
 每次 E2E 的 global setup 都让 Cargo 检查代码是否需要重编译，构建一次宿主和校验工具，所有 worker 复用本轮产物，不复用未经检查的旧二进制。本地编译默认最多两个 Cargo jobs，Playwright 保持单 worker；显式设置的 `CARGO_BUILD_JOBS` 和 CI runner 默认并发不变。
+
+Vite 由整轮测试持有，worker 重启或重复运行场景时不重新启动，结束时统一关闭。各场景负责关闭自己的宿主和浏览器上下文，部分启动失败也会清理已经启动的资源。HTTP 启动探测和操作请求有超时，失败场景保留临时目录及宿主日志。
+
+Linux 还需要 `xvfb-run` 和 `dbus-run-session`，CI 已安装相应依赖。每个宿主使用独立的临时 D-Bus 会话，退出时清理该宿主的进程组，不共享桌面会话。
 
 需要定位耗时时，启用分阶段日志，区分构建、Vite、HTTP host 和页面加载：
 

--- a/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-cutover.spec.ts
@@ -35,14 +35,12 @@ import {
   newDeviceContext,
   removeRunRoot,
   startRgsmHost,
-  startTestWeb,
   type RgsmHost,
 } from './support/rgsm-instance';
 
 test('V1 to V2 cutover interrupts, resumes, and stays idempotent', async ({ browser }) => {
   const runRoot = await createRunRoot('cutover');
   const seeded = await seedLegacyV1Scene(runRoot);
-  const vite = await startTestWeb();
   const v1Bytes = {
     config: seeded.v1ConfigBytes,
     backups: seeded.v1BackupsBytes,
@@ -148,7 +146,6 @@ test('V1 to V2 cutover interrupts, resumes, and stays idempotent', async ({ brow
   } finally {
     await context?.close();
     await host?.stop();
-    await vite.stop();
     if (!failed) {
       await removeRunRoot(runRoot);
     }

--- a/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-library-two-v1-devices.spec.ts
@@ -48,14 +48,12 @@ import {
   newDeviceContext,
   removeRunRoot,
   startRgsmHost,
-  startTestWeb,
   type RgsmHost,
 } from './support/rgsm-instance';
 
 test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ browser }) => {
   const runRoot = await createRunRoot('two-devices');
   const seeded = await seedLegacyV1Scene(runRoot);
-  const vite = await startTestWeb();
   const v1Bytes = {
     config: seeded.v1ConfigBytes,
     backups: seeded.v1BackupsBytes,
@@ -264,7 +262,6 @@ test('two V1 devices cut over, join, and keep V2 device boundaries', async ({ br
     await contextB?.close();
     await hostA?.stop();
     await hostB?.stop();
-    await vite.stop();
     if (!failed) {
       await removeRunRoot(runRoot);
     }

--- a/apps/rgsm-gui/e2e/desktop-window-lifecycle.spec.ts
+++ b/apps/rgsm-gui/e2e/desktop-window-lifecycle.spec.ts
@@ -3,11 +3,11 @@ import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createServer } from 'node:net';
 import { join } from 'node:path';
 import { seedLocalConfig } from './support/local-fixture';
+import { waitForCdpPage } from './support/cdp-page';
 import {
   createRunRoot,
   removeRunRoot,
   rgsmBinaryPath,
-  startTestWeb,
   stopProcessTree,
   workspacePath,
 } from './support/rgsm-instance';
@@ -73,7 +73,9 @@ async function connectDesktop(
           );
         }
         try {
-          const response = await fetch(`${endpoint}/json/list`);
+          const response = await fetch(`${endpoint}/json/list`, {
+            signal: AbortSignal.timeout(1_000),
+          });
           if (!response.ok) return false;
           const targets = (await response.json()) as Array<{ url: string }>;
           return targets.some((target) => target.url === 'http://localhost:5173/');
@@ -86,15 +88,13 @@ async function connectDesktop(
     .toBe(true);
 
   const browser = await chromium.connectOverCDP(endpoint);
-  const page = browser
-    .contexts()
-    .flatMap((context) => context.pages())
-    .find((candidate) => candidate.url() === 'http://localhost:5173/');
-  if (!page) {
-    await browser.close();
-    throw new Error('Desktop WebView page was not available after CDP connected');
+  try {
+    const page = await waitForCdpPage(browser, 'http://localhost:5173/');
+    return { browser, page };
+  } catch (error) {
+    await browser.close().catch(() => undefined);
+    throw error;
   }
-  return { browser, page };
 }
 
 async function closeDesktopWindow(browser: Browser, process: DesktopProcess): Promise<void> {
@@ -108,7 +108,7 @@ async function closeDesktopWindow(browser: Browser, process: DesktopProcess): Pr
       '-Command',
       `$process = Get-Process -Id ${pid}; if (-not $process.CloseMainWindow()) { exit 1 }`,
     ],
-    { stdio: 'pipe', encoding: 'utf8' }
+    { stdio: 'pipe', encoding: 'utf8', windowsHide: true }
   );
   if (close.status !== 0) {
     throw new Error(`Could not close desktop window: ${close.stderr || close.stdout}`);
@@ -128,7 +128,6 @@ async function readBuildInfo(page: Page): Promise<{ version: string; git_hash: s
 test('desktop recreates a destroyed window with live runtime credentials', async () => {
   const runRoot = await createRunRoot('desktop-window-lifecycle');
   const deviceId = `desktop-window-${process.pid}`;
-  const vite = await startTestWeb();
   let failed = false;
   let primary: DesktopProcess | undefined;
   let second: DesktopProcess | undefined;
@@ -172,7 +171,6 @@ test('desktop recreates a destroyed window with live runtime credentials', async
     stopProcessTree(second?.child);
     stopProcessTree(primary?.child);
     stopProcessTree(exitDisabled?.child);
-    await vite.stop();
     if (!failed) await removeRunRoot(runRoot);
   }
 });

--- a/apps/rgsm-gui/e2e/harness-lifecycle.spec.ts
+++ b/apps/rgsm-gui/e2e/harness-lifecycle.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import { createRunRoot, hostPost, removeRunRoot, workspacePath } from './support/rgsm-instance';
+import { startDualSession } from './support/session';
+import { hasServerAddress, startTestWebServer } from './support/test-web';
+import { VITE_ORIGIN } from './support/constants';
+import { seedLocalConfig } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+import type { Game } from '../src/api/generated/types.gen';
+import { waitForCdpPage } from './support/cdp-page';
+
+test('connected page lookup waits for page creation and navigation', async ({ browser }) => {
+  const appUrl = `data:text/html,${encodeURIComponent('<title>App page</title>')}`;
+  const context = await browser.newContext();
+  const pending = waitForCdpPage(browser, appUrl);
+  try {
+    const page = await context.newPage();
+    expect(page.url()).toBe('about:blank');
+    await page.goto(appUrl);
+    expect(await pending).toBe(page);
+    await expect(page).toHaveTitle('App page');
+  } finally {
+    await context.close();
+    await pending.catch(() => undefined);
+  }
+});
+
+test('server readiness accepts a port wrapped in Vite color codes', () => {
+  expect(hasServerAddress('Local: http://localhost:\u001b[1m5173\u001b[22m/', VITE_ORIGIN)).toBe(
+    true
+  );
+  expect(hasServerAddress('VITE ready in 100 ms', VITE_ORIGIN)).toBe(false);
+});
+
+test('HTTP-only selection saves the quick backup game without a tray', async ({ browser }) => {
+  const runRoot = await createRunRoot('quick-game-no-tray');
+  const device = await seedLocalConfig(runRoot);
+  const session = await startLocalSession(browser, {
+    runRoot,
+    device,
+    label: 'quick-game-no-tray',
+  });
+  try {
+    const before = await hostPost<{ games: Game[] }>(session.host, '/api/v1/get-local-config');
+    expect(before.ok, before.raw).toBe(true);
+    const game = before.data!.games[0]!;
+    const selected = await hostPost(session.host, '/api/v1/set-quick-backup-game', { game });
+    expect(selected.ok, selected.raw).toBe(true);
+    const after = await hostPost<{ quick_action: { quick_action_game_id: string } }>(
+      session.host,
+      '/api/v1/get-local-config'
+    );
+    expect(after.data?.quick_action.quick_action_game_id).toBe(game.storage_key);
+    await session.close(true);
+    const log = await readFile(join(runRoot, 'logs', 'quick-game-no-tray.log'), 'utf8');
+    expect(log).not.toContain('Cannot get tray');
+    expect(log).not.toContain('Setting up tray icon');
+    expect(log).not.toContain('Setting up hotkeys');
+  } finally {
+    await session.close();
+  }
+});
+
+test('web setup rejects a busy port without adopting or killing its listener', async () => {
+  let unexpected: Awaited<ReturnType<typeof startTestWebServer>> | undefined;
+  try {
+    await expect(async () => {
+      unexpected = await startTestWebServer(workspacePath('apps', 'rgsm-gui'));
+    }).rejects.toThrow(/Vite failed to start.*exited/s);
+    expect((await fetch(VITE_ORIGIN)).ok).toBe(true);
+  } finally {
+    await unexpected?.stop();
+  }
+});
+
+test('a failed second host startup closes the first host and retains diagnostic files', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('startup-cleanup');
+  const seeded = await seedEmptyCloudWithLocalGame(runRoot);
+  let session: Awaited<ReturnType<typeof startDualSession>> | undefined;
+  try {
+    await expect(async () => {
+      session = await startDualSession(browser, {
+        ...seeded,
+        // The existing config file cannot be used as an application-data directory.
+        deviceB: {
+          ...seeded.deviceB,
+          appDataDir: join(seeded.deviceB.appDataDir, 'GameSaveManager.config.json'),
+        },
+        runRoot,
+        label: 'startup-cleanup',
+      });
+    }).rejects.toThrow();
+    const host = JSON.parse(
+      await readFile(join(seeded.deviceA.appDataDir, 'GameSaveManager.host.json'), 'utf8')
+    );
+    await expect(
+      fetch(`http://127.0.0.1:${host.port}/api/v1/get-build-info`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(1_000),
+      })
+    ).rejects.toThrow();
+    const log = await readFile(join(runRoot, 'logs', 'startup-cleanup-a.log'), 'utf8');
+    expect(log).not.toContain('Setting up tray icon');
+    expect(log).not.toContain('Setting up hotkeys');
+  } finally {
+    await session?.close(true);
+    await removeRunRoot(runRoot);
+  }
+});

--- a/apps/rgsm-gui/e2e/host-isolation.spec.ts
+++ b/apps/rgsm-gui/e2e/host-isolation.spec.ts
@@ -8,14 +8,12 @@ import {
   newDeviceContext,
   removeRunRoot,
   startRgsmHost,
-  startTestWeb,
 } from './support/rgsm-instance';
 import { cloudSyncNav, getCurrentDevice } from './support/gui';
 import { localOwnerPaths } from './support/cloud-assertions';
 
 test('A/B Hosts isolate device id, token, port, and browser traffic', async ({ browser }) => {
   const runRoot = await createRunRoot('isolation');
-  const vite = await startTestWeb();
   const hostA = await startRgsmHost({
     appDataDir: join(runRoot, 'app-data-a'),
     deviceId: DEVICE_A_ID,
@@ -74,7 +72,6 @@ test('A/B Hosts isolate device id, token, port, and browser traffic', async ({ b
   } finally {
     await hostA.stop();
     await hostB.stop();
-    await vite.stop();
     await removeRunRoot(runRoot);
   }
 });

--- a/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
@@ -12,7 +12,6 @@ import {
   newDeviceContext,
   removeRunRoot,
   startRgsmHost,
-  startTestWeb,
   type RgsmHost,
 } from './support/rgsm-instance';
 
@@ -22,7 +21,6 @@ for (const version of ['1.7.0', '1.8.0'] as const) {
   }) => {
     const runRoot = await createRunRoot(`released-${version}`);
     const scene = await seedReleasedUpgrade(runRoot, version);
-    const web = await startTestWeb();
     let host: RgsmHost | undefined;
     let context: BrowserContext | undefined;
     let failed = false;
@@ -104,7 +102,6 @@ for (const version of ['1.7.0', '1.8.0'] as const) {
     } finally {
       await context?.close();
       await host?.stop();
-      await web.stop();
       if (!failed) await removeRunRoot(runRoot);
     }
   });

--- a/apps/rgsm-gui/e2e/local-v1-8-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/local-v1-8-upgrade.spec.ts
@@ -11,7 +11,6 @@ import {
   newDeviceContext,
   removeRunRoot,
   startRgsmHost,
-  startTestWeb,
   workspacePath,
   type RgsmHost,
 } from './support/rgsm-instance';
@@ -196,7 +195,6 @@ test('1.8 dynamic and concrete save paths keep their V2 zip usable after the 1.9
   const runRoot = await createRunRoot('local-v1-8-upgrade');
   const scene = await seedV1_8Scene(runRoot);
   const originalArchive = await readFile(scene.releasedArchive);
-  const web = await startTestWeb();
   let host: RgsmHost | undefined;
   let context: BrowserContext | undefined;
   try {
@@ -291,7 +289,6 @@ test('1.8 dynamic and concrete save paths keep their V2 zip usable after the 1.9
   } finally {
     await context?.close();
     await host?.stop();
-    await web.stop();
     await removeRunRoot(runRoot);
   }
 });

--- a/apps/rgsm-gui/e2e/support/cdp-page.test.mjs
+++ b/apps/rgsm-gui/e2e/support/cdp-page.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { waitForCdpPage } from './cdp-page.ts';
+
+const appUrl = 'http://localhost:5173/';
+const page = (url, closed = false) => ({ url: () => url, isClosed: () => closed });
+
+test('CDP connection waits for a target to attach and finish navigation', async () => {
+  let reads = 0;
+  const target = page(appUrl);
+  const browser = {
+    isConnected: () => true,
+    contexts: () => {
+      reads += 1;
+      if (reads === 1) return [];
+      return [{ pages: () => (reads === 2 ? [page('about:blank')] : [target]) }];
+    },
+  };
+  assert.equal(await waitForCdpPage(browser, appUrl, 500), target);
+  assert.equal(reads, 3);
+});
+
+test('a stale closed target does not stand in for the recreated page', async () => {
+  const target = page(appUrl);
+  const browser = {
+    isConnected: () => true,
+    contexts: () => [{ pages: () => [page(appUrl, true), target] }],
+  };
+  assert.equal(await waitForCdpPage(browser, appUrl, 500), target);
+});
+
+test('disconnection and missing-page timeout remain distinct failures', async () => {
+  await assert.rejects(
+    waitForCdpPage({ isConnected: () => false, contexts: () => [] }, appUrl, 5),
+    /disconnected/
+  );
+  await assert.rejects(
+    waitForCdpPage({ isConnected: () => true, contexts: () => [] }, appUrl, 5),
+    /Timed out.*app page/
+  );
+});

--- a/apps/rgsm-gui/e2e/support/cdp-page.ts
+++ b/apps/rgsm-gui/e2e/support/cdp-page.ts
@@ -1,0 +1,22 @@
+import type { Browser, Page } from '@playwright/test';
+import { setTimeout as delay } from 'node:timers/promises';
+
+export async function waitForCdpPage(
+  browser: Pick<Browser, 'contexts' | 'isConnected'>,
+  appUrl: string,
+  timeoutMs = 10_000
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+  let attachedPages = 0;
+  while (Date.now() < deadline) {
+    if (!browser.isConnected()) throw new Error('CDP disconnected before the app page was ready');
+    const pages = browser.contexts().flatMap((context) => context.pages());
+    attachedPages = pages.length;
+    const page = pages.find((candidate) => !candidate.isClosed() && candidate.url() === appUrl);
+    if (page) return page;
+    await delay(Math.min(50, Math.max(0, deadline - Date.now())));
+  }
+  throw new Error(
+    `Timed out waiting for the app page after CDP connected (${attachedPages} attached pages)`
+  );
+}

--- a/apps/rgsm-gui/e2e/support/global-setup.ts
+++ b/apps/rgsm-gui/e2e/support/global-setup.ts
@@ -1,5 +1,8 @@
-import { prepareRgsmBuild } from './rgsm-instance';
+import { prepareRgsmBuild, workspacePath } from './rgsm-instance';
+import { startTestWebServer } from './test-web';
 
-export default async function globalSetup(): Promise<void> {
+export default async function globalSetup(): Promise<() => Promise<void>> {
   prepareRgsmBuild();
+  const web = await startTestWebServer(workspacePath('apps', 'rgsm-gui'));
+  return () => web.stop();
 }

--- a/apps/rgsm-gui/e2e/support/global-teardown.ts
+++ b/apps/rgsm-gui/e2e/support/global-teardown.ts
@@ -1,5 +1,0 @@
-import { stopSharedTestWeb } from './rgsm-instance';
-
-export default async function globalTeardown(): Promise<void> {
-  await stopSharedTestWeb();
-}

--- a/apps/rgsm-gui/e2e/support/http-probe.test.mjs
+++ b/apps/rgsm-gui/e2e/support/http-probe.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { setTimeout as delay } from 'node:timers/promises';
+import test from 'node:test';
+import { waitForHttpOk } from './http-probe.ts';
+
+async function serve(t, respond) {
+  const server = createServer(respond);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  t.after(async () => {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  });
+  return `http://127.0.0.1:${server.address().port}`;
+}
+
+test('a listener that never responds cannot bypass the startup deadline', async (t) => {
+  const url = await serve(t, () => {});
+  const result = waitForHttpOk(url, 100, 'hung listener').then(
+    () => 'unexpected success',
+    (error) => error.message
+  );
+  assert.match(
+    await Promise.race([result, delay(600, 'still waiting')]),
+    /Timed out.*hung listener/
+  );
+});
+
+test('readiness retries a not-yet-ready response and accepts a later success', async (t) => {
+  let reads = 0;
+  const url = await serve(t, (_request, response) => {
+    response.writeHead(++reads === 1 ? 503 : 200).end();
+  });
+  await waitForHttpOk(url, 2_000, 'starting listener');
+  assert.equal(reads, 2);
+});

--- a/apps/rgsm-gui/e2e/support/http-probe.ts
+++ b/apps/rgsm-gui/e2e/support/http-probe.ts
@@ -1,0 +1,20 @@
+import { setTimeout as delay } from 'node:timers/promises';
+
+export async function waitForHttpOk(url: string, timeoutMs: number, label: string): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(Math.max(1, Math.min(1_000, deadline - Date.now()))),
+      });
+      await response.body?.cancel();
+      if (response.ok) return;
+      lastError = new Error(`${label} returned HTTP ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await delay(Math.max(0, Math.min(250, deadline - Date.now())));
+  }
+  throw new Error(`Timed out waiting for ${label}: ${String(lastError)}`);
+}

--- a/apps/rgsm-gui/e2e/support/local-session.ts
+++ b/apps/rgsm-gui/e2e/support/local-session.ts
@@ -2,14 +2,9 @@ import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 import { DEVICE_A_ID } from './constants';
 import type { DeviceLayout } from './cloud-fixture';
-import {
-  newDeviceContext,
-  removeRunRoot,
-  startRgsmHost,
-  startTestWeb,
-  type RgsmHost,
-} from './rgsm-instance';
+import { newDeviceContext, removeRunRoot, startRgsmHost, type RgsmHost } from './rgsm-instance';
 import { openApp } from './gui';
+import { closeResources } from './process';
 
 export type LocalSession = {
   runRoot: string;
@@ -28,27 +23,36 @@ export async function startLocalSession(
   browser: Browser,
   options: { runRoot: string; device: DeviceLayout; label: string }
 ): Promise<LocalSession> {
-  const vite = await startTestWeb();
-  const host = await startRgsmHost({
-    appDataDir: options.device.appDataDir,
-    deviceId: DEVICE_A_ID,
-    logPath: join(options.runRoot, 'logs', `${options.label}.log`),
-  });
-  const started = await newDeviceContext(browser, host);
-  await openApp(started.page);
-  return {
-    runRoot: options.runRoot,
-    device: options.device,
-    host,
-    context: started.context,
-    page: started.page,
-    close: async (keepRoot = false) => {
-      await started.context.close();
-      await host.stop();
-      await vite.stop();
-      if (!keepRoot) {
-        await removeRunRoot(options.runRoot);
-      }
-    },
-  };
+  const closers: Array<() => Promise<unknown>> = [];
+  try {
+    const host = await startRgsmHost({
+      appDataDir: options.device.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: join(options.runRoot, 'logs', `${options.label}.log`),
+    });
+    closers.push(host.stop);
+    const started = await newDeviceContext(browser, host);
+    closers.push(() => started.context.close());
+    await openApp(started.page);
+    return {
+      runRoot: options.runRoot,
+      device: options.device,
+      host,
+      context: started.context,
+      page: started.page,
+      close: async (keepRoot = false) => {
+        await closeResources(closers);
+        if (!keepRoot) await removeRunRoot(options.runRoot);
+      },
+    };
+  } catch (error) {
+    try {
+      await closeResources(closers);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'Session startup and cleanup failed', {
+        cause: cleanupError,
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/rgsm-gui/e2e/support/process.test.mjs
+++ b/apps/rgsm-gui/e2e/support/process.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { setTimeout as delay } from 'node:timers/promises';
+import test from 'node:test';
+import { closeResources, hostCommand, spawnTestProcess } from './process.ts';
+
+test('resource cleanup runs in reverse acquisition order even after a close fails', async () => {
+  const calls = [];
+  const closers = [
+    async () => calls.push('host'),
+    async () => {
+      calls.push('context');
+      throw new Error('close failed');
+    },
+    async () => calls.push('page'),
+  ];
+  await assert.rejects(closeResources(closers), AggregateError);
+  assert.deepEqual(calls, ['page', 'context', 'host']);
+  await closeResources(closers);
+  assert.equal(calls.length, 3);
+});
+
+test('a missing executable is reported without an unhandled process error', async () => {
+  const owned = spawnTestProcess('rgsm-e2e-nonexistent-executable', []);
+  await delay(100);
+  assert.match(owned.failure().message, /ENOENT/);
+  await owned.stop();
+});
+
+test('the owner stops only its child and repeated cleanup is harmless', async (t) => {
+  const owned = spawnTestProcess(process.execPath, ['-e', 'setInterval(() => {}, 1000)']);
+  t.after(() => owned.stop());
+  await delay(100);
+  assert.equal(owned.failure(), undefined);
+  await Promise.all([owned.stop(), owned.stop()]);
+  assert.ok(owned.child.exitCode !== null || owned.child.signalCode !== null);
+});
+
+test('Linux host launch isolates the session bus; other platforms use the binary directly', () => {
+  assert.deepEqual(hostCommand('/test/rgsm', 'linux'), {
+    command: 'dbus-run-session',
+    args: ['--', '/test/rgsm'],
+  });
+  assert.deepEqual(hostCommand('D:/test/rgsm.exe', 'win32'), {
+    command: 'D:/test/rgsm.exe',
+    args: [],
+  });
+  assert.deepEqual(hostCommand('/test/rgsm', 'darwin'), { command: '/test/rgsm', args: [] });
+});

--- a/apps/rgsm-gui/e2e/support/process.ts
+++ b/apps/rgsm-gui/e2e/support/process.ts
@@ -1,0 +1,91 @@
+import { spawn, spawnSync, type SpawnOptionsWithoutStdio } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+/** The caller retains this handle; cleanup never discovers processes from saved PIDs. */
+export function spawnTestProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio = {}
+) {
+  const child = spawn(command, args, {
+    ...options,
+    detached: process.platform !== 'win32',
+    windowsHide: true,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let spawnError: Error | undefined;
+  child.once('error', (error) => {
+    spawnError = error;
+  });
+  const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+  let stopping: Promise<void> | undefined;
+  function failure(): Error | undefined {
+    if (spawnError) return spawnError;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return new Error(`${command} exited (${child.exitCode ?? child.signalCode})`);
+    }
+  }
+  async function stopOwnedProcess() {
+    const pid = child.pid;
+    if (pid === undefined) return;
+    if (process.platform === 'win32') {
+      if (child.exitCode === null && child.signalCode === null) {
+        const result = spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], {
+          stdio: 'ignore',
+          windowsHide: true,
+          timeout: 5_000,
+        });
+        if (result.error) throw result.error;
+      }
+    } else {
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+      }
+    }
+    const finished = await Promise.race([
+      closed.then(() => true),
+      delay(2_000, false, { ref: false }),
+    ]);
+    if (!finished) {
+      if (process.platform !== 'win32') {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ESRCH') throw error;
+        }
+      }
+      const killed = await Promise.race([
+        closed.then(() => true),
+        delay(2_000, false, { ref: false }),
+      ]);
+      if (!killed) throw new Error(`Test process ${pid} did not stop`);
+    }
+  }
+  return {
+    child,
+    failure,
+    stop: () => (stopping ??= stopOwnedProcess()),
+  };
+}
+
+/** Every acquired resource is closed even when an earlier close fails. */
+export async function closeResources(closers: Array<() => Promise<unknown>>): Promise<void> {
+  const errors: unknown[] = [];
+  for (const close of closers.splice(0).reverse()) {
+    try {
+      await close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length) throw new AggregateError(errors, 'Could not close all test resources');
+}
+
+/** A Linux host gets its own bus, so duplicate GTK application IDs cannot share one. */
+export function hostCommand(binary: string, platform: NodeJS.Platform) {
+  return platform === 'linux'
+    ? { command: 'dbus-run-session', args: ['--', binary] }
+    : { command: binary, args: [] };
+}

--- a/apps/rgsm-gui/e2e/support/rgsm-instance.ts
+++ b/apps/rgsm-gui/e2e/support/rgsm-instance.ts
@@ -1,21 +1,18 @@
-import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { spawnSync, type ChildProcess } from 'node:child_process';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { createWriteStream, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
-import { VITE_ORIGIN, VITE_PORT } from './constants';
+import { setTimeout as delay } from 'node:timers/promises';
+import { finished } from 'node:stream/promises';
+import { hostCommand, spawnTestProcess } from './process';
 import { buildEnvironment, prepareBuild, preparedBinary } from './build-state';
 import { reportTiming } from './timing';
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const workspaceRoot = resolve(appRoot, '../..');
-
-export type TestWeb = {
-  origin: string;
-  stop: () => Promise<void>;
-};
 
 export type RgsmHost = {
   apiBaseUrl: string;
@@ -39,17 +36,6 @@ type HostFile = {
   port: number;
   api_token: string;
 };
-
-type SharedVite = {
-  child: ChildProcess | undefined;
-  users: number;
-};
-
-let sharedVite: SharedVite | undefined;
-
-// The Playwright worker owns the Vite child, but global teardown runs in a
-// separate process, so the child PID is recorded here for cross-process cleanup.
-const viteMarkerPath = join(tmpdir(), 'rgsm-gui-e2e-vite.json');
 
 export function workspacePath(...parts: string[]): string {
   return resolve(workspaceRoot, ...parts);
@@ -136,155 +122,6 @@ export function stopProcessTree(child: ChildProcess | undefined): void {
   child.kill('SIGTERM');
 }
 
-async function waitForHttpOk(url: string, timeoutMs: number, label: string): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url);
-      if (response.ok) return;
-      lastError = new Error(`${label} returned HTTP ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await delay(250);
-  }
-  throw new Error(`Timed out waiting for ${label}: ${String(lastError)}`);
-}
-
-function delay(ms: number): Promise<void> {
-  const { promise, resolve } = Promise.withResolvers<void>();
-  setTimeout(resolve, ms);
-  return promise;
-}
-
-export async function startTestWeb(): Promise<TestWeb> {
-  const startedAt = performance.now();
-  if (sharedVite) {
-    sharedVite.users += 1;
-    return {
-      origin: VITE_ORIGIN,
-      stop: async () => {
-        await releaseTestWeb();
-      },
-    };
-  }
-
-  try {
-    const response = await fetch(`${VITE_ORIGIN}/`);
-    if (response.ok) {
-      // A marker means the listener is a stale orphan from a crashed run; it
-      // can die mid-test when its dead parent's stdio closes. Replace it.
-      let stalePid: number | undefined;
-      try {
-        const marker = JSON.parse(await readFile(viteMarkerPath, 'utf8')) as { pid?: number };
-        stalePid = marker.pid;
-      } catch {
-        // No marker: a foreign dev server owns the port; adopt it.
-      }
-      if (stalePid !== undefined) {
-        stopPidTree(stalePid);
-        await rm(viteMarkerPath, { force: true });
-        await waitForPortFree(10_000);
-      } else {
-        sharedVite = { child: undefined, users: 1 };
-        return {
-          origin: VITE_ORIGIN,
-          stop: async () => {
-            await releaseTestWeb();
-          },
-        };
-      }
-    }
-  } catch {
-    // No leftover Vite on the shared port.
-  }
-
-  // Spawn Vite's node binary directly (no cmd/pnpm wrappers): the recorded PID
-  // is then the port owner itself, so teardown can kill it reliably.
-  const child = spawn(process.execPath, [join(appRoot, 'node_modules', 'vite', 'bin', 'vite.js')], {
-    cwd: appRoot,
-    env: { ...process.env },
-    stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true,
-  });
-  child.stdout?.on('data', (chunk) => {
-    process.stdout.write(`[vite] ${chunk}`);
-  });
-  child.stderr?.on('data', (chunk) => {
-    process.stderr.write(`[vite] ${chunk}`);
-  });
-  child.once('exit', (code) => {
-    if (sharedVite?.child === child) sharedVite = undefined;
-    if (code && code !== 0) {
-      process.stderr.write(`Vite exited with code ${code}\n`);
-    }
-  });
-  try {
-    await waitForHttpOk(`${VITE_ORIGIN}/`, 60_000, `Vite on port ${VITE_PORT}`);
-  } catch (error) {
-    stopProcessTree(child);
-    throw error;
-  }
-  await writeFile(viteMarkerPath, JSON.stringify({ pid: child.pid }), 'utf8');
-  sharedVite = { child, users: 1 };
-  reportTiming('Vite ready', startedAt);
-  return {
-    origin: VITE_ORIGIN,
-    stop: async () => {
-      await releaseTestWeb();
-    },
-  };
-}
-
-async function releaseTestWeb(): Promise<void> {
-  if (!sharedVite) return;
-  sharedVite.users = Math.max(0, sharedVite.users - 1);
-}
-
-async function waitForPortFree(timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      await fetch(`${VITE_ORIGIN}/`);
-    } catch {
-      return;
-    }
-    await delay(250);
-  }
-}
-
-function stopPidTree(pid: number): void {
-  if (process.platform === 'win32') {
-    spawnSync('taskkill', ['/pid', String(pid), '/T', '/F'], {
-      stdio: 'ignore',
-      windowsHide: true,
-    });
-    return;
-  }
-  try {
-    process.kill(pid, 'SIGTERM');
-  } catch {
-    // Already gone.
-  }
-}
-
-export async function stopSharedTestWeb(): Promise<void> {
-  const child = sharedVite?.child;
-  sharedVite = undefined;
-  stopProcessTree(child);
-  try {
-    const marker = JSON.parse(await readFile(viteMarkerPath, 'utf8')) as { pid?: number };
-    if (marker.pid !== undefined && marker.pid !== child?.pid) {
-      stopPidTree(marker.pid);
-    }
-  } catch {
-    // No marker: nothing this suite spawned is still alive.
-  }
-  await rm(viteMarkerPath, { force: true });
-  await waitForPortFree(10_000);
-}
-
 async function readLogTail(logPath: string): Promise<string> {
   try {
     const content = await readFile(logPath, 'utf8');
@@ -314,74 +151,75 @@ export async function startRgsmHost(options: HostStartOptions): Promise<RgsmHost
     else env[key] = value;
   }
 
-  const child = spawn(binary, [], {
-    cwd: workspaceRoot,
-    env,
-    stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true,
-  });
-  // Keep the last bytes of host output in memory: the piped log file is not
-  // reliably flushed when the process dies instantly (e.g. startup panic).
+  const command = hostCommand(binary, process.platform);
+  const owned = spawnTestProcess(command.command, command.args, { cwd: workspaceRoot, env });
+  const { child } = owned;
   let outputTail = '';
   const capture = (chunk: Buffer) => {
-    outputTail = (outputTail + chunk.toString('utf8')).slice(-16384);
+    outputTail = (outputTail + chunk.toString('utf8')).slice(-16_384);
   };
-  child.stdout?.on('data', capture);
-  child.stderr?.on('data', capture);
-  child.stdout?.pipe(log);
-  child.stderr?.pipe(log);
+  child.stdout.on('data', capture);
+  child.stderr.on('data', capture);
+  child.stdout.pipe(log, { end: false });
+  child.stderr.pipe(log, { end: false });
+  let stopping: Promise<void> | undefined;
+  const stop = () =>
+    (stopping ??= (async () => {
+      try {
+        await owned.stop();
+      } finally {
+        log.end();
+        await finished(log);
+      }
+    })());
 
-  const hostConfigPath = join(options.appDataDir, 'GameSaveManager.host.json');
-  const timeoutMs = options.readyTimeoutMs ?? 60_000;
-  const deadline = Date.now() + timeoutMs;
-  let config: HostFile | undefined;
-  let lastError: unknown;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) {
-      const tail = outputTail.trim() || (await readLogTail(options.logPath));
+  try {
+    const hostConfigPath = join(options.appDataDir, 'GameSaveManager.host.json');
+    const deadline = Date.now() + (options.readyTimeoutMs ?? 60_000);
+    let config: HostFile | undefined;
+    let lastError: unknown;
+    while (Date.now() < deadline) {
+      const failure = owned.failure();
+      if (failure) {
+        const tail = outputTail.trim() || (await readLogTail(options.logPath));
+        throw new Error(`RGSM Host for ${options.deviceId} failed: ${failure.message}.\n${tail}`);
+      }
+      try {
+        config = JSON.parse(await readFile(hostConfigPath, 'utf8')) as HostFile;
+        const response = await fetch(`http://127.0.0.1:${config.port}/api/v1/get-build-info`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${config.api_token}` },
+          signal: AbortSignal.timeout(Math.max(1, Math.min(1_000, deadline - Date.now()))),
+        });
+        await response.body?.cancel();
+        if (response.ok) break;
+        lastError = new Error(`get-build-info returned HTTP ${response.status}`);
+        config = undefined;
+      } catch (error) {
+        lastError = error;
+        config = undefined;
+      }
+      await delay(Math.max(0, Math.min(250, deadline - Date.now())));
+    }
+    if (!config) {
       throw new Error(
-        `RGSM Host for ${options.deviceId} exited with code ${child.exitCode}. Host output tail:\n${tail}`
+        `Timed out waiting for RGSM Host ${options.deviceId}: ${String(lastError)}. See ${options.logPath}`
       );
     }
-    try {
-      config = JSON.parse(await readFile(hostConfigPath, 'utf8')) as HostFile;
-      const response = await fetch(`http://127.0.0.1:${config.port}/api/v1/get-build-info`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${config.api_token}` },
-      });
-      if (response.ok) break;
-      lastError = new Error(`get-build-info returned HTTP ${response.status}`);
-      config = undefined;
-    } catch (error) {
-      lastError = error;
-      config = undefined;
-    }
-    await delay(250);
+    reportTiming(`HTTP host ready (${options.deviceId})`, startedAt);
+    return {
+      apiBaseUrl: `http://127.0.0.1:${config.port}`,
+      token: config.api_token,
+      port: config.port,
+      appDataDir: options.appDataDir,
+      deviceId: options.deviceId,
+      logPath: options.logPath,
+      stop,
+    };
+  } catch (error) {
+    await stop();
+    throw error;
   }
-  if (!config) {
-    stopProcessTree(child);
-    throw new Error(
-      `Timed out waiting for RGSM Host ${options.deviceId}: ${String(lastError)}. See ${options.logPath}`
-    );
-  }
-
-  let stopped = false;
-  reportTiming(`HTTP host ready (${options.deviceId})`, startedAt);
-  return {
-    apiBaseUrl: `http://127.0.0.1:${config.port}`,
-    token: config.api_token,
-    port: config.port,
-    appDataDir: options.appDataDir,
-    deviceId: options.deviceId,
-    logPath: options.logPath,
-    stop: async () => {
-      if (stopped) return;
-      stopped = true;
-      stopProcessTree(child);
-      await delay(200);
-      log.end();
-    },
-  };
 }
 
 export async function newDeviceContext(
@@ -389,14 +227,19 @@ export async function newDeviceContext(
   host: RgsmHost
 ): Promise<{ context: BrowserContext; page: Page }> {
   const context = await browser.newContext();
-  await context.addInitScript(
-    ({ apiBaseUrl, token }) => {
-      window.__RGSM_RUNTIME__ = { apiBaseUrl, token };
-    },
-    { apiBaseUrl: host.apiBaseUrl, token: host.token }
-  );
-  const page = await context.newPage();
-  return { context, page };
+  try {
+    await context.addInitScript(
+      ({ apiBaseUrl, token }) => {
+        window.__RGSM_RUNTIME__ = { apiBaseUrl, token };
+      },
+      { apiBaseUrl: host.apiBaseUrl, token: host.token }
+    );
+    const page = await context.newPage();
+    return { context, page };
+  } catch (error) {
+    await context.close();
+    throw error;
+  }
 }
 
 export async function hostPost<T>(
@@ -411,6 +254,7 @@ export async function hostPost<T>(
       ...(body === undefined ? {} : { 'Content-Type': 'application/json' }),
     },
     body: body === undefined ? undefined : JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
   });
   const raw = await response.text();
   let data = undefined as T;

--- a/apps/rgsm-gui/e2e/support/session.ts
+++ b/apps/rgsm-gui/e2e/support/session.ts
@@ -2,14 +2,9 @@ import type { Browser, BrowserContext, Page } from '@playwright/test';
 import { join } from 'node:path';
 import { DEVICE_A_ID, DEVICE_B_ID } from './constants';
 import type { DeviceLayout } from './cloud-fixture';
-import {
-  newDeviceContext,
-  removeRunRoot,
-  startRgsmHost,
-  startTestWeb,
-  type RgsmHost,
-} from './rgsm-instance';
+import { newDeviceContext, removeRunRoot, startRgsmHost, type RgsmHost } from './rgsm-instance';
 import { openApp } from './gui';
+import { closeResources } from './process';
 
 export type DualSession = {
   runRoot: string;
@@ -35,41 +30,50 @@ export async function startDualSession(
     label: string;
   }
 ): Promise<DualSession> {
-  const vite = await startTestWeb();
-  const hostA = await startRgsmHost({
-    appDataDir: options.deviceA.appDataDir,
-    deviceId: DEVICE_A_ID,
-    logPath: join(options.runRoot, 'logs', `${options.label}-a.log`),
-  });
-  const hostB = await startRgsmHost({
-    appDataDir: options.deviceB.appDataDir,
-    deviceId: DEVICE_B_ID,
-    logPath: join(options.runRoot, 'logs', `${options.label}-b.log`),
-  });
-  const startedA = await newDeviceContext(browser, hostA);
-  const startedB = await newDeviceContext(browser, hostB);
-  await openApp(startedA.page);
-  await openApp(startedB.page);
-  return {
-    runRoot: options.runRoot,
-    cloudRoot: options.cloudRoot,
-    deviceA: options.deviceA,
-    deviceB: options.deviceB,
-    hostA,
-    hostB,
-    contextA: startedA.context,
-    contextB: startedB.context,
-    pageA: startedA.page,
-    pageB: startedB.page,
-    close: async (keepRoot = false) => {
-      await startedA.context.close();
-      await startedB.context.close();
-      await hostA.stop();
-      await hostB.stop();
-      await vite.stop();
-      if (!keepRoot) {
-        await removeRunRoot(options.runRoot);
-      }
-    },
-  };
+  const closers: Array<() => Promise<unknown>> = [];
+  try {
+    const hostA = await startRgsmHost({
+      appDataDir: options.deviceA.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: join(options.runRoot, 'logs', `${options.label}-a.log`),
+    });
+    closers.push(hostA.stop);
+    const hostB = await startRgsmHost({
+      appDataDir: options.deviceB.appDataDir,
+      deviceId: DEVICE_B_ID,
+      logPath: join(options.runRoot, 'logs', `${options.label}-b.log`),
+    });
+    closers.push(hostB.stop);
+    const startedA = await newDeviceContext(browser, hostA);
+    closers.push(() => startedA.context.close());
+    const startedB = await newDeviceContext(browser, hostB);
+    closers.push(() => startedB.context.close());
+    await openApp(startedA.page);
+    await openApp(startedB.page);
+    return {
+      runRoot: options.runRoot,
+      cloudRoot: options.cloudRoot,
+      deviceA: options.deviceA,
+      deviceB: options.deviceB,
+      hostA,
+      hostB,
+      contextA: startedA.context,
+      contextB: startedB.context,
+      pageA: startedA.page,
+      pageB: startedB.page,
+      close: async (keepRoot = false) => {
+        await closeResources(closers);
+        if (!keepRoot) await removeRunRoot(options.runRoot);
+      },
+    };
+  } catch (error) {
+    try {
+      await closeResources(closers);
+    } catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], 'Session startup and cleanup failed', {
+        cause: cleanupError,
+      });
+    }
+    throw error;
+  }
 }

--- a/apps/rgsm-gui/e2e/support/test-web.ts
+++ b/apps/rgsm-gui/e2e/support/test-web.ts
@@ -1,0 +1,46 @@
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { stripVTControlCharacters } from 'node:util';
+import { spawnTestProcess } from './process';
+import { waitForHttpOk } from './http-probe';
+import { VITE_ORIGIN } from './constants';
+import { reportTiming } from './timing';
+
+export function hasServerAddress(output: string, origin: string): boolean {
+  return stripVTControlCharacters(output).includes(origin);
+}
+
+/** Global setup owns the server for the complete run, including worker restarts. */
+export async function startTestWebServer(appRoot: string) {
+  const startedAt = performance.now();
+  const processHandle = spawnTestProcess(
+    process.execPath,
+    [join(appRoot, 'node_modules', 'vite', 'bin', 'vite.js')],
+    { cwd: appRoot, env: { ...process.env } }
+  );
+  let output = '';
+  const capture = (chunk: Buffer) => {
+    const text = chunk.toString('utf8');
+    output = (output + text).slice(-16_384);
+    process.stdout.write(`[vite] ${text}`);
+  };
+  processHandle.child.stdout.on('data', capture);
+  processHandle.child.stderr.on('data', capture);
+  try {
+    // Only our child's successful bind can establish ownership. A busy port fails;
+    // it never adopts or terminates a user's development server.
+    const deadline = Date.now() + 60_000;
+    while (!hasServerAddress(output, VITE_ORIGIN)) {
+      const failure = processHandle.failure();
+      if (failure) throw new Error(`Vite failed to start: ${failure.message}\n${output}`);
+      if (Date.now() >= deadline) throw new Error(`Vite did not bind ${VITE_ORIGIN}\n${output}`);
+      await delay(50);
+    }
+    await waitForHttpOk(`${VITE_ORIGIN}/`, Math.max(1, deadline - Date.now()), 'test Vite');
+    reportTiming('Vite ready', startedAt);
+    return processHandle;
+  } catch (error) {
+    await processHandle.stop();
+    throw error;
+  }
+}

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
+    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
     "web:e2e": "playwright test --project=browser",
     "web:e2e:desktop": "playwright test --project=desktop",
     "dev": "tauri dev -- --locked",

--- a/apps/rgsm-gui/playwright.config.ts
+++ b/apps/rgsm-gui/playwright.config.ts
@@ -20,8 +20,9 @@ export default defineConfig({
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'off',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
   },
   outputDir: 'e2e-results',
   globalSetup: './e2e/support/global-setup.ts',
-  globalTeardown: './e2e/support/global-teardown.ts',
 });

--- a/apps/rgsm-gui/src-tauri/src/lib.rs
+++ b/apps/rgsm-gui/src-tauri/src/lib.rs
@@ -95,7 +95,13 @@ pub fn run() -> anyhow::Result<()> {
     configure_development_data_dir()?;
 
     info!("{}", t!("home.hello_world"));
-    config_check()?;
+    let config_outcome = config_check()?;
+    if should_notify_config_update(http_host_only, config_outcome.config_migrated) {
+        rgsm_core::preclude::show_notification(
+            t!("backend.config.updating_config_title"),
+            t!("backend.config.updating_config_body"),
+        );
+    }
 
     // 将 panic 信息记录到日志中
     std::panic::set_hook(Box::new(|panic_info| {
@@ -138,47 +144,47 @@ pub fn run() -> anyhow::Result<()> {
     // Dual Host E2E starts two HTTP-only processes. The desktop single-instance
     // lock would silently exit the second process before it can bind.
     if !http_host_only {
-        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            // Windows delivers this callback inside the synchronous WM_COPYDATA
-            // request sent by the second process. Defer WebView construction until
-            // the callback returns so the sender can complete and release its lock.
-            main_window::defer_show_main_window(app);
-        }));
+        builder = builder
+            .plugin(tauri_plugin_global_shortcut::Builder::new().build())
+            .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+                // Windows delivers this callback inside the synchronous WM_COPYDATA
+                // request sent by the second process. Defer WebView construction until
+                // the callback returns so the sender can complete and release its lock.
+                main_window::defer_show_main_window(app);
+            }));
     }
-    let app = builder
-        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
-        .setup(move |app| {
-            let http_host = tauri::async_runtime::block_on(http::start(app.handle().clone()))?;
-            info!(
-                target: "rgsm::http",
-                "HTTP Host listening on {}",
-                http_host.base_url
-            );
-            if !http_host_only {
-                main_window::show_main_window(app.handle())?;
-            }
-            let emitter = std::sync::Arc::new(TauriSyncEmitter {
-                app: app.handle().clone(),
-            });
-            let cloud_sync_manager = rgsm_core::cloud_sync::CloudSyncTaskManager::new(emitter);
-            let cloud_sync_worker = cloud_sync_manager.clone();
-            tauri::async_runtime::spawn(async move {
-                cloud_sync_worker.run().await;
-            });
-            let config = get_config().expect("Failed to load config while building hooks");
-            let cloud_operation_state = cloud_operation::CloudOperationState::default();
-            app.manage(cloud_operation_state.clone());
-            let pipeline = hooks::build_builtin_pipeline(app.handle(), &config);
-            app.manage(hooks::HookPipelineState::new(pipeline));
-
-            app.manage(cloud_sync_manager);
-            snapshot_sync::setup(app.handle().clone(), cloud_operation_state);
-
-            sound::setup(app).expect("Cannot setup sound manager");
-            // 处理快捷备份，包括托盘、定时、快捷键
-            quick_actions::setup(app).expect("Cannot setup quick actions");
-            Ok(())
+    let app = builder.setup(move |app| {
+        let http_host = tauri::async_runtime::block_on(http::start(app.handle().clone()))?;
+        info!(
+            target: "rgsm::http",
+            "HTTP Host listening on {}",
+            http_host.base_url
+        );
+        if !http_host_only {
+            main_window::show_main_window(app.handle())?;
+        }
+        let emitter = std::sync::Arc::new(TauriSyncEmitter {
+            app: app.handle().clone(),
         });
+        let cloud_sync_manager = rgsm_core::cloud_sync::CloudSyncTaskManager::new(emitter);
+        let cloud_sync_worker = cloud_sync_manager.clone();
+        tauri::async_runtime::spawn(async move {
+            cloud_sync_worker.run().await;
+        });
+        let config = get_config().expect("Failed to load config while building hooks");
+        let cloud_operation_state = cloud_operation::CloudOperationState::default();
+        app.manage(cloud_operation_state.clone());
+        let pipeline = hooks::build_builtin_pipeline(app.handle(), &config);
+        app.manage(hooks::HookPipelineState::new(pipeline));
+
+        app.manage(cloud_sync_manager);
+        snapshot_sync::setup(app.handle().clone(), cloud_operation_state);
+
+        sound::setup(app).expect("Cannot setup sound manager");
+        // 处理快捷备份，包括托盘、定时、快捷键
+        quick_actions::setup(app, !http_host_only).expect("Cannot setup quick actions");
+        Ok(())
+    });
 
     // 处理退出到托盘（关闭窗口不退出）
     let config = get_config()?;
@@ -218,6 +224,10 @@ fn should_prevent_exit(http_host_only: bool, exit_to_tray: bool, code: Option<i3
     code.is_none() && (http_host_only || exit_to_tray)
 }
 
+fn should_notify_config_update(http_host_only: bool, config_migrated: bool) -> bool {
+    !http_host_only && config_migrated
+}
+
 #[cfg(debug_assertions)]
 fn validate_e2e_cutover_failpoint() -> anyhow::Result<()> {
     rgsm_core::cloud_sync::v2::validate_e2e_cutover_interrupt_env()
@@ -232,7 +242,15 @@ fn validate_e2e_cutover_failpoint() -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod lifecycle_tests {
-    use super::should_prevent_exit;
+    use super::{should_notify_config_update, should_prevent_exit};
+
+    #[test]
+    fn configuration_update_notice_is_owned_by_desktop_startup() {
+        assert!(should_notify_config_update(false, true));
+        assert!(!should_notify_config_update(false, false));
+        assert!(!should_notify_config_update(true, true));
+        assert!(!should_notify_config_update(true, false));
+    }
 
     #[test]
     fn windowless_http_host_stays_alive_until_explicitly_stopped() {

--- a/apps/rgsm-gui/src-tauri/src/quick_actions/manager.rs
+++ b/apps/rgsm-gui/src-tauri/src/quick_actions/manager.rs
@@ -227,7 +227,7 @@ impl QuickActionWorker {
             state.current_game = Some(game.clone());
         }
 
-        self.set_tray_title(&current_game_label(Some(&game)))?;
+        self.refresh_tray_title(&current_game_label(Some(&game)));
 
         self.refresh_tray_game_label();
         Ok(())
@@ -243,23 +243,21 @@ impl QuickActionWorker {
             state.current_game = current_game;
         }
 
-        if let Err(err) = self.set_tray_title(&label) {
+        self.refresh_tray_title(&label);
+        self.refresh_tray_game_label();
+        Ok(())
+    }
+
+    fn refresh_tray_title(&self, label: &str) {
+        // HTTP-only hosts have no tray; selection and persistence remain available.
+        if let Some(tray) = self.manager.app_handle().tray_by_id("tray_icon")
+            && let Err(err) = tray.set_title(Some(label))
+        {
             warn!(
                 target: "rgsm::quick_action::manager",
                 "Failed to refresh quick action tray title: {err:?}"
             );
         }
-        self.refresh_tray_game_label();
-        Ok(())
-    }
-
-    fn set_tray_title(&self, label: &str) -> anyhow::Result<()> {
-        self.manager
-            .app_handle()
-            .tray_by_id("tray_icon")
-            .ok_or_else(|| anyhow::anyhow!("Cannot get tray"))?
-            .set_title(Some(label))?;
-        Ok(())
     }
 
     fn refresh_tray_game_label(&self) {

--- a/apps/rgsm-gui/src-tauri/src/quick_actions/mod.rs
+++ b/apps/rgsm-gui/src-tauri/src/quick_actions/mod.rs
@@ -24,7 +24,7 @@ use tray::setup_tray;
 
 use rgsm_core::config::get_config;
 
-pub fn setup(app: &mut tauri::App) -> anyhow::Result<()> {
+pub fn setup(app: &mut tauri::App, desktop_enabled: bool) -> anyhow::Result<()> {
     let manager = QuickActionManager::new(app.handle());
     app.manage(manager);
 
@@ -36,8 +36,10 @@ pub fn setup(app: &mut tauri::App) -> anyhow::Result<()> {
     process_monitor.sync_from_config();
     app.manage(process_monitor);
 
-    let config = get_config()?;
-    setup_tray(app)?;
-    setup_hotkeys(&config, app)?;
+    if desktop_enabled {
+        let config = get_config()?;
+        setup_tray(app)?;
+        setup_hotkeys(&config, app)?;
+    }
     Ok(())
 }

--- a/crates/rgsm-core/src/updater/migration.rs
+++ b/crates/rgsm-core/src/updater/migration.rs
@@ -1,4 +1,3 @@
-use rust_i18n::t;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -15,7 +14,7 @@ use crate::device::{DeviceResourceKind, DeviceResourceSource, get_current_device
 use crate::path_pattern::{
     ManifestPathConstraints, ManifestPathPattern, StoreKind, is_dynamic_manifest_path,
 };
-use crate::preclude::*;
+use crate::preclude::UpdaterError;
 use crate::updater::{
     probe::probe_config_version,
     versions::{
@@ -516,12 +515,6 @@ fn migrate_snapshot_created_by_fields(raw: &mut Value) -> usize {
 fn backup_config<P: AsRef<Path>>(path: P) -> Result<PathBuf, UpdaterError> {
     let path = path.as_ref();
     let backup_path = path.with_extension("json.bak");
-
-    // Show notification
-    show_notification(
-        t!("backend.config.updating_config_title"),
-        t!("backend.config.updating_config_body"),
-    );
 
     // Create backup
     fs::copy(path, &backup_path)?;


### PR DESCRIPTION
Depends on #537

Give each E2E run one owned Vite server and each session explicitly owned hosts and browser contexts. Startup failures unwind acquired resources; HTTP probes and cleanup have bounded waits. An occupied frontend port fails without adopting or terminating its listener

HTTP-only hosts retain backup, scheduler, and quick-game APIs without creating tray icons or registering global shortcuts. Tray updates are optional presentation, so selecting a game still succeeds without a desktop shell

Configuration migration reports its outcome without sending desktop notifications. Only normal desktop startup presents an upgrade notice; migration tests and HTTP-only hosts stay silent

Desktop attachment waits for the app page after CDP connects, rather than treating an initial empty or not-yet-navigated page list as failure. Window destruction, recreation, authenticated API access, and exit assertions remain in place

Linux hosts receive separate temporary D-Bus sessions. In the observed second CI shard, the E2E step fell from 13m48s to 2m24s and most host startups fell from about 25s to 0.26s. Real API and migration coverage remains in place; no separate backend is introduced
