### PR TITLE
fix(games): preserve stable references across navigation and upgrades

### DIFF
--- a/apps/rgsm-gui/e2e/local-game-identity.spec.ts
+++ b/apps/rgsm-gui/e2e/local-game-identity.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Game, Snapshot } from '../src/api/generated/types.gen';
+import { createRunRoot, hostPost } from './support/rgsm-instance';
+import { seedLocalConfig, writeSaveText } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+import { snapshotRow } from './support/gui';
+import { waitForCommand } from './support/command-result';
+
+test('same-title favorites open and restore the selected game independently', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('game-identities');
+  const saveA = join(runRoot, 'saves', 'a.sav');
+  const saveB = join(runRoot, 'saves', 'b.sav');
+  const device = await seedLocalConfig(runRoot, {
+    games: [
+      { name: 'Same', storageKey: 'first', units: [{ type: 'File', path: saveA }] },
+      { name: 'Same', storageKey: 'second', units: [{ type: 'File', path: saveB }] },
+    ],
+    favorites: [
+      { node_id: 'a', label: 'Same', is_leaf: true, game_id: 'first' },
+      { node_id: 'b', label: 'Same', is_leaf: true, game_id: 'second' },
+    ],
+  });
+  await writeSaveText(saveA, 'First game');
+  await writeSaveText(saveB, 'Second game');
+  const session = await startLocalSession(browser, { runRoot, device, label: 'game-identities' });
+  try {
+    const { page, host } = session;
+    await page.locator('.fav-row.leaf').nth(1).click();
+    await expect(page).toHaveURL(/gameId=second/);
+    await page.reload();
+    await expect(page).toHaveURL(/gameId=second/);
+    await page.getByPlaceholder('New backup description').fill('Second only');
+    const [created] = await Promise.all([
+      page.waitForResponse((response) => response.url().endsWith('/api/v1/create-snapshot-at')),
+      page.getByRole('button', { name: 'Create new snapshot' }).click(),
+    ]);
+    expect(created.ok(), await created.text()).toBe(true);
+    expect(created.request().postDataJSON().game.storage_key).toBe('second');
+    const config = await hostPost<{ games: Game[] }>(host, '/api/v1/get-local-config');
+    const second = config.data.games.find((game) => game.storage_key === 'second')!;
+    const catalog = await hostPost<{ backups: Snapshot[] }>(
+      host,
+      '/api/v1/get-game-snapshots-info',
+      {
+        game: second,
+      }
+    );
+    const snapshot = catalog.data.backups.find((item) => item.describe === 'Second only')!;
+    expect(snapshot).toBeTruthy();
+    await writeSaveText(saveB, 'Changed second game');
+    await waitForCommand(page, '/api/v1/restore-snapshot', snapshot.date, () =>
+      snapshotRow(page, snapshot.date).getByRole('button', { name: 'Apply', exact: true }).click()
+    );
+    expect(await readFile(saveA, 'utf8')).toBe('First game');
+    expect(await readFile(saveB, 'utf8')).toBe('Second game');
+
+    const promoted = await hostPost(host, '/api/v1/set-snapshot-created-by', {
+      gameId: 'second',
+      gameName: 'Same',
+      snapshotDate: snapshot.date,
+      createdBy: 'Manual',
+    });
+    expect(promoted.ok, promoted.raw).toBe(true);
+    for (const gameId of [undefined, 'missing']) {
+      const unresolved = await hostPost(host, '/api/v1/set-snapshot-created-by', {
+        gameId,
+        gameName: 'Same',
+        snapshotDate: snapshot.date,
+        createdBy: 'Manual',
+      });
+      expect(unresolved.ok, unresolved.raw).toBe(false);
+    }
+
+    await page.getByRole('button', { name: 'View managed files' }).click();
+    const drawer = page.getByRole('dialog');
+    // Trimming leaves the existing name unchanged, even though another game shares it.
+    await drawer.getByRole('textbox', { name: 'Game name', exact: true }).fill(' Same ');
+    const [edit] = await Promise.all([
+      page.waitForResponse((response) => response.url().endsWith('/api/v1/update-game'), {
+        timeout: 5000,
+      }),
+      drawer.getByRole('button', { name: 'save', exact: true }).click(),
+    ]);
+    expect(edit.ok(), await edit.text()).toBe(true);
+    expect(edit.request().postDataJSON().storageKey).toBe('second');
+    await expect(drawer).not.toBeVisible();
+    const renamed = await hostPost(host, '/api/v1/update-game', {
+      storageKey: 'second',
+      game: {
+        name: 'Renamed second',
+        save_paths: second.save_paths,
+        game_paths: second.game_paths ?? {},
+      },
+    });
+    expect(renamed.ok, renamed.raw).toBe(true);
+    // The saved old-title URL still identifies the renamed game.
+    await page.reload();
+    await expect(page.getByRole('heading', { name: 'Renamed second', exact: true })).toBeVisible();
+    await expect(page.locator('.fav-row.leaf').nth(0)).toHaveText('Same');
+    await expect(page.locator('.fav-row.leaf').nth(1)).toHaveText('Renamed second');
+    const first = config.data.games.find((game) => game.storage_key === 'first')!;
+    const removed = await hostPost(host, '/api/v1/delete-game', { game: first });
+    expect(removed.ok, removed.raw).toBe(true);
+    await page.reload();
+    await expect(page.locator('.fav-row.leaf')).toHaveCount(1);
+    await expect(page.locator('.fav-row.leaf')).toHaveText('Renamed second');
+    await expect(snapshotRow(page, snapshot.date)).toBeVisible();
+  } finally {
+    await session.close();
+  }
+});

--- a/apps/rgsm-gui/e2e/local-ludusavi-import.spec.ts
+++ b/apps/rgsm-gui/e2e/local-ludusavi-import.spec.ts
@@ -2,7 +2,77 @@ import { test, expect } from '@playwright/test';
 import { seedLocalConfig } from './support/local-fixture';
 import { startLocalSession } from './support/local-session';
 import { getLocalGame } from './support/local-gui';
-import { createRunRoot } from './support/rgsm-instance';
+import { createRunRoot, hostPost } from './support/rgsm-instance';
+
+test('batch import with automatic favorites keeps all imported games and binds their identities', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('batch-favorites');
+  const device = await seedLocalConfig(runRoot, {
+    games: [],
+    settings: { add_new_to_favorites: true },
+  });
+  const session = await startLocalSession(browser, { runRoot, device, label: 'batch-favorites' });
+  let failed = false;
+  let releaseCheck = () => {};
+  try {
+    const { page, host } = session;
+    await page.getByRole('button', { name: 'Add game' }).first().click();
+    await page.getByRole('button', { name: 'Detect local games' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Import Games (Auto-detect Save Locations)' });
+    await dialog.getByRole('checkbox', { name: 'Show only locally installed games' }).uncheck();
+    const search = dialog.getByRole('textbox', { name: 'Search games...' });
+    await expect(search).toBeEnabled({ timeout: 120_000 });
+    for (const name of ['Stardew Valley', 'Hollow Knight']) {
+      await search.fill(name);
+      await dialog.getByRole('checkbox', { name, exact: true }).check();
+    }
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve;
+    });
+    let heldCheck = false;
+    await page.route('**/api/v1/check-paths', async (route) => {
+      if (heldCheck) return route.continue();
+      heldCheck = true;
+      const response = await route.fetch();
+      await checkGate;
+      await route.fulfill({ response });
+    });
+    await Promise.all([
+      page.waitForRequest((request) => request.url().endsWith('/api/v1/check-paths')),
+      dialog.getByRole('button', { name: /Import 2 selected game/ }).click(),
+    ]);
+    const batch = page.getByRole('dialog', { name: 'Batch Import: 2 games' });
+    releaseCheck();
+    await expect(batch.getByRole('button', { name: 'Verify paths', exact: true })).toBeEnabled();
+    await batch.getByRole('button', { name: 'Select all', exact: true }).click();
+    for (const name of ['Stardew Valley', 'Hollow Knight']) {
+      await expect(batch.getByRole('checkbox', { name, exact: true })).toBeChecked();
+    }
+    await batch.getByRole('button', { name: /Import 2 selected game/ }).click();
+    await expect(batch).not.toBeVisible();
+    await expect
+      .poll(async () => {
+        const result = await hostPost<{
+          games: Array<{ name: string; storage_key: string }>;
+          favorites: Array<{ game_id?: string }>;
+        }>(host, '/api/v1/get-local-config');
+        return {
+          games: result.data.games.map((game) => game.name).sort(),
+          bound: result.data.favorites.filter((favorite) =>
+            result.data.games.some((game) => game.storage_key === favorite.game_id)
+          ).length,
+        };
+      })
+      .toEqual({ games: ['Hollow Knight', 'Stardew Valley'], bound: 2 });
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    releaseCheck();
+    await session.close(failed);
+  }
+});
 
 const IMPORTED_GAME = 'Stardew Valley';
 
@@ -17,6 +87,7 @@ test('ludusavi import: search manifest, customize paths, game joins the library'
   const session = await startLocalSession(browser, { runRoot, device, label: 'local-import' });
   const { page, host } = session;
   let failed = false;
+  let releaseCheck = () => {};
   try {
     await page.goto('/');
     await page.getByRole('button', { name: 'Add game' }).first().click();
@@ -35,12 +106,30 @@ test('ludusavi import: search manifest, customize paths, game joins the library'
     await expect(row).toBeVisible({ timeout: 30_000 });
     await row.check();
 
+    let heldCheck = false;
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve;
+    });
+    await page.route('**/api/v1/check-paths', async (route) => {
+      if (heldCheck || route.request().postDataJSON().paths.length <= 1) return route.continue();
+      heldCheck = true;
+      const response = await route.fetch();
+      await checkGate;
+      await route.fulfill({ response });
+    });
     await dialog.getByRole('button', { name: /Import 1 selected game/ }).click();
 
     const customize = page.getByRole('dialog', { name: `Customize Import: ${IMPORTED_GAME}` });
     await expect(customize).toBeVisible({ timeout: 60_000 });
-    // Paths default to unselected; confirm only imports the checked ones.
+    await expect.poll(() => heldCheck).toBe(true);
+    // Complete initial path detection before choosing this import's paths.
+    releaseCheck();
+    await expect(
+      customize.getByRole('button', { name: 'Verify paths', exact: true })
+    ).toBeEnabled();
     await customize.getByRole('button', { name: 'Select all' }).click();
+    const paths = customize.getByRole('checkbox');
+    for (const path of await paths.all()) await expect(path).toBeChecked({ timeout: 5000 });
     await customize.getByRole('button', { name: /^confirm$/i }).click();
 
     // The game joins the library: sidebar entry plus resolved save units.
@@ -53,6 +142,7 @@ test('ludusavi import: search manifest, customize paths, game joins the library'
     failed = true;
     throw error;
   } finally {
+    releaseCheck();
     await session.close(failed);
   }
 });

--- a/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/local-released-upgrade.spec.ts
@@ -41,6 +41,14 @@ for (const version of ['1.7.0', '1.8.0'] as const) {
         logPath: join(runRoot, 'host.log'),
       });
       const game = await getLocalGame(host, GAME_NAME);
+      const upgraded = await hostPost<{
+        favorites: Array<{ game_id: string }>;
+        games: Array<{ name: string; storage_key: string }>;
+        quick_action: { quick_action_game_id: string };
+      }>(host, '/api/v1/get-local-config');
+      expect(upgraded.data.favorites[0].game_id).toBe(game.storage_key);
+      expect(upgraded.data.games.find((game) => game.name === 'A_B')?.storage_key).toBe('A_B_2');
+      expect(upgraded.data.quick_action.quick_action_game_id).toBe('A_B_2');
       expect(game.save_paths.map((unit) => unit.id)).toEqual(scene.ids);
       expect(game.save_paths.map((unit) => unit.source)).toEqual([
         expect.objectContaining({ type: 'concrete', unit_type: 'Folder' }),

--- a/apps/rgsm-gui/e2e/support/local-fixture.ts
+++ b/apps/rgsm-gui/e2e/support/local-fixture.ts
@@ -13,6 +13,7 @@ export type LocalUnitSeed = {
 
 export type LocalGameSeed = {
   name: string;
+  storageKey?: string;
   units: LocalUnitSeed[];
 };
 
@@ -46,7 +47,7 @@ export async function seedLocalConfig(
     backup_path: forwardSlashes(device.archiveRoot),
     games: games.map((game) => ({
       name: game.name,
-      storage_key: game.name,
+      storage_key: game.storageKey ?? game.name,
       save_paths: game.units.map((unit, index) => ({
         id: index + 1,
         unit_type: unit.type,
@@ -109,9 +110,9 @@ export async function seedLocalConfig(
   // Snapshot metadata recording expects an existing Backups.json; games added
   // through the product get one at creation time.
   for (const game of games) {
-    await mkdir(join(device.archiveRoot, game.name), { recursive: true });
+    await mkdir(join(device.archiveRoot, game.storageKey ?? game.name), { recursive: true });
     await writeFile(
-      join(device.archiveRoot, game.name, 'Backups.json'),
+      join(device.archiveRoot, game.storageKey ?? game.name, 'Backups.json'),
       `${JSON.stringify({ name: game.name, backups: [], device_heads: {}, sync_version: 0 }, null, 2)}\n`,
       'utf8'
     );

--- a/apps/rgsm-gui/e2e/support/released-upgrade.ts
+++ b/apps/rgsm-gui/e2e/support/released-upgrade.ts
@@ -29,6 +29,9 @@ export async function seedReleasedUpgrade(runRoot: string, version: '1.7.0' | '1
   const ids = version === '1.8.0' ? [7, 11, 12] : [0, 1, 2];
   config.backup_path = join(appDataDir, 'save_data').replaceAll('\\', '/');
   config.games[0].name = GAME_NAME;
+  config.favorites = [
+    { node_id: 'legacy-favorite', label: GAME_NAME, is_leaf: true, children: null },
+  ];
   config.games[0].save_paths = units.map((unit, index) => ({
     ...(version === '1.8.0' ? { id: ids[index] } : {}),
     unit_type: unit.type,
@@ -42,6 +45,16 @@ export async function seedReleasedUpgrade(runRoot: string, version: '1.7.0' | '1
   config.devices = { [DEVICE_A_ID]: { id: DEVICE_A_ID, name: 'Upgrade device' } };
   config.quick_action.enable_sound = false;
   config.quick_action.enable_notification = false;
+  // These games have no backup directories yet. The first generated key shadows
+  // the second game's old name, but must not capture its quick-action selection.
+  const collidingGames = ['A__B', 'A_B'].map((name) => ({
+    ...structuredClone(config.games[0]),
+    name,
+    save_paths: [],
+    game_paths: {},
+  }));
+  config.games.push(...collidingGames);
+  config.quick_action.quick_action_game = collidingGames[1];
   await mkdir(archiveDir, { recursive: true });
   await writeFile(join(appDataDir, 'GameSaveManager.config.json'), JSON.stringify(config));
   const savePaths: string[] = [];

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
+    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/appRoutes.test.mjs src/utils/gameName.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
     "web:e2e": "playwright test --project=browser",
     "web:e2e:desktop": "playwright test --project=desktop",
     "dev": "tauri dev -- --locked",

--- a/apps/rgsm-gui/src-tauri/src/commands.rs
+++ b/apps/rgsm-gui/src-tauri/src/commands.rs
@@ -329,18 +329,11 @@ pub async fn get_local_config() -> Result<Config, String> {
     get_config().map_err(|e| e.to_string())
 }
 
-pub async fn add_game(game: GameDraft, app_handle: AppHandle) -> Result<(), String> {
-    info!(target:"rgsm::commands", "Adding game draft: {:?}", game);
+pub async fn add_game(game: GameDraft, app_handle: AppHandle) -> Result<Game, String> {
     svc(&app_handle)
         .add_game(&game, HookSource::UserManual)
         .await
-        .map_err(|e| {
-            error!(target:"rgsm::commands", "Failed to add game: {:?}", e);
-            e.to_string()
-        })?;
-
-    info!(target:"rgsm::commands", "Successfully added game draft: {:?}", game.name);
-    Ok(())
+        .map_err(|e| e.to_string())
 }
 
 pub async fn update_game(
@@ -1225,6 +1218,7 @@ pub async fn set_game_auto_save_settings(
 pub async fn set_snapshot_created_by(
     app_handle: AppHandle,
     game_name: String,
+    game_id: Option<String>,
     snapshot_date: String,
     created_by: CreatedBy,
 ) -> Result<GameSnapshots, String> {
@@ -1235,6 +1229,7 @@ pub async fn set_snapshot_created_by(
     svc(&app_handle)
         .set_snapshot_created_by(
             &game_name,
+            game_id.as_deref(),
             &snapshot_date,
             created_by,
             HookSource::UserManual,

--- a/apps/rgsm-gui/src-tauri/src/commands/http_commands.rs
+++ b/apps/rgsm-gui/src-tauri/src/commands/http_commands.rs
@@ -128,12 +128,12 @@ pub struct AddGameRequest {
     path = "/api/v1/add-game",
     operation_id = "addGame",
     request_body = AddGameRequest,
-    responses((status = 200, body = ()), (status = 400, body = ApiError), (status = 401, body = ApiError), (status = 409, body = ApiError), (status = 500, body = ApiError))
+    responses((status = 200, body = Game), (status = 400, body = ApiError), (status = 401, body = ApiError), (status = 409, body = ApiError), (status = 500, body = ApiError))
 )]
 pub async fn http_add_game(
     State(state): State<HttpHostState>,
     Json(request): Json<AddGameRequest>,
-) -> Result<Json<()>, ApiError> {
+) -> Result<Json<Game>, ApiError> {
     commands::add_game(request.game, state.app().clone())
         .await
         .map(Json)
@@ -1463,6 +1463,7 @@ pub async fn http_set_game_auto_save_settings(
 #[serde(rename_all = "camelCase")]
 pub struct SetSnapshotCreatedByRequest {
     pub game_name: String,
+    pub game_id: Option<String>,
     pub snapshot_date: String,
     pub created_by: CreatedBy,
 }
@@ -1481,6 +1482,7 @@ pub async fn http_set_snapshot_created_by(
     commands::set_snapshot_created_by(
         state.app().clone(),
         request.game_name,
+        request.game_id,
         request.snapshot_date,
         request.created_by,
     )

--- a/apps/rgsm-gui/src/App.vue
+++ b/apps/rgsm-gui/src/App.vue
@@ -175,13 +175,8 @@ async function initializeApp() {
       await saveConfig();
     }
 
-    const destination = resolveStartupDestination(
-      route.path,
-      mappedHome,
-      config.value.games,
-      'name' in route.params ? route.params.name : undefined
-    );
-    if (destination !== route.path) {
+    const destination = resolveStartupDestination(route.fullPath, mappedHome, config.value.games);
+    if (destination !== route.fullPath) {
       await navigateTo(destination);
     }
 

--- a/apps/rgsm-gui/src/api/commands.ts
+++ b/apps/rgsm-gui/src/api/commands.ts
@@ -455,12 +455,14 @@ export const commands = {
     );
   },
   async setSnapshotCreatedBy(
-    gameName: types.SetSnapshotCreatedByRequest['gameName'],
+    game: types.Game,
     snapshotDate: types.SetSnapshotCreatedByRequest['snapshotDate'],
     createdBy: types.SetSnapshotCreatedByRequest['createdBy']
   ) {
     return unwrap<types.SetSnapshotCreatedByResponses[200]>(
-      await sdk.setSnapshotCreatedBy({ body: { gameName, snapshotDate, createdBy } })
+      await sdk.setSnapshotCreatedBy({
+        body: { gameName: game.name, gameId: game.storage_key, snapshotDate, createdBy },
+      })
     );
   },
   async getAutoBackupStatus() {

--- a/apps/rgsm-gui/src/api/generated/index.ts
+++ b/apps/rgsm-gui/src/api/generated/index.ts
@@ -116,6 +116,7 @@ export type {
   AddGameError,
   AddGameErrors,
   AddGameRequest,
+  AddGameResponse,
   AddGameResponses,
   ApiError,
   ApiErrorCode,

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -562,6 +562,7 @@ export type ExtraBackupItem = {
 
 export type FavoriteTreeNode = {
   children?: Array<FavoriteTreeNode> | null;
+  game_id?: string | null;
   is_leaf: boolean;
   label: string;
   node_id: string;
@@ -1342,6 +1343,7 @@ export type SetSharedSnapshotRetentionRequest = {
 
 export type SetSnapshotCreatedByRequest = {
   createdBy: CreatedBy;
+  gameId?: string | null;
   gameName: string;
   snapshotDate: string;
 };
@@ -1572,8 +1574,10 @@ export type AddGameErrors = {
 export type AddGameError = AddGameErrors[keyof AddGameErrors];
 
 export type AddGameResponses = {
-  200: unknown;
+  200: Game;
 };
+
+export type AddGameResponse = AddGameResponses[keyof AddGameResponses];
 
 export type ApplyAllData = {
   body?: never;

--- a/apps/rgsm-gui/src/components/AddGameDrawer.vue
+++ b/apps/rgsm-gui/src/components/AddGameDrawer.vue
@@ -3,6 +3,7 @@ import { Check, Download, FilePlus2, RotateCcw, Search, Trash2 } from '@lucide/v
 import { computed, reactive, ref, watch } from 'vue';
 import {
   commands,
+  type Game,
   type GameDraft,
   type SaveUnitDraft,
   type Device,
@@ -11,7 +12,6 @@ import {
   type PathCheckResult,
 } from '../api/commands';
 import { $t } from '../i18n';
-import { v4 as uuidv4 } from 'uuid';
 import { error } from '../utils/logger';
 import PathVariableInput from './PathVariableInput.vue';
 import GameImportDialog from './GameImportDialog.vue';
@@ -20,6 +20,9 @@ import GameBatchImportDialog from './GameBatchImportDialog.vue';
 import { KAlert, KButton, KDrawer, KInput, KTag, KTagInput } from '../ui/kit';
 import { concreteSaveUnit, manifestSaveUnit, saveUnitPaths, saveUnitType } from '../utils/saveUnit';
 import { useAddGameDrawer } from '../composables/useAddGameDrawer';
+import { createGameFavorite, collectFavoriteGameIds } from './favoriteTreeContext';
+import { hasGameNameConflict } from '../utils/gameName';
+import { resolveGameReference } from '../utils/appRoutes';
 
 const feedback = useFeedback();
 const { config, refreshConfig, saveConfig } = useConfig();
@@ -134,7 +137,7 @@ watch(visible, (isOpen) => {
     reset_info(false);
     return;
   }
-  const gameConfig = config.value?.games.find((game) => game.name === gameName);
+  const gameConfig = resolveGameReference(config.value.games, gameName);
   if (gameConfig) {
     is_editing.value = true;
     editing_storage_key.value = gameConfig.storage_key ?? '';
@@ -580,6 +583,7 @@ interface GameConfig {
 
 async function handleBatchImportConfirm(configs: GameConfig[], storeUserId: string | null) {
   let successCount = 0;
+  const addedGames: Game[] = [];
   const failedGames: Array<{ name: string; reason: string }> = [];
 
   // Build lookup for Ludusavi metadata from original ImportableGame list
@@ -701,16 +705,8 @@ async function handleBatchImportConfirm(configs: GameConfig[], storeUserId: stri
 
       if (addResult.status === 'ok') {
         successCount++;
+        addedGames.push(addResult.data);
         existingNames.add(normalized);
-        if (config.value && config.value.settings.add_new_to_favorites) {
-          config.value.favorites = config.value.favorites ?? [];
-          config.value.favorites.push({
-            label: newGame.name,
-            is_leaf: true,
-            children: [],
-            node_id: uuidv4().toString(),
-          });
-        }
       } else {
         failedGames.push({ name: gameName, reason: addResult.error });
       }
@@ -723,17 +719,9 @@ async function handleBatchImportConfirm(configs: GameConfig[], storeUserId: stri
     }
   }
 
-  if (config.value && config.value.settings.add_new_to_favorites) {
-    try {
-      await saveConfig();
-    } catch (e) {
-      error(`Error saving favorites after batch import: ${e}`);
-    }
-  }
-
   if (successCount > 0) {
+    if (!(await saveImportedFavorites(addedGames))) return;
     notifySuccess($t('game_import.import_success', { count: successCount }));
-    await refreshConfig();
     if (failedGames.length > 0) {
       const failedDetails = failedGames.map((f) => `${f.name}: ${f.reason}`).join('\n');
       notifyWarning(
@@ -746,6 +734,19 @@ async function handleBatchImportConfirm(configs: GameConfig[], storeUserId: stri
     notifyError($t('game_import.import_error'));
   }
 }
+
+async function saveImportedFavorites(games: Game[]): Promise<boolean> {
+  // Reload the saved games before persisting favorites, never submit the pre-import config.
+  if (!(await refreshConfig())) return false;
+  if (!config.value.settings.add_new_to_favorites) return true;
+  config.value.favorites ??= [];
+  const existing = collectFavoriteGameIds(config.value.favorites, config.value.games);
+  config.value.favorites.push(
+    ...games.filter((game) => !existing.has(game.storage_key ?? '')).map(createGameFavorite)
+  );
+  return saveConfig();
+}
+
 async function save() {
   const accountResourceId = await ensureSteamAccountResource(pendingStoreUserId.value);
   const normalizedInstallDirs = manualInstallDirs.value
@@ -763,15 +764,9 @@ async function save() {
     return;
   }
 
-  // Duplicate name check: when editing, allow keeping the same name
-  const duplicate = config.value?.games.find(
-    (x) => x.name.toLowerCase() == game_name.value.toLowerCase()
-  );
-  if (duplicate) {
-    if (!is_editing.value || duplicate.storage_key !== editing_storage_key.value) {
-      notifyError($t('addgame.duplicated_name_error'));
-      return;
-    }
+  if (hasGameNameConflict(config.value.games, game_name.value, editingGame.value)) {
+    notifyError($t('addgame.duplicated_name_error'));
+    return;
   }
 
   const game: GameDraft = {
@@ -802,21 +797,14 @@ async function save() {
   }
   try {
     if (is_editing.value) {
-      await commands.updateGame(editing_storage_key.value, game);
+      const result = await commands.updateGame(editing_storage_key.value, game);
+      if (result.status === 'error') throw new Error(result.error);
       is_editing.value = false;
       notifySuccess($t('addgame.add_game_success'));
     } else {
-      await commands.addGame(game);
-      if (config.value?.settings.add_new_to_favorites) {
-        await refreshConfig();
-        config.value?.favorites?.push({
-          label: game.name,
-          is_leaf: true,
-          children: [],
-          node_id: uuidv4().toString(),
-        });
-        await saveConfig();
-      }
+      const result = await commands.addGame(game);
+      if (result.status === 'error') throw new Error(result.error);
+      if (!(await saveImportedFavorites([result.data]))) return;
       notifySuccess($t('addgame.add_game_success'));
     }
     reset_info(false);

--- a/apps/rgsm-gui/src/components/CloudSyncOverview.vue
+++ b/apps/rgsm-gui/src/components/CloudSyncOverview.vue
@@ -192,7 +192,7 @@ function distribution(game: CloudArchiveGameView) {
 }
 
 function openGame(game: CloudArchiveGameView) {
-  void router.push(getGameManagementPath(game.name));
+  void router.push(getGameManagementPath({ name: game.name, storage_key: game.game_id }));
 }
 </script>
 

--- a/apps/rgsm-gui/src/components/FavoriteTree.vue
+++ b/apps/rgsm-gui/src/components/FavoriteTree.vue
@@ -15,7 +15,9 @@ import FavoriteTreeNode from './FavoriteTreeNode.vue';
 import {
   FAVORITE_TREE_CTX,
   collectFolderIds,
-  collectLeafNames,
+  collectFavoriteGameIds,
+  createGameFavorite,
+  favoriteGame,
   countLeaves,
   filterTree,
   findNode,
@@ -40,7 +42,9 @@ const addDialogOpen = ref(false);
 const searching = computed(() => !!props.searchQuery.trim());
 const rootNodes = computed(() => config.value?.favorites ?? []);
 const visibleTree = computed(() => filterTree(rootNodes.value, props.searchQuery));
-const favoriteNames = computed(() => collectLeafNames(config.value?.favorites));
+const favoriteIds = computed(() =>
+  collectFavoriteGameIds(config.value.favorites, config.value.games)
+);
 
 // ——— 持久化 ———
 const persist = useDebounceFn(async () => {
@@ -83,11 +87,12 @@ function toggleExpand(id: string) {
 
 // ——— 叶子点击：跳转游戏页；收藏指向已删除游戏时提示 ———
 function clickLeaf(node: FavNode) {
-  if (!config.value?.games.find((game) => game.name === node.label)) {
+  const game = favoriteGame(node, config.value.games);
+  if (!game) {
     notifyWarning($t('favorite.game_not_found') + ': ' + node.label);
     return;
   }
-  router.push(getGameManagementPath(node.label));
+  router.push(getGameManagementPath(game));
 }
 
 // ——— 编辑操作 ———
@@ -139,8 +144,8 @@ async function addFolder() {
 }
 
 function addGame(game: Game) {
-  if (!config.value || favoriteNames.value.has(game.name)) return;
-  rootNodes.value.push({ label: game.name, is_leaf: true, children: null, node_id: uuidv4() });
+  if (!config.value || favoriteIds.value.has(game.storage_key ?? '')) return;
+  rootNodes.value.push(createGameFavorite(game));
   commitTree();
   notifySuccess($t('favorite.add_success') + ': ' + game.name);
 }
@@ -160,15 +165,10 @@ async function addAllGames() {
     return;
   }
   if (!config.value) return;
-  const existing = favoriteNames.value;
+  const existing = favoriteIds.value;
   const fresh = config.value.games
-    .filter((game) => !existing.has(game.name))
-    .map((game) => ({
-      label: game.name,
-      is_leaf: true,
-      children: null,
-      node_id: uuidv4(),
-    }));
+    .filter((game) => !existing.has(game.storage_key ?? ''))
+    .map(createGameFavorite);
   if (fresh.length === 0) {
     notifyWarning($t('favorite.no_new_games'));
     return;
@@ -292,12 +292,16 @@ provide(FAVORITE_TREE_CTX, {
 
     <KDialog v-model:open="addDialogOpen" :title="$t('favorite.choose_game_add')" :width="560">
       <div class="add-list">
-        <div v-for="game in config?.games ?? []" :key="game.name" class="add-row">
+        <div v-for="game in config?.games ?? []" :key="game.storage_key" class="add-row">
           <div class="add-info">
             <span class="add-name">{{ game.name }}</span>
             <span class="add-path">{{ gamePathsText(game) }}</span>
           </div>
-          <KButton size="sm" :disabled="favoriteNames.has(game.name)" @click="addGame(game)">
+          <KButton
+            size="sm"
+            :disabled="favoriteIds.has(game.storage_key ?? '')"
+            @click="addGame(game)"
+          >
             {{ $t('favorite.add_to_favorite') }}
           </KButton>
         </div>

--- a/apps/rgsm-gui/src/components/MainSideBar.vue
+++ b/apps/rgsm-gui/src/components/MainSideBar.vue
@@ -1,11 +1,11 @@
 <script lang="ts" setup>
 import { computed, onMounted, ref, watch } from 'vue';
 import { Cloud, Home, Info, Plus, Settings, Star } from '@lucide/vue';
-import { v4 as uuidv4 } from 'uuid';
 import { $t } from '../i18n';
 import { error } from '../utils/logger';
-import { commands, type FavoriteTreeNode, type Game } from '../api/commands';
+import { commands, type Game } from '../api/commands';
 import { getGameManagementPath } from '../composables/useGameManagementRoute';
+import { resolveManagementGame } from '../utils/appRoutes';
 import { useAddGameDrawer } from '../composables/useAddGameDrawer';
 import { useSidebarResize } from '../composables/useSidebarResize';
 import { refreshCloudLibrary } from '../composables/useCloudLibrary';
@@ -13,7 +13,12 @@ import KButton from '../ui/kit/KButton.vue';
 import KInput from '../ui/kit/KInput.vue';
 import KSegmented from '../ui/kit/KSegmented.vue';
 import FavoriteTree from './FavoriteTree.vue';
-import { collectLeafNames } from './favoriteTreeContext';
+import {
+  collectLeafNames,
+  collectFavoriteGameIds,
+  createGameFavorite,
+  removeFavoriteGame,
+} from './favoriteTreeContext';
 
 const { config, isGameVisible, saveConfig } = useConfig();
 const { sortedGames } = useSaveListSort();
@@ -25,6 +30,9 @@ const { isResizing, startResize } = useSidebarResize({
 const router = useRouter();
 const { open: openAddGame } = useAddGameDrawer();
 const route = useRoute();
+const activeGameId = computed(
+  () => resolveManagementGame(config.value.games, route.fullPath)?.storage_key
+);
 const searchQuery = ref('');
 
 // ——— 导航（主页/云同步/设置/关于）———
@@ -52,32 +60,17 @@ const visibleGames = computed(() => {
 });
 
 // 收藏叶子集合：「全部」视图的星标状态；树本身的组织在 FavoriteTree 内
-const favoriteNames = computed(() => collectLeafNames(config.value?.favorites));
-
-function removeFavoriteLeaf(nodes: FavoriteTreeNode[], name: string): boolean {
-  const index = nodes.findIndex((node) => node.is_leaf && node.label === name);
-  if (index >= 0) {
-    nodes.splice(index, 1);
-    return true;
-  }
-  for (const node of nodes) {
-    if (!node.is_leaf && node.children && removeFavoriteLeaf(node.children, name)) return true;
-  }
-  return false;
-}
+const favoriteIds = computed(() =>
+  collectFavoriteGameIds(config.value.favorites, config.value.games)
+);
 
 async function toggleFavorite(game: Game) {
   if (!config.value) return;
   const favorites = [...(config.value.favorites ?? [])];
-  if (favoriteNames.value.has(game.name)) {
-    removeFavoriteLeaf(favorites, game.name);
+  if (favoriteIds.value.has(game.storage_key ?? '')) {
+    removeFavoriteGame(favorites, game.storage_key ?? '', config.value.games);
   } else {
-    favorites.push({
-      label: game.name,
-      is_leaf: true,
-      children: null,
-      node_id: uuidv4(),
-    });
+    favorites.push(createGameFavorite(game));
   }
   config.value.favorites = favorites;
   await saveConfig();
@@ -123,11 +116,11 @@ watch(
 );
 
 function isActive(path: string): boolean {
-  return route.path === path;
+  return route.fullPath === path;
 }
 
 function goGame(game: Game) {
-  router.push(getGameManagementPath(game.name));
+  router.push(getGameManagementPath(game));
   void refreshCloudLibrary();
 }
 
@@ -179,10 +172,10 @@ function navigatePage(path: string) {
         <div v-show="viewMode === 'all'" class="all-list">
           <button
             v-for="game in visibleGames"
-            :key="game.name"
+            :key="game.storage_key"
             type="button"
             class="side-row game-row"
-            :class="{ active: isActive(getGameManagementPath(game.name)) }"
+            :class="{ active: !!game.storage_key && activeGameId === game.storage_key }"
             :title="game.name"
             @click="goGame(game)"
           >
@@ -194,16 +187,19 @@ function navigatePage(path: string) {
             <span class="row-text">{{ game.name }}</span>
             <span
               class="game-star"
-              :class="{ faved: favoriteNames.has(game.name) }"
+              :class="{ faved: favoriteIds.has(game.storage_key ?? '') }"
               role="button"
               :aria-label="
-                favoriteNames.has(game.name)
+                favoriteIds.has(game.storage_key ?? '')
                   ? $t('favorite.remove')
                   : $t('favorite.add_to_favorite')
               "
               @click.stop="toggleFavorite(game)"
             >
-              <Star :size="13" :fill="favoriteNames.has(game.name) ? 'currentColor' : 'none'" />
+              <Star
+                :size="13"
+                :fill="favoriteIds.has(game.storage_key ?? '') ? 'currentColor' : 'none'"
+              />
             </span>
           </button>
           <p v-if="visibleGames.length === 0 && searchQuery.trim()" class="empty-hint">

--- a/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
+++ b/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
@@ -16,6 +16,7 @@ import { usePathResolution } from '../composables/usePathResolution';
 import PathVariableInput from './PathVariableInput.vue';
 import ResourceMultiSelect from './ResourceMultiSelect.vue';
 import { saveUnitPaths, saveUnitType } from '../utils/saveUnit';
+import { hasGameNameConflict } from '../utils/gameName';
 import { KAlert, KButton, KDrawer, KInput, KSelect, KSwitch, KTag, KTooltip } from '../ui/kit';
 
 const { config } = useConfig();
@@ -300,11 +301,7 @@ function saveChanges() {
     return;
   }
 
-  const isDuplicate = config.value?.games.some(
-    (g) =>
-      g.storage_key !== props.game.storage_key && g.name.toLowerCase() === trimmedName.toLowerCase()
-  );
-  if (isDuplicate) {
+  if (hasGameNameConflict(config.value.games, trimmedName, props.game)) {
     notifyError($t('addgame.duplicated_name_error'));
     return;
   }

--- a/apps/rgsm-gui/src/components/favoriteTreeContext.ts
+++ b/apps/rgsm-gui/src/components/favoriteTreeContext.ts
@@ -1,5 +1,7 @@
 import type { InjectionKey, Ref } from 'vue';
-import type { FavoriteTreeNode } from '../api/commands';
+import type { FavoriteTreeNode, Game } from '../api/commands';
+import { resolveGameReference } from '../utils/appRoutes';
+import { v4 as uuidv4 } from 'uuid';
 
 export type DropPos = 'before' | 'after' | 'inner';
 
@@ -20,6 +22,45 @@ export interface FavoriteTreeCtx {
 }
 
 export const FAVORITE_TREE_CTX: InjectionKey<FavoriteTreeCtx> = Symbol('favorite-tree-ctx');
+
+export function createGameFavorite(game: Game): FavoriteTreeNode {
+  return {
+    node_id: uuidv4(),
+    label: game.name,
+    game_id: game.storage_key,
+    is_leaf: true,
+    children: null,
+  };
+}
+
+export function favoriteGame(node: FavoriteTreeNode, games: readonly Game[]): Game | undefined {
+  return node.is_leaf ? resolveGameReference(games, node.label, node.game_id) : undefined;
+}
+
+export function collectFavoriteGameIds(
+  nodes: FavoriteTreeNode[] | null | undefined,
+  games: readonly Game[],
+  out = new Set<string>()
+): Set<string> {
+  for (const node of nodes ?? []) {
+    const game = favoriteGame(node, games);
+    if (game?.storage_key) out.add(game.storage_key);
+    if (node.children) collectFavoriteGameIds(node.children, games, out);
+  }
+  return out;
+}
+
+export function removeFavoriteGame(
+  nodes: FavoriteTreeNode[],
+  gameId: string,
+  games: readonly Game[]
+): void {
+  for (let index = nodes.length - 1; index >= 0; index--) {
+    const node = nodes[index];
+    if (favoriteGame(node, games)?.storage_key === gameId) nodes.splice(index, 1);
+    else if (node.children) removeFavoriteGame(node.children, gameId, games);
+  }
+}
 
 // ——— 纯树操作：就地修改传入的根数组，调用方负责触发响应式并持久化 ———
 

--- a/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
+++ b/apps/rgsm-gui/src/components/management/useSnapshotTransfers.ts
@@ -286,7 +286,7 @@ export function useSnapshotTransfers(deps: {
           return;
         }
       }
-      const result = await commands.setSnapshotCreatedBy(game.value.name, snapshotDate, 'Manual');
+      const result = await commands.setSnapshotCreatedBy(game.value, snapshotDate, 'Manual');
       if (result.status === 'error') {
         notifyError($t('manage.convert_to_permanent_failed'));
         return;

--- a/apps/rgsm-gui/src/composables/useGameManagementRoute.ts
+++ b/apps/rgsm-gui/src/composables/useGameManagementRoute.ts
@@ -1,7 +1,1 @@
-import { getGameNameFromRouteParam } from '../utils/appRoutes';
-
-export function getGameManagementPath(gameName: string): string {
-  return `/Management/${encodeURIComponent(gameName)}`;
-}
-
-export { getGameNameFromRouteParam };
+export { getGameManagementPath, getGameNameFromRouteParam } from '../utils/appRoutes';

--- a/apps/rgsm-gui/src/composables/useNavigationLinks.ts
+++ b/apps/rgsm-gui/src/composables/useNavigationLinks.ts
@@ -27,7 +27,7 @@ export function useNavigationLinks() {
   const linksWithGames = computed<NavigationLink[]>(() => {
     const list = [...baseLinks.value];
     config.value?.games.forEach((game) => {
-      list.push({ text: game.name, link: getGameManagementPath(game.name), icon: Gamepad2 });
+      list.push({ text: game.name, link: getGameManagementPath(game), icon: Gamepad2 });
     });
     return list;
   });

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -50,6 +50,7 @@ import {
   getGameManagementPath,
   getGameNameFromRouteParam,
 } from '../../composables/useGameManagementRoute';
+import { resolveGameReference, resolveManagementGame } from '../../utils/appRoutes';
 import { useApplyConfirmation } from '../../composables/useApplyConfirmation';
 import { useCloudLibrary } from '../../composables/useCloudLibrary';
 import { usePathResolution } from '../../composables/usePathResolution';
@@ -248,7 +249,7 @@ const autoSaveConfigured = computed(() => isAutoSaveConfigured(config.value, gam
 
 async function onAutoSaveSettingsSaved() {
   await refreshConfig();
-  const latestGame = config.value.games.find((item) => item.name === game.value.name);
+  const latestGame = config.value.games.find((item) => item.storage_key === game.value.storage_key);
   if (latestGame) {
     game.value = latestGame;
   }
@@ -257,13 +258,11 @@ async function onAutoSaveSettingsSaved() {
 
 // Init game info
 watch(
-  () => ('name' in route.params ? route.params.name : undefined),
-  (newValue) => {
-    if (!newValue) {
-      return;
-    }
-    const name = getGameNameFromRouteParam(newValue);
-    game.value = config.value.games.find((x) => x.name == name) as Game;
+  () => route.fullPath,
+  (path) => {
+    const selected = resolveManagementGame(config.value.games, path);
+    if (!selected) return;
+    game.value = selected;
     undoInfo.value = null;
     retentionProtectedDates.value = new Set();
     refresh_backups_info();
@@ -323,7 +322,7 @@ async function onDefinitionSelected() {
   const gameId = game.value.storage_key;
   await refreshConfig();
   const selected = config.value.games.find((item) => item.storage_key === gameId);
-  if (selected) await router.replace(getGameManagementPath(selected.name));
+  if (selected) await router.replace(getGameManagementPath(selected));
   await refreshCloudLibrary(true);
 }
 
@@ -826,7 +825,9 @@ async function chooseRestoreLocation(mapping: {
       return false;
     }
     await refreshConfig();
-    const refreshedGame = config.value.games.find((item) => item.name === game.value.name);
+    const refreshedGame = config.value.games.find(
+      (item) => item.storage_key === game.value.storage_key
+    );
     if (refreshedGame) {
       game.value = refreshedGame;
     }
@@ -987,7 +988,11 @@ async function verify_archive_hashes() {
 // 设置快速备份，由快捷键和tray触发备份和恢复
 const isQuickBackupGame = computed(() => {
   const identity = config.value.quick_action?.quick_action_game_id;
-  return identity === game.value.storage_key || identity === game.value.name;
+  if (!identity) return false;
+  const selected =
+    config.value.games.find((item) => item.storage_key === identity) ??
+    resolveGameReference(config.value.games, identity);
+  return selected?.storage_key === game.value.storage_key;
 });
 
 async function set_quick_backup() {
@@ -1024,9 +1029,11 @@ async function on_drawer_save_changes(updatedGame: Game) {
       'name' in route.params ? route.params.name : undefined
     );
     if (updatedGame.name !== currentRouteGameName) {
-      await router.replace(getGameManagementPath(updatedGame.name));
+      await router.replace(getGameManagementPath(updatedGame));
     } else {
-      const refreshedGame = config.value.games.find((g) => g.name === updatedGame.name);
+      const refreshedGame = config.value.games.find(
+        (g) => g.storage_key === updatedGame.storage_key
+      );
       if (refreshedGame) {
         game.value = refreshedGame;
         await checkCurrentDeviceSavePaths();
@@ -1223,7 +1230,7 @@ async function copyPathsFromDevice(sourceDeviceId: string) {
 
   // 如果有更新，保存配置
   if (updated) {
-    const index = config.value.games.findIndex((g) => g.name === game.value.name);
+    const index = config.value.games.findIndex((g) => g.storage_key === game.value.storage_key);
     if (index !== -1) {
       config.value.games[index] = game.value;
       try {

--- a/apps/rgsm-gui/src/pages/index.vue
+++ b/apps/rgsm-gui/src/pages/index.vue
@@ -265,7 +265,7 @@ function goAutoBackup() {
   // 定时备份是按游戏配置的:有游戏去第一个游戏的管理页,没有则引导先导入
   const first = config.value?.games?.[0];
   if (first) {
-    navigateTo(getGameManagementPath(first.name));
+    navigateTo(getGameManagementPath(first));
   } else {
     openAddGame();
   }

--- a/apps/rgsm-gui/src/router.ts
+++ b/apps/rgsm-gui/src/router.ts
@@ -2,12 +2,7 @@ import { warn } from './utils/logger';
 import { createRouter, createWebHistory } from 'vue-router';
 import { routes, handleHotUpdate } from 'vue-router/auto-routes';
 import { useConfig } from './composables/useConfig';
-import {
-  isValidAppDestination,
-  managementGameExists,
-  mapLegacyHomePage,
-  getGameNameFromRouteParam,
-} from './utils/appRoutes';
+import { isValidAppDestination, mapLegacyHomePage } from './utils/appRoutes';
 
 export const router = createRouter({
   history: createWebHistory(),
@@ -23,11 +18,10 @@ router.beforeEach(async (to) => {
   await whenConfigReady();
 
   if (to.path.startsWith('/Management')) {
-    const routeParam = 'name' in to.params ? to.params.name : undefined;
-    if (managementGameExists(config.value.games, routeParam)) {
+    if (isValidAppDestination(to.fullPath, config.value.games)) {
       return true;
     }
-    void warn(`Game ${getGameNameFromRouteParam(routeParam)} not found`);
+    void warn(`Game destination ${to.fullPath} is missing or ambiguous`);
     return '/';
   }
 

--- a/apps/rgsm-gui/src/utils/appRoutes.test.mjs
+++ b/apps/rgsm-gui/src/utils/appRoutes.test.mjs
@@ -6,9 +6,46 @@ import {
   mapLegacyHomePage,
   managementGameExists,
   resolveStartupDestination,
+  resolveGameReference,
+  resolveManagementGame,
+  getGameManagementPath,
 } from './appRoutes.ts';
 
 const games = [{ name: 'Isaac' }, { name: 'Hollow Knight' }];
+
+test('explicit references never fall back to another games name', () => {
+  const first = { name: 'second', storage_key: 'first' };
+  const second = { name: 'Title', storage_key: 'second' };
+  assert.equal(resolveGameReference([first, second], 'second', 'second'), second);
+  assert.equal(resolveGameReference([first], 'second', 'second'), undefined);
+  assert.equal(resolveGameReference([first, second], 'second'), first);
+});
+
+test('route encoding preserves percent signs and reserved characters exactly once', () => {
+  const game = { name: 'Save %2F / ? #', storage_key: 'key&one' };
+  const link = getGameManagementPath(game);
+  assert.equal(resolveManagementGame([game], link), game);
+  assert.equal(resolveManagementGame([game], `/Management/${encodeURIComponent(game.name)}`), game);
+  assert.equal(isValidAppDestination('/Management/Title/extra?gameId=key%26one', [game]), false);
+});
+
+test('same-title games require an explicit identity in management routes', () => {
+  const duplicates = [
+    { name: 'Echo Keep', storage_key: 'echo-a' },
+    { name: 'Echo Keep', storage_key: 'echo-b' },
+  ];
+  assert.equal(isValidAppDestination('/Management/Echo%20Keep', duplicates), false);
+  assert.equal(isValidAppDestination('/Management/Echo%20Keep?gameId=echo-b', duplicates), true);
+  assert.equal(isValidAppDestination('/Management/Echo%20Keep?gameId=missing', duplicates), false);
+  assert.equal(isValidAppDestination('/Management/Echo%20Keep?gameId=', duplicates), false);
+});
+
+test('startup retains stable identity after a game is renamed', () => {
+  const renamed = [{ name: 'New title', storage_key: 'echo-a' }];
+  const link = '/Management/Old%20title?gameId=echo-a';
+  assert.equal(resolveStartupDestination(link, '/', renamed), link);
+  assert.equal(resolveStartupDestination('/', link, renamed), link);
+});
 
 test('legacy AddGame homepage maps to home', () => {
   assert.equal(mapLegacyHomePage('/AddGame'), '/');

--- a/apps/rgsm-gui/src/utils/appRoutes.ts
+++ b/apps/rgsm-gui/src/utils/appRoutes.ts
@@ -9,6 +9,39 @@ const LEGACY_HOME_PAGES: Record<string, string> = {
   '/AddGame': '/',
 };
 
+type NamedGame = { name: string; storage_key?: string };
+
+/** An explicit ID is authoritative; only unbound legacy references use a unique name. */
+export function resolveGameReference<T extends NamedGame>(
+  games: readonly T[],
+  name: string,
+  gameId?: string | null
+): T | undefined {
+  if (gameId != null) return games.find((game) => gameId !== '' && game.storage_key === gameId);
+  const matches = games.filter((game) => name !== '' && game.name === name);
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+export function getGameManagementPath(game: NamedGame): string {
+  const path = `/Management/${encodeURIComponent(game.name)}`;
+  return game.storage_key ? `${path}?gameId=${encodeURIComponent(game.storage_key)}` : path;
+}
+
+export function resolveManagementGame<T extends NamedGame>(
+  games: readonly T[],
+  path: string,
+  routeName?: string | string[]
+): T | undefined {
+  if (!path.startsWith('/Management/')) return;
+  const url = new URL(path, 'http://app.invalid');
+  if (!/^\/Management\/[^/]+$/.test(url.pathname)) return;
+  return resolveGameReference(
+    games,
+    getGameNameFromRouteParam(routeName ?? url.pathname.slice('/Management/'.length)),
+    url.searchParams.get('gameId')
+  );
+}
+
 export function getGameNameFromRouteParam(routeName: string | string[] | undefined): string {
   const raw = Array.isArray(routeName) ? (routeName[0] ?? '') : (routeName ?? '');
   try {
@@ -24,29 +57,27 @@ export function mapLegacyHomePage(path: string | null | undefined): string {
 }
 
 export function managementGameExists(
-  games: readonly { name: string }[],
+  games: readonly NamedGame[],
   routeName: string | string[] | undefined
 ): boolean {
   const gameName = getGameNameFromRouteParam(routeName);
-  return gameName.length > 0 && games.some((game) => game.name === gameName);
+  return resolveGameReference(games, gameName) !== undefined;
 }
 
 export function isValidAppDestination(
   path: string,
-  games: readonly { name: string }[],
+  games: readonly NamedGame[],
   routeName?: string | string[]
 ): boolean {
   const mapped = mapLegacyHomePage(path);
   if (KNOWN_APP_PAGES[mapped]) return true;
-  if (!mapped.startsWith('/Management')) return false;
-  const name = routeName ?? mapped.slice('/Management/'.length);
-  return managementGameExists(games, name);
+  return resolveManagementGame(games, mapped, routeName) !== undefined;
 }
 
 export function resolveStartupDestination(
   currentPath: string,
   homePage: string | null | undefined,
-  games: readonly { name: string }[],
+  games: readonly NamedGame[],
   routeName?: string | string[]
 ): string {
   const mappedCurrent = mapLegacyHomePage(currentPath);

--- a/apps/rgsm-gui/src/utils/gameName.test.mjs
+++ b/apps/rgsm-gui/src/utils/gameName.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { hasGameNameConflict } from './gameName.ts';
+
+test('existing same-title games can keep their names while editing', () => {
+  const first = { name: 'Same', storage_key: 'first' };
+  const second = { name: 'Same', storage_key: 'second' };
+  assert.equal(hasGameNameConflict([first, second], ' Same ', second), false);
+  assert.equal(hasGameNameConflict([first, second], 'SAME', { ...second }), false);
+});
+
+test('new games and renames cannot take another games name', () => {
+  const first = { name: 'Same', storage_key: 'first' };
+  const second = { name: 'Other', storage_key: 'second' };
+  assert.equal(hasGameNameConflict([first, second], ' same '), true);
+  assert.equal(hasGameNameConflict([first, second], 'same', second), true);
+  assert.equal(hasGameNameConflict([first, second], 'Unique', second), false);
+});

--- a/apps/rgsm-gui/src/utils/gameName.ts
+++ b/apps/rgsm-gui/src/utils/gameName.ts
@@ -1,0 +1,12 @@
+type NamedGame = { name: string };
+
+/** Existing same-title games remain editable; only a new or changed name can conflict. */
+export function hasGameNameConflict(
+  games: readonly NamedGame[],
+  nextName: string,
+  existing?: NamedGame | null
+): boolean {
+  const name = nextName.trim().toLowerCase();
+  if (existing?.name.toLowerCase() === name) return false;
+  return games.some((game) => game.name.toLowerCase() === name);
+}

--- a/crates/rgsm-core/src/backup/game.rs
+++ b/crates/rgsm-core/src/backup/game.rs
@@ -987,12 +987,11 @@ impl Game {
         let backup_path = get_backup_path()?.join(self.backup_dir_name().as_ref());
         fs::remove_dir_all(&backup_path)?;
 
+        // Bind any legacy references while the deleted game is still present.
+        config.remove_deleted_game_references(self);
         config
             .games
             .retain(|x| x.backup_dir_name() != self.backup_dir_name());
-        // TODO(config-hooks): move this cleanup into a gated config-change hook
-        // once config commits can mutate/abort the pending write transaction.
-        config.remove_deleted_game_references(self);
         set_config_local(&config)?;
 
         info!(target:"rgsm::backup::game",

--- a/crates/rgsm-core/src/backup/utils.rs
+++ b/crates/rgsm-core/src/backup/utils.rs
@@ -9,7 +9,7 @@ use tokio::sync::Semaphore;
 
 use super::game::SnapshotCreated;
 use super::storage_key::generate_unique_storage_key;
-use super::{GameDraft, GameSnapshots};
+use super::{Game, GameDraft, GameSnapshots};
 
 async fn create_backup_folder(dir_name: &str) -> Result<(), BackupError> {
     let backup_path = get_backup_path()?.join(dir_name);
@@ -27,7 +27,7 @@ async fn create_backup_folder(dir_name: &str) -> Result<(), BackupError> {
     Ok(())
 }
 
-pub async fn create_game_backup(game: &GameDraft) -> Result<(), BackupError> {
+pub async fn create_game_backup(game: &GameDraft) -> Result<Game, BackupError> {
     let mut config = get_config()?;
 
     if config
@@ -51,10 +51,10 @@ pub async fn create_game_backup(game: &GameDraft) -> Result<(), BackupError> {
     create_backup_folder(&storage_key).await?;
     let mut new_game = game.clone().into_game(None);
     new_game.storage_key = storage_key;
-    config.games.push(new_game);
+    config.games.push(new_game.clone());
 
     set_config_local(&config)?;
-    Ok(())
+    Ok(new_game)
 }
 
 pub async fn backup_all() -> Result<Vec<SnapshotCreated>, BackupError> {

--- a/crates/rgsm-core/src/config/app_config.rs
+++ b/crates/rgsm-core/src/config/app_config.rs
@@ -86,6 +86,7 @@ impl Config {
     }
 
     pub fn remove_deleted_game_references(&mut self, deleted_game: &Game) -> bool {
+        self.bind_legacy_game_references();
         let quick_action_changed = self
             .quick_action
             .remove_deleted_game_reference(deleted_game);
@@ -98,10 +99,16 @@ impl Config {
     /// Locate a game by its stable identity, accepting legacy display-name
     /// callers while preferring `storage_key` when available.
     pub fn position_game_by_identity(&self, identity: &str) -> Option<usize> {
-        self.games
-            .iter()
-            .position(|game| !identity.is_empty() && game.storage_key == identity)
-            .or_else(|| self.games.iter().position(|game| game.name == identity))
+        super::game_identity::position_game_by_identity(&self.games, identity)
+    }
+
+    pub(crate) fn bind_legacy_game_references(&mut self) {
+        FavoriteTreeNode::bind_legacy_games(&mut self.favorites, &self.games);
+        if let Some(game) = self.quick_action.selected_game(&self.games)
+            && !game.storage_key.is_empty()
+        {
+            self.quick_action.quick_action_game_id = Some(game.storage_key.clone());
+        }
     }
 }
 
@@ -110,37 +117,56 @@ pub struct FavoriteTreeNode {
     node_id: String,
     label: String,
     is_leaf: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    game_id: Option<String>,
     #[schema(no_recursion)]
     children: Option<Vec<Self>>,
 }
 
 impl FavoriteTreeNode {
-    pub(crate) fn rename_game_leaves(nodes: &mut [Self], previous: &str, next: &str) {
+    fn bind_legacy_games(nodes: &mut [Self], games: &[Game]) {
         for node in nodes {
-            if node.is_leaf && node.label == previous {
+            if node.is_leaf && node.game_id.is_none() {
+                let mut matches = games.iter().filter(|game| game.name == node.label);
+                if let Some(game) = matches.next()
+                    && matches.next().is_none()
+                    && !game.storage_key.is_empty()
+                {
+                    node.game_id = Some(game.storage_key.clone());
+                }
+            }
+            if let Some(children) = &mut node.children {
+                Self::bind_legacy_games(children, games);
+            }
+        }
+    }
+
+    pub(crate) fn rename_game_leaves(nodes: &mut [Self], game_id: &str, next: &str) {
+        for node in nodes {
+            if node.is_leaf && node.game_id.as_deref() == Some(game_id) {
                 node.label = next.to_string();
             }
             if let Some(children) = &mut node.children {
-                Self::rename_game_leaves(children, previous, next);
+                Self::rename_game_leaves(children, game_id, next);
             }
         }
     }
 
     fn remove_deleted_game_leaves(nodes: &mut Vec<Self>, deleted_game: &Game) -> bool {
-        Self::remove_game_leaves(nodes, &deleted_game.name)
+        Self::remove_game_leaves(nodes, &deleted_game.storage_key)
     }
 
-    pub(crate) fn remove_game_leaves(nodes: &mut Vec<Self>, game_name: &str) -> bool {
+    pub(crate) fn remove_game_leaves(nodes: &mut Vec<Self>, game_id: &str) -> bool {
         let mut changed = false;
 
         nodes.retain_mut(|node| {
-            if node.is_leaf && node.label == game_name {
+            if node.is_leaf && node.game_id.as_deref() == Some(game_id) {
                 changed = true;
                 return false;
             }
 
             if let Some(children) = &mut node.children
-                && Self::remove_game_leaves(children, game_name)
+                && Self::remove_game_leaves(children, game_id)
             {
                 changed = true;
             }
@@ -175,6 +201,7 @@ mod tests {
             node_id: format!("leaf-{label}"),
             label: label.to_string(),
             is_leaf: true,
+            game_id: None,
             children: None,
         }
     }
@@ -184,6 +211,7 @@ mod tests {
             node_id: format!("folder-{label}"),
             label: label.to_string(),
             is_leaf: false,
+            game_id: None,
             children: Some(children),
         }
     }
@@ -192,6 +220,10 @@ mod tests {
     fn cleanup_deleted_game_references_removes_matching_favorite_leaves() {
         let deleted_game = test_game("Deleted Game", "deleted-game-key");
         let mut config = Config {
+            games: vec![
+                deleted_game.clone(),
+                test_game("Remaining Game", "remaining"),
+            ],
             favorites: vec![
                 favorite_leaf("Deleted Game"),
                 favorite_folder(
@@ -230,7 +262,8 @@ mod tests {
             "Before",
             vec![favorite_leaf("Before"), favorite_leaf("Other")],
         )];
-        FavoriteTreeNode::rename_game_leaves(&mut nodes, "Before", "After");
+        FavoriteTreeNode::bind_legacy_games(&mut nodes, &[test_game("Before", "stable")]);
+        FavoriteTreeNode::rename_game_leaves(&mut nodes, "stable", "After");
         assert_eq!(nodes[0].label, "Before");
         let children = nodes[0].children.as_ref().unwrap();
         assert_eq!(children[0].label, "After");
@@ -258,6 +291,68 @@ mod tests {
         };
 
         assert_eq!(config.position_game_by_identity("Display Name"), Some(0));
+    }
+
+    #[test]
+    fn game_references_reject_ambiguous_legacy_names() {
+        let config = Config {
+            games: vec![test_game("Same", "first"), test_game("Same", "second")],
+            ..Default::default()
+        };
+        assert_eq!(config.position_game_by_identity("Same"), None);
+        assert_eq!(config.position_game_by_identity("second"), Some(1));
+    }
+
+    #[test]
+    fn game_references_delete_only_the_matching_favorite_identity() {
+        let deleted = test_game("Same", "first");
+        let mut config = Config {
+            games: vec![deleted.clone(), test_game("Same", "second")],
+            favorites: serde_json::from_value(serde_json::json!([
+                {"node_id":"a", "label":"Same", "is_leaf":true, "game_id":"first"},
+                {"node_id":"b", "label":"Same", "is_leaf":true, "game_id":"second"}
+            ]))
+            .unwrap(),
+            ..Default::default()
+        };
+        assert!(config.remove_deleted_game_references(&deleted));
+        assert_eq!(config.favorites.len(), 1);
+        assert_eq!(config.favorites[0].node_id, "b");
+    }
+
+    #[test]
+    fn game_references_bind_legacy_favorites_before_splitting_owners() {
+        let config = Config {
+            games: vec![test_game("Legacy", "legacy-id")],
+            favorites: vec![favorite_folder("Folder", vec![favorite_leaf("Legacy")])],
+            ..Default::default()
+        };
+        let owners = crate::config::ConfigurationOwners::from_legacy(&config, &"device".into());
+        let favorites =
+            serde_json::to_value(&owners.device_profiles["device"].private_favorites).unwrap();
+        assert_eq!(favorites[0]["children"][0]["game_id"], "legacy-id");
+    }
+
+    #[test]
+    fn game_references_do_not_guess_ambiguous_or_stale_favorites() {
+        let mut config = Config {
+            games: vec![
+                test_game("Same", "first"),
+                test_game("Same", "second"),
+                test_game("Unique", "unique"),
+            ],
+            favorites: serde_json::from_value(serde_json::json!([
+                {"node_id":"ambiguous", "label":"Same", "is_leaf":true},
+                {"node_id":"stale", "label":"Unique", "is_leaf":true, "game_id":"removed"},
+                {"node_id":"legacy", "label":"Unique", "is_leaf":true}
+            ]))
+            .unwrap(),
+            ..Default::default()
+        };
+        config.bind_legacy_game_references();
+        assert_eq!(config.favorites[0].game_id, None);
+        assert_eq!(config.favorites[1].game_id.as_deref(), Some("removed"));
+        assert_eq!(config.favorites[2].game_id.as_deref(), Some("unique"));
     }
 
     #[test]

--- a/crates/rgsm-core/src/config/game_identity.rs
+++ b/crates/rgsm-core/src/config/game_identity.rs
@@ -1,0 +1,17 @@
+use crate::backup::Game;
+
+/// Prefer a stable key. A legacy name is usable only when it identifies one game.
+pub(super) fn position_game_by_identity(games: &[Game], identity: &str) -> Option<usize> {
+    if identity.is_empty() {
+        return None;
+    }
+    if let Some(index) = games.iter().position(|game| game.storage_key == identity) {
+        return Some(index);
+    }
+    let mut matches = games
+        .iter()
+        .enumerate()
+        .filter(|(_, game)| game.name == identity);
+    let (index, _) = matches.next()?;
+    matches.next().is_none().then_some(index)
+}

--- a/crates/rgsm-core/src/config/mod.rs
+++ b/crates/rgsm-core/src/config/mod.rs
@@ -1,5 +1,6 @@
 mod app_config;
 pub mod backup;
+mod game_identity;
 mod local_games;
 pub(crate) mod owner_store;
 mod ownership;

--- a/crates/rgsm-core/src/config/ownership.rs
+++ b/crates/rgsm-core/src/config/ownership.rs
@@ -109,7 +109,7 @@ impl DeviceProfile {
         let game_changed = self.games.remove(game_id).is_some();
         let quick_action_changed = self.quick_action.remove_game_reference(game_id, game_name);
         let favorites_changed =
-            FavoriteTreeNode::remove_game_leaves(&mut self.private_favorites, game_name);
+            FavoriteTreeNode::remove_game_leaves(&mut self.private_favorites, game_id);
         game_changed || quick_action_changed || favorites_changed
     }
 
@@ -287,6 +287,8 @@ impl ConfigurationOwners {
     /// Split a loaded flat configuration into explicit shared, per-device, and
     /// local owners without consulting process-global device state.
     pub fn from_legacy(config: &Config, current_device_id: &DeviceId) -> Self {
+        let mut config = config.clone();
+        config.bind_legacy_game_references();
         let shared_library = SharedLibrary {
             schema_version: V2_CONFIG_SCHEMA_VERSION,
             games: config.games.iter().map(SharedGame::from).collect(),

--- a/crates/rgsm-core/src/config/quick_actions_settings.rs
+++ b/crates/rgsm-core/src/config/quick_actions_settings.rs
@@ -116,10 +116,7 @@ impl Default for QuickActionsSettings {
 impl QuickActionsSettings {
     pub fn selected_game<'a>(&self, games: &'a [Game]) -> Option<&'a Game> {
         let identity = self.quick_action_game_id.as_deref()?;
-        games
-            .iter()
-            .find(|game| !identity.is_empty() && game.storage_key == identity)
-            .or_else(|| games.iter().find(|game| game.name == identity))
+        super::game_identity::position_game_by_identity(games, identity).map(|index| &games[index])
     }
 
     pub fn remove_deleted_game_reference(&mut self, deleted_game: &Game) -> bool {
@@ -130,7 +127,9 @@ impl QuickActionsSettings {
         let should_clear = self
             .quick_action_game_id
             .as_deref()
-            .is_some_and(|identity| identity == game_id || identity == game_name);
+            .is_some_and(|identity| {
+                identity == game_id || (game_id.is_empty() && identity == game_name)
+            });
 
         if should_clear {
             self.quick_action_game_id = None;
@@ -146,7 +145,9 @@ impl QuickActionsSettings {
     pub(crate) fn references_game_identity(&self, game_id: &str, game_name: &str) -> bool {
         self.quick_action_game_id
             .as_deref()
-            .is_some_and(|identity| identity == game_id || identity == game_name)
+            .is_some_and(|identity| {
+                identity == game_id || (game_id.is_empty() && identity == game_name)
+            })
             || self
                 .game_automations
                 .iter()
@@ -155,8 +156,8 @@ impl QuickActionsSettings {
 
     pub fn sync_updated_game_reference(&mut self, previous_game: &Game, updated_game: &Game) {
         if let Some(identity) = self.quick_action_game_id.as_deref()
-            && ((!previous_game.storage_key.is_empty() && identity == previous_game.storage_key)
-                || identity == previous_game.name)
+            && (identity == previous_game.storage_key
+                || (previous_game.storage_key.is_empty() && identity == previous_game.name))
         {
             self.quick_action_game_id = Some(if updated_game.storage_key.is_empty() {
                 updated_game.name.clone()
@@ -266,6 +267,26 @@ mod tests {
                 .selected_game(&games)
                 .map(|game| game.storage_key.as_str()),
             Some("stable-key")
+        );
+    }
+
+    #[test]
+    fn stable_quick_reference_is_not_changed_by_another_games_name() {
+        let other = game("selected-id", "other-id");
+        let renamed = game("Renamed", "other-id");
+        let mut settings = QuickActionsSettings {
+            quick_action_game_id: Some("selected-id".to_string()),
+            ..Default::default()
+        };
+        settings.sync_updated_game_reference(&other, &renamed);
+        assert_eq!(
+            settings.quick_action_game_id.as_deref(),
+            Some("selected-id")
+        );
+        assert!(!settings.remove_deleted_game_reference(&other));
+        assert_eq!(
+            settings.quick_action_game_id.as_deref(),
+            Some("selected-id")
         );
     }
 }

--- a/crates/rgsm-core/src/services/device_game_lifecycle.rs
+++ b/crates/rgsm-core/src/services/device_game_lifecycle.rs
@@ -331,6 +331,7 @@ mod tests {
                 service
                     .set_snapshot_created_by(
                         "Old Name",
+                        None,
                         "2026-09-05_12-00-00",
                         crate::backup::CreatedBy::Manual,
                         crate::hooks::HookSource::UserManual,
@@ -341,6 +342,7 @@ mod tests {
             service
                 .set_snapshot_created_by(
                     "Renamed Local",
+                    None,
                     "2026-09-05_12-00-00",
                     crate::backup::CreatedBy::Manual,
                     crate::hooks::HookSource::UserManual,

--- a/crates/rgsm-core/src/services/game.rs
+++ b/crates/rgsm-core/src/services/game.rs
@@ -14,7 +14,7 @@ use crate::hooks::{GameAddedCtx, GameDeletedCtx, GameUpdatedCtx, HookSource};
 use super::{ServiceContext, cloud_library_target::bound_v2_operator};
 
 impl ServiceContext {
-    pub async fn add_game(&self, game: &GameDraft, source: HookSource) -> Result<()> {
+    pub async fn add_game(&self, game: &GameDraft, source: HookSource) -> Result<Game> {
         let config = get_config()?;
         if config
             .games
@@ -26,7 +26,7 @@ impl ServiceContext {
         let previous_config = config;
         let v2_change = capture_v2_game_change()?;
 
-        backup::create_game_backup(game).await?;
+        let saved_game = backup::create_game_backup(game).await?;
         if let Some(expected) = v2_change
             && let Err(error) = publish_v2_game_change(expected).await
         {
@@ -35,24 +35,17 @@ impl ServiceContext {
         }
 
         let config = get_config()?;
-        let saved_game = config
-            .games
-            .iter()
-            .find(|existing| existing.name.eq_ignore_ascii_case(&game.name))
-            .cloned()
-            .ok_or_else(|| anyhow!("Game '{}' was not found after save", game.name))?;
-
         let snapshots = saved_game.get_game_snapshots_info()?;
         self.pipeline()
             .fire_game_added(&GameAddedCtx {
                 config,
                 source,
-                game: saved_game,
+                game: saved_game.clone(),
                 snapshots,
             })
             .await;
 
-        Ok(())
+        Ok(saved_game)
     }
 
     /// Update an existing game identified by `storage_key`.
@@ -76,12 +69,14 @@ impl ServiceContext {
             .ok_or_else(|| anyhow!("Game with storage_key '{}' not found", storage_key))?;
 
         let previous_game = config.games[index].clone();
+        config.bind_legacy_game_references();
 
         // Check for name collision with a *different* game
-        if config
-            .games
-            .iter()
-            .any(|g| g.storage_key != storage_key && g.name.eq_ignore_ascii_case(&draft.name))
+        if !previous_game.name.eq_ignore_ascii_case(&draft.name)
+            && config
+                .games
+                .iter()
+                .any(|g| g.storage_key != storage_key && g.name.eq_ignore_ascii_case(&draft.name))
         {
             bail!("Another game with name '{}' already exists", draft.name);
         }
@@ -94,7 +89,7 @@ impl ServiceContext {
             .sync_updated_game_reference(&previous_game, &updated_game);
         crate::config::FavoriteTreeNode::rename_game_leaves(
             &mut config.favorites,
-            &previous_game.name,
+            &previous_game.storage_key,
             &updated_game.name,
         );
         set_config(&config).await?;

--- a/crates/rgsm-core/src/services/snapshot.rs
+++ b/crates/rgsm-core/src/services/snapshot.rs
@@ -450,23 +450,27 @@ impl ServiceContext {
     pub async fn set_snapshot_created_by(
         &self,
         game_name: &str,
+        game_id: Option<&str>,
         snapshot_date: &str,
         created_by: CreatedBy,
         source: HookSource,
     ) -> Result<GameSnapshots, BackupError> {
         let config = get_config()?;
-        let game = config
-            .games
-            .iter()
-            .find(|game| game.name == game_name)
+        let mut matches = config.games.iter().filter(|game| match game_id {
+            Some(id) => !id.is_empty() && game.storage_key == id,
+            None => game.name == game_name,
+        });
+        let game = matches
+            .next()
+            .filter(|_| matches.next().is_none())
             .cloned()
             .ok_or_else(|| BackupError::BackupNotExist {
                 name: game_name.to_string(),
                 date: snapshot_date.to_string(),
             })?;
 
-        // Resolve the name-only legacy endpoint once before checking ownership.
-        // An unrelated local ID may be identical to this Game's display name.
+        // Resolve the authoritative Game once before both ownership and metadata writes.
+        // Name-only callers remain supported only when their name is unambiguous.
         if self
             .is_shared_game(&game.storage_key)
             .map_err(|error| BackupError::Unexpected(error.into()))?

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -544,7 +544,7 @@ impl ServiceContext {
         let game = get_config()?
             .games
             .into_iter()
-            .find(|game| game.storage_key == game_id || game.name == game_id)
+            .find(|game| game.storage_key == game_id)
             .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?;
         let snapshots = game.get_game_snapshots_info()?;
         let snapshot = snapshots
@@ -1132,7 +1132,7 @@ fn import_downloaded_lineage(
     let game = get_config()?
         .games
         .into_iter()
-        .find(|game| game.storage_key == game_id || game.name == game_id)
+        .find(|game| game.storage_key == game_id)
         .ok_or_else(|| CloudLibraryServiceError::GameProfileNotFound(game_id.to_string()))?;
     let mut local = match game.get_game_snapshots_info() {
         Ok(snapshots) => snapshots,

--- a/crates/rgsm-core/src/updater/migration.rs
+++ b/crates/rgsm-core/src/updater/migration.rs
@@ -663,6 +663,12 @@ fn migrate_save_unit_ids(mut config: Config) -> Config {
 /// Also replaces a legacy quick-action display-name reference with the storage
 /// key assigned to that game.
 fn migrate_storage_keys(mut config: Config, backup_path: &Path) -> Config {
+    // Resolve the old reference before newly generated keys can shadow names.
+    let quick_action_index = config
+        .quick_action
+        .quick_action_game_id
+        .as_deref()
+        .and_then(|identity| config.position_game_by_identity(identity));
     let mut assigned: std::collections::HashSet<String> = config
         .games
         .iter()
@@ -698,13 +704,9 @@ fn migrate_storage_keys(mut config: Config, backup_path: &Path) -> Config {
         assigned.insert(key);
     }
 
-    // Legacy quick-action references without a storage key deserialize to the
-    // display name. Replace that transitional identity after keys are assigned.
-    if let Some(ref mut identity) = config.quick_action.quick_action_game_id
-        && let Some(matched) = config.games.iter().find(|game| game.name == *identity)
-    {
-        *identity = matched.storage_key.clone();
-    }
+    config.quick_action.quick_action_game_id =
+        quick_action_index.map(|index| config.games[index].storage_key.clone());
+    config.bind_legacy_game_references();
 
     config
 }
@@ -1389,6 +1391,46 @@ mod tests {
         assert_ne!(k0, k1);
         assert!(!k0.is_empty());
         assert!(!k1.is_empty());
+    }
+
+    #[test]
+    fn migrate_storage_keys_preserves_quick_action_before_generated_keys_shadow_names() {
+        let temp_dir = temp_dir::TempDir::new().unwrap();
+        let mut config = Config::default();
+        for name in ["A__B", "A_B"] {
+            config.games.push(crate::backup::Game {
+                name: name.to_string(),
+                storage_key: String::new(),
+                save_paths: vec![],
+                game_paths: Default::default(),
+                next_save_unit_id: 0,
+                cloud_sync_enabled: false,
+                auto_backup: None,
+                ludusavi_meta: None,
+                device_bindings: Default::default(),
+            });
+        }
+        config.quick_action = serde_json::from_value(serde_json::json!({
+            "quick_action_game": config.games[1],
+        }))
+        .unwrap();
+
+        let migrated = migrate_storage_keys(config, temp_dir.path());
+
+        assert_eq!(migrated.games[0].storage_key, "A_B");
+        assert_eq!(migrated.games[1].storage_key, "A_B_2");
+        assert_eq!(
+            migrated.quick_action.quick_action_game_id.as_deref(),
+            Some("A_B_2")
+        );
+        assert_eq!(
+            migrated
+                .quick_action
+                .selected_game(&migrated.games)
+                .unwrap()
+                .name,
+            "A_B"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Depends on #538

Keep same-title games distinct throughout navigation, favorites, editing, and snapshot operations by using their existing storage keys. Legacy name-only links remain usable when unambiguous; 1.7/1.8 favorites are bound during upgrade.

Game creation now returns the saved game, so automatic favorites use its actual identity. Batch import reloads the saved configuration before adding favorites, fixing imported games being erased by a stale configuration write.

Regression coverage exercises second-game-only restore, unchanged-name editing, rename/reload/delete, ambiguous references, and upgrades without post-migration configuration repair.
