### PR TITLE
fix(sync): tolerate incomplete metadata reads during overwrites

### DIFF
--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -4,6 +4,7 @@ use opendal::{ErrorKind, Operator};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::metadata_read::read_complete_json;
 use super::{CLOUD_ARCHIVES_PREFIX, DELETION_REGISTRY_PATH};
 use crate::device::DeviceId;
 
@@ -54,12 +55,19 @@ impl DeletionRegistryRepository {
     }
 
     pub async fn load(&self) -> Result<DeletionRegistry, DeletionRegistryError> {
-        let bytes = match self.operator.read(DELETION_REGISTRY_PATH).await {
-            Ok(bytes) => bytes.to_vec(),
-            Err(error) if error.kind() == ErrorKind::NotFound => {
-                return Ok(DeletionRegistry::default());
-            }
-            Err(error) => return Err(error.into()),
+        let bytes = read_complete_json(
+            || async {
+                match self.operator.read(DELETION_REGISTRY_PATH).await {
+                    Ok(bytes) => Ok(Some(bytes.to_vec())),
+                    Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+                    Err(error) => Err(error),
+                }
+            },
+            self.max_attempts,
+        )
+        .await?;
+        let Some(bytes) = bytes else {
+            return Ok(DeletionRegistry::default());
         };
         let registry: DeletionRegistry = serde_json::from_slice(&bytes)?;
         if registry.schema_version != DELETION_REGISTRY_SCHEMA_VERSION {
@@ -200,6 +208,38 @@ mod tests {
         let stored = repository.load().await.unwrap();
         assert_eq!(stored.deleted_profiles["deck"].deleted_by, "pc");
         assert!(operator.exists(DELETION_REGISTRY_PATH).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn deletion_registry_read_waits_for_an_in_progress_overwrite() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let operator =
+            Operator::new(services::Fs::default().root(root.path().to_string_lossy().as_ref()))
+                .unwrap()
+                .finish();
+        operator
+            .write(DELETION_REGISTRY_PATH, Vec::<u8>::new())
+            .await
+            .unwrap();
+        let writer = operator.clone();
+        let write = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let registry = DeletionRegistry {
+                revision: 7,
+                ..DeletionRegistry::default()
+            };
+            writer
+                .write(
+                    DELETION_REGISTRY_PATH,
+                    serde_json::to_vec(&registry).unwrap(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let result = DeletionRegistryRepository::new(operator, 10).load().await;
+        write.await.unwrap();
+        assert_eq!(result.unwrap().revision, 7);
     }
 
     #[tokio::test]

--- a/crates/rgsm-core/src/cloud_sync/v2/metadata_read.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/metadata_read.rs
@@ -1,0 +1,72 @@
+use std::{future::Future, time::Duration};
+
+/// Some providers expose an empty or truncated object while overwriting JSON.
+/// Retry only that incomplete-read case; repositories still decode, validate,
+/// and report the final bytes using their own error types. Missing objects and
+/// transport errors keep their original meaning.
+pub(super) async fn read_complete_json<F, Fut, E>(
+    mut read: F,
+    max_attempts: usize,
+) -> Result<Option<Vec<u8>>, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<Vec<u8>>, E>>,
+{
+    let attempts = max_attempts.max(1);
+    for attempt in 0..attempts {
+        let bytes = read().await?;
+        let incomplete = bytes.as_deref().is_some_and(|bytes| {
+            serde_json::from_slice::<serde::de::IgnoredAny>(bytes)
+                .is_err_and(|error| error.is_eof())
+        });
+        if !incomplete || attempt + 1 == attempts {
+            return Ok(bytes);
+        }
+        tokio::time::sleep(Duration::from_millis(10 << attempt.min(4))).await;
+    }
+    unreachable!("at least one read attempt")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{cell::Cell, future::ready};
+
+    #[tokio::test]
+    async fn incomplete_json_is_retried_without_replacing_the_final_error_bytes() {
+        let reads = Cell::new(0);
+        let result = read_complete_json(
+            || {
+                reads.set(reads.get() + 1);
+                ready(Ok::<_, ()>(Some(b"{\"games\":".to_vec())))
+            },
+            2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(reads.get(), 2);
+        assert_eq!(result, Some(b"{\"games\":".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn complete_missing_malformed_and_transport_results_are_not_retried() {
+        for result in [
+            Ok(Some(b"{}".to_vec())),
+            Ok(None),
+            Ok(Some(b"{broken".to_vec())),
+            Err("offline"),
+        ] {
+            let reads = Cell::new(0);
+            let actual = read_complete_json(
+                || {
+                    reads.set(reads.get() + 1);
+                    ready(result.clone())
+                },
+                3,
+            )
+            .await;
+            assert_eq!(reads.get(), 1);
+            assert_eq!(actual, result);
+        }
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -16,6 +16,7 @@ mod materialization_models;
 mod materialization_read_tests;
 #[cfg(test)]
 mod materialization_tests;
+mod metadata_read;
 mod namespace;
 mod profile_removal;
 mod profile_repository;

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use super::super::V1_CONFIG_PATH;
 #[cfg(test)]
 use super::super::V1_SAVE_DATA_PREFIX;
+use super::metadata_read::read_complete_json;
 use super::{CloudManifest, ManifestError};
 use crate::config::{Config, OwnershipError, SharedLibrary};
 use crate::device::encode_device_id;
@@ -24,6 +25,7 @@ pub const CLOUD_MANIFEST_PATH: &str = "v2/cloud-manifest.json";
 pub const CLOUD_ARCHIVES_PREFIX: &str = "v2/archives/";
 pub const DELETION_REGISTRY_PATH: &str = "v2/deletions.json";
 const CLASSIFICATION_ENTRY_SAMPLE_LIMIT: usize = 8;
+const NAMESPACE_READ_ATTEMPTS: usize = 3;
 
 pub fn device_profile_path(device_id: &str) -> String {
     format!(
@@ -98,17 +100,17 @@ impl CloudLibraryTarget {
     }
 
     pub(crate) async fn verify(&self) -> Result<Operator, CloudNamespaceError> {
-        let bytes = match self.operator.read(V2_NAMESPACE_DESCRIPTOR_PATH).await {
-            Ok(bytes) => bytes,
-            Err(error) if error.kind() == ErrorKind::NotFound => {
-                return Err(CloudNamespaceError::MissingRequiredObject(
-                    V2_NAMESPACE_DESCRIPTOR_PATH,
-                ));
-            }
-            Err(error) => return Err(error.into()),
-        };
+        let transport = OpenDalNamespaceTransport::new(self.operator.clone());
+        let bytes = read_complete_json(
+            || transport.read(V2_NAMESPACE_DESCRIPTOR_PATH),
+            NAMESPACE_READ_ATTEMPTS,
+        )
+        .await?
+        .ok_or(CloudNamespaceError::MissingRequiredObject(
+            V2_NAMESPACE_DESCRIPTOR_PATH,
+        ))?;
         let descriptor: CloudNamespaceDescriptor =
-            parse_json(V2_NAMESPACE_DESCRIPTOR_PATH, &bytes.to_vec())?;
+            parse_json(V2_NAMESPACE_DESCRIPTOR_PATH, &bytes)?;
         descriptor.validate()?;
         if descriptor.library_id != self.expected_library_id {
             return Err(CloudNamespaceError::LibraryIdentityMismatch);
@@ -201,7 +203,7 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
     /// Classify without writing, deleting, or interpreting provider errors as
     /// absence. Empty requires a successful listing of the entire root.
     pub async fn classify(&self) -> Result<CloudNamespaceClassification, CloudNamespaceError> {
-        if let Some(bytes) = self.transport.read(V2_NAMESPACE_DESCRIPTOR_PATH).await? {
+        if let Some(bytes) = self.read_object(V2_NAMESPACE_DESCRIPTOR_PATH).await? {
             return self.classify_v2(&bytes).await;
         }
 
@@ -213,7 +215,7 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
             return Err(CloudNamespaceError::PartialV2(v2_entries));
         }
 
-        if let Some(bytes) = self.transport.read(V1_CONFIG_PATH).await? {
+        if let Some(bytes) = self.read_object(V1_CONFIG_PATH).await? {
             let config = parse_json(V1_CONFIG_PATH, &bytes)?;
             return Ok(CloudNamespaceClassification::V1Only {
                 config: Box::new(config),
@@ -255,10 +257,13 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
     }
 
     async fn required_object(&self, path: &'static str) -> Result<Vec<u8>, CloudNamespaceError> {
-        self.transport
-            .read(path)
+        self.read_object(path)
             .await?
             .ok_or(CloudNamespaceError::MissingRequiredObject(path))
+    }
+
+    async fn read_object(&self, path: &str) -> Result<Option<Vec<u8>>, CloudNamespaceError> {
+        Ok(read_complete_json(|| self.transport.read(path), NAMESPACE_READ_ATTEMPTS).await?)
     }
 }
 
@@ -371,6 +376,49 @@ mod tests {
             serde_json::to_vec(&CloudManifest::default()).unwrap(),
         );
         transport
+    }
+
+    #[tokio::test]
+    async fn classification_waits_for_an_in_progress_metadata_overwrite() {
+        struct OverwritingTransport {
+            ready: FakeTransport,
+            path: &'static str,
+            reads: std::sync::atomic::AtomicUsize,
+        }
+        #[async_trait]
+        impl NamespaceTransport for OverwritingTransport {
+            async fn read(&self, path: &str) -> Result<Option<Vec<u8>>, opendal::Error> {
+                if path == self.path
+                    && self.reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0
+                {
+                    return Ok(Some(Vec::new()));
+                }
+                self.ready.read(path).await
+            }
+
+            async fn list_sample(
+                &self,
+                prefix: &str,
+                limit: usize,
+            ) -> Result<Vec<String>, opendal::Error> {
+                self.ready.list_sample(prefix, limit).await
+            }
+        }
+        for path in [
+            V2_NAMESPACE_DESCRIPTOR_PATH,
+            SHARED_LIBRARY_PATH,
+            CLOUD_MANIFEST_PATH,
+        ] {
+            let classifier = CloudNamespaceClassifier::with_transport(OverwritingTransport {
+                ready: complete_v2(),
+                path,
+                reads: Default::default(),
+            });
+            assert!(matches!(
+                classifier.classify().await.unwrap(),
+                CloudNamespaceClassification::SupportedV2 { .. }
+            ));
+        }
     }
 
     #[tokio::test]

--- a/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
@@ -2,6 +2,7 @@ use futures_util::TryStreamExt;
 use opendal::Operator;
 use thiserror::Error;
 
+use super::metadata_read::read_complete_json;
 use super::{
     DeletionRegistryError, DeletionRegistryRepository, V2_DEVICE_PROFILES_PREFIX,
     device_profile_path,
@@ -105,20 +106,18 @@ impl DeviceProfileRepository {
         &self,
         path: &str,
     ) -> Result<DeviceProfile, DeviceProfileRepositoryError> {
-        let mut last_error = None;
-        for attempt in 0..self.max_attempts {
-            let bytes = self.operator.read(path).await?;
-            match serde_json::from_slice(&bytes.to_vec()) {
-                Ok(profile) => return Ok(profile),
-                Err(error) => last_error = Some(error),
-            }
-            if attempt + 1 < self.max_attempts {
-                tokio::time::sleep(std::time::Duration::from_millis(10 << attempt.min(4))).await;
-            }
-        }
-        Err(last_error
-            .expect("at least one profile read attempt")
-            .into())
+        let bytes = read_complete_json(
+            || async {
+                self.operator
+                    .read(path)
+                    .await
+                    .map(|bytes| Some(bytes.to_vec()))
+            },
+            self.max_attempts,
+        )
+        .await?
+        .expect("a successful profile read contains bytes");
+        Ok(serde_json::from_slice(&bytes)?)
     }
 
     pub async fn delete(&self, device_id: &str) -> Result<(), DeviceProfileRepositoryError> {

--- a/crates/rgsm-core/src/cloud_sync/v2/repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/repository.rs
@@ -5,6 +5,7 @@ use opendal::{ErrorKind, Operator};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+use super::metadata_read::read_complete_json;
 use super::{CloudManifest, DeletionRegistryError, DeletionRegistryRepository, ManifestError};
 
 #[async_trait]
@@ -75,7 +76,8 @@ impl<T: ManifestTransport> CloudManifestRepository<T> {
     }
 
     pub async fn load(&self) -> Result<CloudManifest, ManifestRepositoryError> {
-        let manifest = match self.transport.read().await? {
+        let manifest = match read_complete_json(|| self.transport.read(), self.max_attempts).await?
+        {
             Some(bytes) => serde_json::from_slice(&bytes)?,
             None => CloudManifest::default(),
         };
@@ -231,6 +233,49 @@ mod tests {
         assert!(matches!(
             result,
             Err(ManifestRepositoryError::RetryExhausted { attempts: 2 })
+        ));
+    }
+
+    #[tokio::test]
+    async fn manifest_read_waits_for_an_in_progress_overwrite() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let operator = Operator::new(
+            opendal::services::Fs::default().root(root.path().to_string_lossy().as_ref()),
+        )
+        .unwrap()
+        .finish();
+        operator
+            .write("manifest.json", Vec::<u8>::new())
+            .await
+            .unwrap();
+        let writer = operator.clone();
+        let write = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let manifest = CloudManifest {
+                revision: 7,
+                ..CloudManifest::default()
+            };
+            writer
+                .write("manifest.json", serde_json::to_vec(&manifest).unwrap())
+                .await
+                .unwrap();
+        });
+
+        let result = CloudManifestRepository::new(operator, "manifest.json", 10)
+            .load()
+            .await;
+        write.await.unwrap();
+        assert_eq!(result.unwrap().revision, 7);
+    }
+
+    #[tokio::test]
+    async fn an_incomplete_manifest_is_not_treated_as_an_empty_library() {
+        let transport = FakeTransport::new(0);
+        transport.state.lock().unwrap().bytes = Some(Vec::new());
+        let repository = CloudManifestRepository::with_transport(transport, 2);
+        assert!(matches!(
+            repository.load().await,
+            Err(ManifestRepositoryError::Serialization(_))
         ));
     }
 

--- a/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/shared_library_repository.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+use super::metadata_read::read_complete_json;
 use super::{
     DeletionRegistryError, DeletionRegistryRepository, ManifestTransport, OpenDalManifestTransport,
     SHARED_LIBRARY_PATH,
@@ -39,9 +40,7 @@ impl<T: ManifestTransport> SharedLibraryRepository<T> {
     }
 
     pub async fn load(&self) -> Result<SharedLibrary, SharedLibraryRepositoryError> {
-        let bytes = self
-            .transport
-            .read()
+        let bytes = read_complete_json(|| self.transport.read(), self.max_attempts)
             .await?
             .ok_or(SharedLibraryRepositoryError::Missing)?;
         let library: SharedLibrary = serde_json::from_slice(&bytes)?;
@@ -210,6 +209,35 @@ mod tests {
                 .unwrap(),
             accepted
         );
+    }
+
+    #[tokio::test]
+    async fn shared_library_read_waits_for_an_in_progress_overwrite() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let operator = opendal::Operator::new(
+            opendal::services::Fs::default().root(root.path().to_string_lossy().as_ref()),
+        )
+        .unwrap()
+        .finish();
+        operator
+            .write(SHARED_LIBRARY_PATH, b"{\"games\":".to_vec())
+            .await
+            .unwrap();
+        let writer = operator.clone();
+        let write = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            writer
+                .write(
+                    SHARED_LIBRARY_PATH,
+                    serde_json::to_vec(&library(None)).unwrap(),
+                )
+                .await
+                .unwrap();
+        });
+
+        let result = SharedLibraryRepository::new(operator, 10).load().await;
+        write.await.unwrap();
+        assert_eq!(result.unwrap(), library(None));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Depends on #541

Cloud storage can expose empty or truncated JSON during an overwrite. Retry these incomplete reads within a small bound instead of immediately failing discovery, refresh, or publication

Manifest, shared-library, deletion-registry, profile, and namespace reads share the same policy. Missing objects, transport failures, unsupported schemas, and persistent corruption retain their existing errors and semantics; incomplete metadata is never replaced with an empty library

This does not require atomic provider writes or add transactions, rollback state, or automatic recovery writes
