### PR TITLE
fix(import): preserve confirmed path selections

### DIFF
--- a/apps/rgsm-gui/e2e/local-ludusavi-import.spec.ts
+++ b/apps/rgsm-gui/e2e/local-ludusavi-import.spec.ts
@@ -43,9 +43,9 @@ test('batch import with automatic favorites keeps all imported games and binds t
       dialog.getByRole('button', { name: /Import 2 selected game/ }).click(),
     ]);
     const batch = page.getByRole('dialog', { name: 'Batch Import: 2 games' });
+    await batch.getByRole('button', { name: 'Select all', exact: true }).click();
     releaseCheck();
     await expect(batch.getByRole('button', { name: 'Verify paths', exact: true })).toBeEnabled();
-    await batch.getByRole('button', { name: 'Select all', exact: true }).click();
     for (const name of ['Stardew Valley', 'Hollow Knight']) {
       await expect(batch.getByRole('checkbox', { name, exact: true })).toBeChecked();
     }
@@ -122,12 +122,12 @@ test('ludusavi import: search manifest, customize paths, game joins the library'
     const customize = page.getByRole('dialog', { name: `Customize Import: ${IMPORTED_GAME}` });
     await expect(customize).toBeVisible({ timeout: 60_000 });
     await expect.poll(() => heldCheck).toBe(true);
-    // Complete initial path detection before choosing this import's paths.
+    // A late automatic check must not undo the player's explicit path selection.
+    await customize.getByRole('button', { name: 'Select all' }).click();
     releaseCheck();
     await expect(
       customize.getByRole('button', { name: 'Verify paths', exact: true })
     ).toBeEnabled();
-    await customize.getByRole('button', { name: 'Select all' }).click();
     const paths = customize.getByRole('checkbox');
     for (const path of await paths.all()) await expect(path).toBeChecked({ timeout: 5000 });
     await customize.getByRole('button', { name: /^confirm$/i }).click();

--- a/apps/rgsm-gui/src/components/GameBatchImportDialog.vue
+++ b/apps/rgsm-gui/src/components/GameBatchImportDialog.vue
@@ -95,7 +95,12 @@
               :class="{ 'rotate-90': activeGames.includes(game.name) }"
               aria-hidden="true"
             />
-            <KCheckbox v-model="game.selected" :aria-label="game.name" @click.stop />
+            <KCheckbox
+              v-model="game.selected"
+              :aria-label="game.name"
+              @update:model-value="selectionRevision++"
+              @click.stop
+            />
             <span class="min-w-0 flex-1 truncate text-sm font-medium text-text">
               {{ game.name }}
             </span>
@@ -123,7 +128,11 @@
                   :key="pathIndex"
                   class="flex items-center gap-2"
                 >
-                  <KCheckbox v-model="path.selected" :aria-label="path.path" />
+                  <KCheckbox
+                    v-model="path.selected"
+                    :aria-label="path.path"
+                    @update:model-value="selectionRevision++"
+                  />
                   <KInput
                     v-model="path.path"
                     size="sm"
@@ -256,6 +265,7 @@ const isChecking = ref(false);
 const searchText = ref('');
 const onlySelected = ref(false);
 const autoCheckedOnce = ref(false);
+const selectionRevision = ref(0);
 
 // Store user ID selection (datalist: 候选补全 + 允许任意输入)
 const selectedStoreUserId = ref<string | null>(null);
@@ -308,6 +318,7 @@ function formatTimeAgo(epochSecs: number): string {
 watch(
   () => [props.games, props.gamePaths],
   () => {
+    selectionRevision.value = 0;
     gameConfigs.value = props.games.map((game) => {
       const paths = props.gamePaths[game.name] || [];
       return {
@@ -347,7 +358,7 @@ watch(
     if (!open || loading || loadingUserIds) return;
     if (autoCheckedOnce.value) return;
     autoCheckedOnce.value = true;
-    await checkAllPaths(true);
+    await checkAllPaths(selectionRevision.value === 0);
   },
   { immediate: true }
 );
@@ -403,7 +414,8 @@ function handleCancel() {
 
 function handleConfirm() {
   const selected = gameConfigs.value.filter((g) => g.selected);
-  emit('confirm', selected, selectedStoreUserId.value || null);
+  // The importer owns a fixed selection, independent of late checks or another editing session.
+  emit('confirm', JSON.parse(JSON.stringify(selected)), selectedStoreUserId.value || null);
   emit('update:modelValue', false);
 }
 
@@ -416,10 +428,17 @@ async function handleStoreUserIdChange() {
 
 async function checkAllPaths(applySelection: boolean = false) {
   if (gameConfigs.value.length === 0) return;
+  const checkedGames = gameConfigs.value;
+  const revision = selectionRevision.value;
+  const canSelect = () =>
+    applySelection &&
+    dialogVisible.value &&
+    checkedGames === gameConfigs.value &&
+    revision === selectionRevision.value;
 
   isChecking.value = true;
   try {
-    for (const game of gameConfigs.value) {
+    for (const game of checkedGames) {
       const paths = game.paths.map((pathItem) => pathItem.path);
       if (paths.length === 0) continue;
 
@@ -455,7 +474,7 @@ async function checkAllPaths(applySelection: boolean = false) {
       }
     }
 
-    if (applySelection) {
+    if (canSelect()) {
       applySelectionByCheck();
     }
   } catch (e) {
@@ -465,7 +484,7 @@ async function checkAllPaths(applySelection: boolean = false) {
         p.check = { error: msg };
       });
     });
-    if (applySelection) {
+    if (canSelect()) {
       selectAllSupported();
     }
   } finally {
@@ -474,6 +493,7 @@ async function checkAllPaths(applySelection: boolean = false) {
 }
 
 function selectAllSupported() {
+  selectionRevision.value++;
   gameConfigs.value.forEach((game) => {
     game.selected = true;
     game.paths.forEach((p) => {
@@ -497,6 +517,7 @@ function applySelectionByCheck() {
 }
 
 async function selectByCheck() {
+  selectionRevision.value++;
   const hasAnyCheck = gameConfigs.value.some((g) => g.paths.some((p) => p.check));
   if (!hasAnyCheck) {
     await checkAllPaths(true);

--- a/apps/rgsm-gui/src/components/GameImportCustomizeDialog.vue
+++ b/apps/rgsm-gui/src/components/GameImportCustomizeDialog.vue
@@ -210,6 +210,7 @@ type PathCheckState = {
 };
 
 const selectedPaths = ref<SavePath[]>([]);
+const selectionRevision = ref(0);
 const isChecking = ref(false);
 const pathChecks = ref<Array<PathCheckState | null>>([]);
 
@@ -305,6 +306,7 @@ function isRowSelected(row: SavePath) {
 }
 
 function toggleRow(row: SavePath) {
+  selectionRevision.value++;
   if (isRowSelected(row)) {
     selectedPaths.value = selectedPaths.value.filter((item) => item !== row);
   } else {
@@ -316,6 +318,7 @@ function toggleRow(row: SavePath) {
 watch(
   () => [props.gameName, props.savePaths],
   () => {
+    selectionRevision.value = 0;
     form.value = {
       gameName: props.gameName,
       savePaths: JSON.parse(JSON.stringify(props.savePaths)),
@@ -346,7 +349,7 @@ watch(
     selectedStoreUserId.value = null;
     await loadUserIdCandidates();
     await nextTick();
-    await checkAllPaths(true);
+    await checkAllPaths(selectionRevision.value === 0);
   }
 );
 
@@ -364,13 +367,14 @@ function handleCancel() {
 function handleConfirm() {
   emit('confirm', {
     gameName: form.value.gameName,
-    savePaths: selectedPaths.value,
+    savePaths: JSON.parse(JSON.stringify(selectedPaths.value)),
     storeUserId: selectedStoreUserId.value || null,
   });
   emit('update:modelValue', false);
 }
 
 function selectAllSupported() {
+  selectionRevision.value++;
   selectedPaths.value = [...form.value.savePaths];
 }
 
@@ -383,6 +387,13 @@ function applySelectionByCheck() {
 
 async function checkAllPaths(applySelection: boolean = false) {
   if (!form.value.savePaths.length) return;
+  const checkedForm = form.value;
+  const revision = selectionRevision.value;
+  const canSelect = () =>
+    applySelection &&
+    dialogVisible.value &&
+    checkedForm === form.value &&
+    revision === selectionRevision.value;
   isChecking.value = true;
   try {
     const paths = form.value.savePaths.map((p) => p.path);
@@ -416,22 +427,22 @@ async function checkAllPaths(applySelection: boolean = false) {
         }
         return {};
       });
-      if (applySelection) {
-        await nextTick();
+      await nextTick();
+      if (canSelect()) {
         applySelectionByCheck();
       }
     } else {
       pathChecks.value = form.value.savePaths.map(() => ({ error: result.error }));
-      if (applySelection) {
-        await nextTick();
+      await nextTick();
+      if (canSelect()) {
         selectAllSupported();
       }
     }
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     pathChecks.value = form.value.savePaths.map(() => ({ error: msg }));
-    if (applySelection) {
-      await nextTick();
+    await nextTick();
+    if (canSelect()) {
       selectAllSupported();
     }
   } finally {
@@ -440,6 +451,7 @@ async function checkAllPaths(applySelection: boolean = false) {
 }
 
 async function selectByCheck() {
+  selectionRevision.value++;
   const hasAnyCheck = pathChecks.value.some((x) => x !== null);
   if (!hasAnyCheck) {
     await checkAllPaths(true);


### PR DESCRIPTION
Depends on #539

Keep explicit game and path selections when automatic path checks finish later. A late check may update its suggestions, but cannot overwrite a player's newer selection or a different editing session.

Confirmation passes a copied import plan instead of reactive dialog rows, preventing an in-flight check from removing later games while an import is already running. Delayed-response regressions cover single and batch imports against the real backend.
