### PR TITLE
fix(backup): keep game timers and settings drafts independent

### DIFF
--- a/apps/rgsm-gui/e2e/local-auto-backup.spec.ts
+++ b/apps/rgsm-gui/e2e/local-auto-backup.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@playwright/test';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import type { Config, Game, QuickActionCompleted, Snapshot } from '../src/api/commands';
+import { createRunRoot, hostPost, type RgsmHost } from './support/rgsm-instance';
+import { seedLocalConfig, writeSaveText } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+
+async function setTimer(host: RgsmHost, gameId: string, interval: number | null) {
+  const result = await hostPost(host, '/api/v1/set-game-auto-backup', {
+    gameName: gameId,
+    autoBackup: interval === null ? null : { interval_secs: interval, max_backup_count: null },
+  });
+  expect(result.ok, result.raw).toBe(true);
+}
+
+async function snapshots(host: RgsmHost, game: Game) {
+  const result = await hostPost<{ backups: Snapshot[] }>(host, '/api/v1/get-game-snapshots-info', {
+    game,
+  });
+  expect(result.ok, result.raw).toBe(true);
+  return result.data.backups;
+}
+
+test('same-title games each create timer backups and keep independent indicators', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('independent-timers');
+  const saves = [join(runRoot, 'first.sav'), join(runRoot, 'second.sav')];
+  const device = await seedLocalConfig(runRoot, {
+    games: ['first', 'second'].map((storageKey, index) => ({
+      name: 'Same',
+      storageKey,
+      units: [{ type: 'File', path: saves[index] }],
+    })),
+  });
+  for (const [index, path] of saves.entries()) await writeSaveText(path, `Game ${index}`);
+  const session = await startLocalSession(browser, {
+    runRoot,
+    device,
+    label: 'independent-timers',
+  });
+  let failed = false;
+  try {
+    const { host, page } = session;
+    await setTimer(host, 'first', 1);
+    await setTimer(host, 'second', 1);
+    const status = await hostPost<Array<{ game_id: string; game_name: string }>>(
+      host,
+      '/api/v1/get-auto-backup-status'
+    );
+    expect(status.data.map((row) => row.game_id).sort()).toEqual(['first', 'second']);
+    const config = await hostPost<Config>(host, '/api/v1/get-local-config');
+    for (const game of config.data.games) {
+      await expect
+        .poll(
+          async () =>
+            (await snapshots(host, game)).filter((snapshot) => snapshot.created_by === 'Timer')
+              .length,
+          { timeout: 15_000 }
+        )
+        .toBe(1);
+    }
+    await setTimer(host, 'first', null);
+    await page.reload();
+    const rows = page.locator('.all-list .game-row');
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0).locator('.game-dot')).not.toHaveClass(/\bon\b/);
+    await expect(rows.nth(1).locator('.game-dot')).toHaveClass(/\bon\b/);
+    for (const [index, path] of saves.entries())
+      expect(await readFile(path, 'utf8')).toBe(`Game ${index}`);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});
+
+test('a real timer completion preserves unsaved settings without submitting them', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('timer-settings-draft');
+  const device = await seedLocalConfig(runRoot);
+  await writeSaveText(device.savePath, 'Timer source');
+  const session = await startLocalSession(browser, {
+    runRoot,
+    device,
+    label: 'timer-settings-draft',
+  });
+  let failed = false;
+  try {
+    const { page, host } = session;
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Quick Actions', exact: true }).click();
+    const save = page.getByRole('button', { name: 'Save hotkeys', exact: true });
+    await expect(save).toBeDisabled();
+    const sound = page
+      .getByText('Play sound when quick actions finish', { exact: true })
+      .locator('..')
+      .getByRole('switch');
+    await expect(sound).not.toBeChecked();
+    await sound.click();
+    await expect(save).toBeEnabled();
+    let writes = 0;
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === '/api/v1/set-config') writes += 1;
+    });
+    await page.evaluate(async () => {
+      const state = window as typeof window & { timerCompletions: QuickActionCompleted[] };
+      state.timerCompletions = [];
+      const modulePath = '/src/api/commands.ts';
+      const { events } = await import(modulePath);
+      await events.quickActionCompleted.listen((event: { payload: QuickActionCompleted }) => {
+        if (event.payload.trigger === 'Timer' && event.payload.status === 'Success') {
+          state.timerCompletions.push(event.payload);
+        }
+      });
+    });
+    const config = await hostPost<Config>(host, '/api/v1/get-local-config');
+    const game = config.data.games[0];
+    await setTimer(host, game.storage_key!, 1);
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            () =>
+              (window as typeof window & { timerCompletions: QuickActionCompleted[] })
+                .timerCompletions.length
+          ),
+        { timeout: 15_000 }
+      )
+      .toBeGreaterThan(0);
+    await setTimer(host, game.storage_key!, null);
+    expect((await snapshots(host, game)).some((snapshot) => snapshot.created_by === 'Timer')).toBe(
+      true
+    );
+    // Give an erroneous config replacement time to trigger Settings' 500 ms autosave.
+    await page.waitForTimeout(750);
+    await expect(sound).toBeChecked();
+    await expect(save).toBeEnabled();
+    expect(writes).toBe(0);
+    const persisted = await hostPost<Config>(host, '/api/v1/get-local-config');
+    expect(persisted.data.quick_action?.enable_sound).toBe(false);
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session.close(failed);
+  }
+});

--- a/apps/rgsm-gui/src-tauri/src/quick_actions/scheduler.rs
+++ b/apps/rgsm-gui/src-tauri/src/quick_actions/scheduler.rs
@@ -18,7 +18,7 @@ use super::{QuickActionType, perform_changed_auto_backup};
 pub enum SchedulerCommand {
     /// Bulk-sync scheduler state from persisted game configs.
     /// Called on startup and whenever game configs change.
-    SyncFromConfig(Vec<(String, Game, AutoBackupConfig)>),
+    SyncFromConfig(Vec<Game>),
     /// Query current scheduler status.
     GetStatus {
         respond_to: oneshot::Sender<Vec<AutoBackupGameStatus>>,
@@ -28,6 +28,7 @@ pub enum SchedulerCommand {
 /// Status of one game's auto-backup timer, returned by `GetStatus`.
 #[derive(Debug, Clone, Serialize, Deserialize, Type, utoipa::ToSchema)]
 pub struct AutoBackupGameStatus {
+    pub game_id: String,
     pub game_name: String,
     pub interval_secs: u32,
 }
@@ -64,14 +65,7 @@ impl AutoBackupScheduler {
     /// Sync scheduler state from config — reads all games and enables timers for those with auto_backup.
     pub fn sync_from_config(&self) {
         let entries = match get_config() {
-            Ok(config) => config
-                .games
-                .into_iter()
-                .filter_map(|game| {
-                    let config = game.auto_backup.clone()?;
-                    Some((game.name.clone(), game, config))
-                })
-                .collect(),
+            Ok(config) => config.games,
             Err(e) => {
                 warn!(
                     target: "rgsm::scheduler",
@@ -125,46 +119,41 @@ fn handle_command(games: &mut HashMap<String, ScheduledGame>, cmd: SchedulerComm
     match cmd {
         SchedulerCommand::SyncFromConfig(entries) => {
             let now = Instant::now();
-            let new_names: std::collections::HashSet<String> =
-                entries.iter().map(|(name, _, _)| name.clone()).collect();
-
-            // Remove games no longer in config
-            games.retain(|name, _| new_names.contains(name));
-
-            for (name, game, config) in entries {
-                if let Some(existing) = games.get_mut(&name) {
-                    // Update game reference and config; keep existing schedule
-                    // if interval hasn't changed, otherwise reset
-                    if existing.config.interval_secs != config.interval_secs {
-                        existing.next_trigger =
-                            now + Duration::from_secs(config.interval_secs as u64);
-                    }
-                    existing.game = game;
-                    existing.config = config;
-                } else {
-                    // New game — schedule first trigger
-                    info!(
+            let mut previous = std::mem::take(games);
+            for game in entries {
+                let Some(config) = game.auto_backup.clone() else {
+                    continue;
+                };
+                if game.storage_key.is_empty() || config.interval_secs == 0 {
+                    warn!(
                         target: "rgsm::scheduler",
-                        "Enabling auto-backup for '{}' every {}s",
-                        name,
-                        config.interval_secs
+                        "Ignoring invalid auto-backup settings for '{}'",
+                        game.name
                     );
-                    games.insert(
-                        name,
-                        ScheduledGame {
-                            game,
-                            next_trigger: now + Duration::from_secs(config.interval_secs as u64),
-                            config,
-                        },
-                    );
+                    continue;
                 }
+                // Renaming or editing a game must not postpone its next backup.
+                let next_trigger = previous
+                    .remove(&game.storage_key)
+                    .filter(|scheduled| scheduled.config.interval_secs == config.interval_secs)
+                    .map(|scheduled| scheduled.next_trigger)
+                    .unwrap_or_else(|| now + Duration::from_secs(config.interval_secs as u64));
+                games.insert(
+                    game.storage_key.clone(),
+                    ScheduledGame {
+                        game,
+                        config,
+                        next_trigger,
+                    },
+                );
             }
         }
         SchedulerCommand::GetStatus { respond_to } => {
             let status: Vec<AutoBackupGameStatus> = games
-                .iter()
-                .map(|(name, sg)| AutoBackupGameStatus {
-                    game_name: name.clone(),
+                .values()
+                .map(|sg| AutoBackupGameStatus {
+                    game_id: sg.game.storage_key.clone(),
+                    game_name: sg.game.name.clone(),
                     interval_secs: sg.config.interval_secs,
                 })
                 .collect();
@@ -176,14 +165,14 @@ fn handle_command(games: &mut HashMap<String, ScheduledGame>, cmd: SchedulerComm
 /// Trigger auto-backups for all games whose timers have fired.
 async fn trigger_due_games(app: &AppHandle, games: &mut HashMap<String, ScheduledGame>) {
     let now = Instant::now();
-    let due_names: Vec<String> = games
+    let due_ids: Vec<String> = games
         .iter()
         .filter(|(_, sg)| sg.next_trigger <= now)
-        .map(|(name, _)| name.clone())
+        .map(|(id, _)| id.clone())
         .collect();
 
-    for name in due_names {
-        if let Some(sg) = games.get_mut(&name) {
+    for id in due_ids {
+        if let Some(sg) = games.get_mut(&id) {
             perform_timer_backup(app, &sg.game, &sg.config).await;
             sg.next_trigger = Instant::now() + Duration::from_secs(sg.config.interval_secs as u64);
         }
@@ -212,7 +201,7 @@ mod tests {
         game_paths.insert("device-1".to_string(), launch_path.to_string());
         Game {
             name: name.to_string(),
-            storage_key: String::new(),
+            storage_key: name.to_string(),
             save_paths: vec![],
             game_paths,
             next_save_unit_id: 0,
@@ -224,10 +213,30 @@ mod tests {
     }
 
     #[test]
+    fn same_title_games_keep_independent_timers() {
+        let interval = auto_backup_config(30);
+        let mut first = test_game("Same", "first.exe", Some(interval.clone()));
+        first.storage_key = "first".into();
+        let mut second = test_game("Same", "second.exe", Some(interval.clone()));
+        second.storage_key = "second".into();
+        let mut games = HashMap::new();
+
+        handle_command(
+            &mut games,
+            SchedulerCommand::SyncFromConfig(vec![first, second]),
+        );
+
+        assert_eq!(games.len(), 2);
+        assert_eq!(games["first"].game.name, "Same");
+        assert_eq!(games["second"].game.name, "Same");
+    }
+
+    #[test]
     fn sync_from_config_updates_existing_game_without_resetting_deadline_when_interval_matches() {
         let interval = auto_backup_config(30);
         let original_game = test_game("GameA", "C:\\old.exe", Some(interval.clone()));
-        let updated_game = test_game("GameA", "C:\\new.exe", Some(interval.clone()));
+        let mut updated_game = test_game("GameA", "C:\\new.exe", Some(interval.clone()));
+        updated_game.name = "Renamed".into();
         let original_deadline = Instant::now() + Duration::from_secs(123);
 
         let mut games = HashMap::new();
@@ -242,15 +251,12 @@ mod tests {
 
         handle_command(
             &mut games,
-            SchedulerCommand::SyncFromConfig(vec![(
-                "GameA".to_string(),
-                updated_game.clone(),
-                interval,
-            )]),
+            SchedulerCommand::SyncFromConfig(vec![updated_game.clone()]),
         );
 
         let synced = games.get("GameA").expect("game should still be scheduled");
         assert_eq!(synced.game.game_paths, updated_game.game_paths);
+        assert_eq!(synced.game.name, "Renamed");
         assert_eq!(synced.next_trigger, original_deadline);
     }
 
@@ -277,16 +283,45 @@ mod tests {
             },
         );
 
-        handle_command(
-            &mut games,
-            SchedulerCommand::SyncFromConfig(vec![(
-                "GameA".to_string(),
-                game_a,
-                auto_backup_config(30),
-            )]),
-        );
+        handle_command(&mut games, SchedulerCommand::SyncFromConfig(vec![game_a]));
 
         assert!(games.contains_key("GameA"));
         assert!(!games.contains_key("GameB"));
+    }
+
+    #[test]
+    fn disabled_or_invalid_timers_are_not_scheduled() {
+        let enabled = test_game("GameA", "game.exe", Some(auto_backup_config(30)));
+        let mut games = HashMap::new();
+        handle_command(
+            &mut games,
+            SchedulerCommand::SyncFromConfig(vec![enabled.clone()]),
+        );
+        assert_eq!(games.len(), 1);
+        let mut disabled = enabled;
+        disabled.auto_backup = None;
+        let zero = test_game("Zero", "game.exe", Some(auto_backup_config(0)));
+        let no_id = test_game("", "game.exe", Some(auto_backup_config(30)));
+        handle_command(
+            &mut games,
+            SchedulerCommand::SyncFromConfig(vec![disabled, zero, no_id]),
+        );
+        assert!(games.is_empty());
+    }
+
+    #[test]
+    fn changed_interval_resets_the_deadline() {
+        let mut games = HashMap::new();
+        let game = test_game("GameA", "game.exe", Some(auto_backup_config(30)));
+        handle_command(
+            &mut games,
+            SchedulerCommand::SyncFromConfig(vec![game.clone()]),
+        );
+        let mut updated = game;
+        updated.auto_backup = Some(auto_backup_config(60));
+        let before = Instant::now();
+        handle_command(&mut games, SchedulerCommand::SyncFromConfig(vec![updated]));
+        assert!(games["GameA"].next_trigger >= before + Duration::from_secs(60));
+        assert!(games["GameA"].next_trigger <= Instant::now() + Duration::from_secs(60));
     }
 }

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -64,6 +64,7 @@ export type AutoBackupConfig = {
  * Status of one game's auto-backup timer, returned by `GetStatus`.
  */
 export type AutoBackupGameStatus = {
+  game_id: string;
   game_name: string;
   interval_secs: number;
 };

--- a/apps/rgsm-gui/src/components/MainSideBar.vue
+++ b/apps/rgsm-gui/src/components/MainSideBar.vue
@@ -98,7 +98,7 @@ async function refreshAutoBackup() {
   try {
     const result = await commands.getAutoBackupStatus();
     if (result.status === 'ok') {
-      autoBackupGames.value = new Set(result.data.map((row) => row.game_name));
+      autoBackupGames.value = new Set(result.data.map((row) => row.game_id));
     }
   } catch (e) {
     error(`refresh auto-backup status error: ${e}`);
@@ -109,7 +109,9 @@ onMounted(refreshAutoBackup);
 // 定时备份与进程自动化配置变化都会改变状态点;config 引用替换即触发
 watch(
   () => [
-    (config.value?.games ?? []).map((game) => `${game.name}:${game.auto_backup ? 1 : 0}`).join('|'),
+    (config.value?.games ?? [])
+      .map((game) => `${game.storage_key}:${game.auto_backup ? 1 : 0}`)
+      .join('|'),
     JSON.stringify(config.value?.quick_action?.game_automations ?? []),
   ],
   refreshAutoBackup
@@ -181,8 +183,12 @@ function navigatePage(path: string) {
           >
             <span
               class="game-dot"
-              :class="{ on: autoBackupGames.has(game.name) }"
-              :title="autoBackupGames.has(game.name) ? $t('sidebar.auto_backup_on') : undefined"
+              :class="{ on: autoBackupGames.has(game.storage_key ?? '') }"
+              :title="
+                autoBackupGames.has(game.storage_key ?? '')
+                  ? $t('sidebar.auto_backup_on')
+                  : undefined
+              "
             />
             <span class="row-text">{{ game.name }}</span>
             <span

--- a/apps/rgsm-gui/src/composables/useConfig.ts
+++ b/apps/rgsm-gui/src/composables/useConfig.ts
@@ -1,11 +1,5 @@
 import { error } from '../utils/logger';
-import {
-  commands,
-  DEFAULT_CONFIG,
-  events,
-  type Config,
-  type DeviceGameStatus,
-} from '../api/commands';
+import { commands, DEFAULT_CONFIG, type Config, type DeviceGameStatus } from '../api/commands';
 import { $t } from '../i18n';
 
 const config = ref<Config>(structuredClone(DEFAULT_CONFIG));
@@ -65,19 +59,6 @@ async function saveConfig(): Promise<boolean> {
     notifyError($t('error.set_config_failed'));
     return false;
   }
-}
-
-if (typeof window !== 'undefined') {
-  events.quickActionCompleted
-    .listen((event) => {
-      const payload = event.payload;
-      if (payload.status === 'Success' && payload.operation === 'Backup') {
-        void refreshConfig();
-      }
-    })
-    .catch((err) => {
-      error(`Failed to listen quick action events: ${err}`);
-    });
 }
 
 firstLoad = refreshConfig();


### PR DESCRIPTION
Depends on #540

Key timers and sidebar indicators by the existing game ID so same-title games are backed up independently. Renaming or editing a game preserves its deadline; changing the interval resets it, and disabling or deleting the game removes the timer.

Stop reloading the entire configuration after a quick backup. Snapshot views already refresh from the completion event; reloading unrelated settings erased unsaved edits.

Real HTTP/SSE regressions cover both games producing timer snapshots and a successful background backup leaving the settings draft untouched.
