### PR TITLE
fix(sync): allow removed devices to reconnect after confirmation

### DIFF
--- a/apps/rgsm-gui/e2e/cloud-remove-device.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-remove-device.spec.ts
@@ -1,25 +1,32 @@
 import { test, expect } from '@playwright/test';
 import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { DEVICE_A_ID, DEVICE_B_ID } from './support/constants';
 import {
   cloudArchivePath,
   cloudPaths,
   expectDeviceHasNoHead,
   expectDeviceProfiles,
+  localArchivePath,
   readJson,
 } from './support/cloud-assertions';
-import { seedEmptyCloudWithLocalGame } from './support/cloud-fixture';
+import { seedEmptyCloudWithLocalGame, readSave } from './support/cloud-fixture';
 import {
   connectLibrary,
   createLibrary,
   createPublishedSnapshot,
   enableMode,
+  downloadSnapshot,
+  openGame,
+  reconnectCloudLibrary,
   removeLibraryDevice,
 } from './support/gui';
 import { createRunRoot } from './support/rgsm-instance';
 import { startDualSession } from './support/session';
 
-test('remove other device from library', async ({ browser }) => {
+test('a removed device reconnects only after confirmation and keeps existing backups', async ({
+  browser,
+}) => {
   const runRoot = await createRunRoot('remove-device');
   const seeded = await seedEmptyCloudWithLocalGame(runRoot);
   const session = await startDualSession(browser, { ...seeded, runRoot, label: 'remove-device' });
@@ -31,11 +38,26 @@ test('remove other device from library', async ({ browser }) => {
     await connectLibrary(session.pageB);
     await enableMode(session.pageB, session.hostB, 'Cloud Backup', 'Keep in cloud');
     await expectDeviceProfiles(seeded.cloudRoot, [DEVICE_A_ID, DEVICE_B_ID]);
+    await openGame(session.pageB);
+    await downloadSnapshot(session.pageB, snapshotId);
+    const archive = await readFile(cloudArchivePath(seeded.cloudRoot, snapshotId));
+    const liveSaves = [await readSave(seeded.deviceA), await readSave(seeded.deviceB)];
 
     await removeLibraryDevice(session.pageA, 'E2E Device B');
     await expectDeviceProfiles(seeded.cloudRoot, [DEVICE_A_ID]);
     expect(existsSync(cloudArchivePath(seeded.cloudRoot, snapshotId))).toBe(true);
     expectDeviceHasNoHead(await readJson(cloudPaths(seeded.cloudRoot).manifest), DEVICE_B_ID);
+
+    await reconnectCloudLibrary(session.pageB);
+    await expectDeviceProfiles(seeded.cloudRoot, [DEVICE_A_ID, DEVICE_B_ID]);
+    expect(await readFile(cloudArchivePath(seeded.cloudRoot, snapshotId))).toEqual(archive);
+    expect(await readFile(localArchivePath(seeded.deviceA.appDataDir, snapshotId))).toEqual(
+      archive
+    );
+    expect(await readFile(localArchivePath(seeded.deviceB.appDataDir, snapshotId))).toEqual(
+      archive
+    );
+    expect([await readSave(seeded.deviceA), await readSave(seeded.deviceB)]).toEqual(liveSaves);
   } catch (error) {
     failed = true;
     throw error;

--- a/apps/rgsm-gui/e2e/support/gui.ts
+++ b/apps/rgsm-gui/e2e/support/gui.ts
@@ -487,7 +487,7 @@ export async function removeLibraryDevice(page: Page, deviceName: string): Promi
   // Only non-current, non-removed devices offer the action, so it is unique.
   await section.getByRole('button', { name: 'Remove device' }).click();
   await page.getByRole('dialog').getByRole('button', { name: 'Remove device' }).click();
-  await expectActivity(page, /Device Profile removed/);
+  await expectActivity(page, 'Device removed');
 }
 
 export async function rebuildCloudLibrary(page: Page): Promise<void> {

--- a/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/deletion_registry.rs
@@ -148,6 +148,17 @@ impl DeletionRegistryRepository {
         .await
     }
 
+    pub(super) async fn reactivate_profile(
+        &self,
+        device_id: &str,
+    ) -> Result<(), DeletionRegistryError> {
+        self.mutate(|registry| {
+            registry.deleted_profiles.remove(device_id);
+        })
+        .await?;
+        Ok(())
+    }
+
     async fn mutate(
         &self,
         mut change: impl FnMut(&mut DeletionRegistry),
@@ -178,7 +189,7 @@ pub enum DeletionRegistryError {
     UnsupportedSchema(u32),
     #[error("Deletion registry update was not visible after {attempts} attempts")]
     RetryExhausted { attempts: usize },
-    #[error("Device Profile has been permanently removed: {0}")]
+    #[error("Device {0} was removed; confirm reconnection on that device to continue")]
     ProfileDeleted(DeviceId),
     #[error("Shared Game has been permanently deleted: {0}")]
     GameDeleted(String),

--- a/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/profile_repository.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use super::metadata_read::read_complete_json;
 use super::{
-    DeletionRegistryError, DeletionRegistryRepository, V2_DEVICE_PROFILES_PREFIX,
+    DeletionRegistry, DeletionRegistryError, DeletionRegistryRepository, V2_DEVICE_PROFILES_PREFIX,
     device_profile_path,
 };
 use crate::config::{DeviceProfile, V2_CONFIG_SCHEMA_VERSION};
@@ -35,18 +35,33 @@ impl DeviceProfileRepository {
         let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts)
             .load()
             .await?;
+        Self::validate_profile(acting_device_id, profile, &registry)?;
         if registry.deleted_profiles.contains_key(acting_device_id) {
             return Err(DeviceProfileRepositoryError::Deleted(
                 acting_device_id.to_string(),
             ));
         }
-        if let Some(game_id) = profile
-            .games
-            .keys()
-            .find(|game_id| registry.deleted_games.contains_key(*game_id))
-        {
-            return Err(DeviceProfileRepositoryError::DeletedGame(game_id.clone()));
-        }
+        self.write_profile(acting_device_id, profile).await
+    }
+
+    /// Explicitly re-register this Device after the player confirms reconnecting.
+    /// Ordinary publication never clears a removal marker.
+    pub async fn reconnect(
+        &self,
+        acting_device_id: &str,
+        profile: &DeviceProfile,
+    ) -> Result<(), DeviceProfileRepositoryError> {
+        let registry = DeletionRegistryRepository::new(self.operator.clone(), self.max_attempts);
+        Self::validate_profile(acting_device_id, profile, &registry.load().await?)?;
+        registry.reactivate_profile(acting_device_id).await?;
+        self.publish(acting_device_id, profile).await
+    }
+
+    fn validate_profile(
+        acting_device_id: &str,
+        profile: &DeviceProfile,
+        registry: &DeletionRegistry,
+    ) -> Result<(), DeviceProfileRepositoryError> {
         if profile.schema_version != V2_CONFIG_SCHEMA_VERSION {
             return Err(DeviceProfileRepositoryError::UnsupportedSchema(
                 profile.schema_version,
@@ -58,6 +73,21 @@ impl DeviceProfileRepository {
                 profile: profile.device.id.clone(),
             });
         }
+        if let Some(game_id) = profile
+            .games
+            .keys()
+            .find(|game_id| registry.deleted_games.contains_key(*game_id))
+        {
+            return Err(DeviceProfileRepositoryError::DeletedGame(game_id.clone()));
+        }
+        Ok(())
+    }
+
+    async fn write_profile(
+        &self,
+        acting_device_id: &str,
+        profile: &DeviceProfile,
+    ) -> Result<(), DeviceProfileRepositoryError> {
         let path = device_profile_path(acting_device_id);
         let expected = serde_json::to_vec_pretty(profile)?;
         for _ in 0..self.max_attempts {
@@ -168,7 +198,7 @@ pub enum DeviceProfileRepositoryError {
     UnsupportedSchema(u32),
     #[error("Device {acting} cannot publish Device Profile {profile}")]
     WrongDevice { acting: String, profile: String },
-    #[error("Device Profile {0} has been permanently removed")]
+    #[error("Device {0} was removed; confirm reconnection on that device to continue")]
     Deleted(DeviceId),
     #[error("Game {0} has been permanently deleted")]
     DeletedGame(String),
@@ -243,6 +273,51 @@ mod tests {
         assert_eq!(
             repository.list().await.unwrap()[0].device.name,
             "Steam Deck"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconnect_validates_before_clearing_removal_and_normal_publish_stays_blocked() {
+        let operator = Operator::new(services::Memory::default()).unwrap().finish();
+        let registry = DeletionRegistryRepository::new(operator.clone(), 3);
+        registry.mark_profile_deleted("deck", "pc").await.unwrap();
+        registry
+            .mark_game_deleted("deleted-game", "Deleted", "pc")
+            .await
+            .unwrap();
+        let before = registry.load().await.unwrap();
+        let repository = DeviceProfileRepository::new(operator.clone(), 3);
+        assert!(matches!(
+            repository.publish("deck", &profile()).await,
+            Err(DeviceProfileRepositoryError::Deleted(_))
+        ));
+
+        let mut wrong_device = profile();
+        wrong_device.device.id = "pc".into();
+        let mut wrong_schema = profile();
+        wrong_schema.schema_version += 1;
+        let mut deleted_game = profile();
+        deleted_game.games.insert(
+            "deleted-game".into(),
+            serde_json::from_value(serde_json::json!({
+                "visible": true, "sync_mode": crate::config::SyncMode::Manual,
+            }))
+            .unwrap(),
+        );
+        for invalid in [wrong_device, wrong_schema, deleted_game] {
+            assert!(repository.reconnect("deck", &invalid).await.is_err());
+            assert_eq!(registry.load().await.unwrap(), before);
+            assert!(!operator.exists(&device_profile_path("deck")).await.unwrap());
+        }
+        repository.reconnect("deck", &profile()).await.unwrap();
+        assert!(operator.exists(&device_profile_path("deck")).await.unwrap());
+        assert!(
+            !registry
+                .load()
+                .await
+                .unwrap()
+                .deleted_profiles
+                .contains_key("deck")
         );
     }
 

--- a/crates/rgsm-core/src/services/cloud_connection_tests.rs
+++ b/crates/rgsm-core/src/services/cloud_connection_tests.rs
@@ -88,6 +88,83 @@ fn runtime() -> tokio::runtime::Runtime {
 }
 
 #[test]
+fn removed_profile_requires_reconnect_even_when_its_stale_file_is_present() {
+    let _lock = crate::config::lock_config_test_file();
+    runtime().block_on(async {
+        let fixture = Fixture::new().await;
+        fixture.service.connect_cloud_library().await.unwrap();
+        let (_, _, state) = cloud_bootstrap_inputs().unwrap();
+        DeletionRegistryRepository::new(fixture.operator.clone(), 3)
+            .mark_profile_deleted(&state.current_device_id, "other-device")
+            .await
+            .unwrap();
+        assert!(fixture.profile_path().is_file());
+        assert!(matches!(
+            fixture.service.inspect_cloud_library().await.unwrap(),
+            CloudLibraryStatus::ReconnectRequired { .. }
+        ));
+        fixture.assert_local_protected();
+    });
+}
+
+#[test]
+fn confirmed_reconnect_reactivates_only_this_device_and_preserves_local_games() {
+    let _lock = crate::config::lock_config_test_file();
+    runtime().block_on(async {
+        let fixture = Fixture::new().await;
+        fixture.service.connect_cloud_library().await.unwrap();
+        let (_, _, state) = cloud_bootstrap_inputs().unwrap();
+        let registry = DeletionRegistryRepository::new(fixture.operator.clone(), 3);
+        registry
+            .mark_profile_deleted(&state.current_device_id, "other-device")
+            .await
+            .unwrap();
+        registry
+            .mark_profile_deleted("offline-device", "other-device")
+            .await
+            .unwrap();
+        registry
+            .mark_game_deleted("deleted-game", "Deleted", "other-device")
+            .await
+            .unwrap();
+        let before = registry.load().await.unwrap();
+        let other_path = device_profile_path("other-device");
+        let other_bytes = fixture.operator.read(&other_path).await.unwrap().to_vec();
+
+        assert!(matches!(
+            fixture.service.reconnect_cloud_library(false).await,
+            Err(CloudLibraryServiceError::ConfirmationRequired)
+        ));
+        assert_eq!(registry.load().await.unwrap(), before);
+
+        assert!(matches!(
+            fixture.service.reconnect_cloud_library(true).await.unwrap(),
+            CloudLibraryStatus::Active { .. }
+        ));
+        let after = registry.load().await.unwrap();
+        assert!(
+            !after
+                .deleted_profiles
+                .contains_key(&state.current_device_id)
+        );
+        assert_eq!(
+            after.deleted_profiles["offline-device"],
+            before.deleted_profiles["offline-device"]
+        );
+        assert_eq!(after.deleted_games, before.deleted_games);
+        assert_eq!(
+            fixture.operator.read(&other_path).await.unwrap().to_vec(),
+            other_bytes
+        );
+        fixture.assert_local_protected();
+        let profile: crate::config::DeviceProfile =
+            serde_json::from_slice(&std::fs::read(fixture.profile_path()).unwrap()).unwrap();
+        assert!(!profile.games.contains_key("pending"));
+        assert!(profile.games.contains_key("ready"));
+    });
+}
+
+#[test]
 fn failed_initial_profile_publication_can_retry_connection() {
     let _lock = crate::config::lock_config_test_file();
     runtime().block_on(async {

--- a/crates/rgsm-core/src/services/sync.rs
+++ b/crates/rgsm-core/src/services/sync.rs
@@ -117,7 +117,7 @@ pub enum CloudLibraryServiceError {
     CurrentPositionBlocksDeletion(String),
     #[error("The active V2 Cloud Library no longer matches the saved connection")]
     ActiveLibraryUnavailable,
-    #[error("This device must reconnect to the rebuilt Cloud Library")]
+    #[error("This device must reconnect to the Cloud Library")]
     DeviceReconnectRequired,
     #[error("This installation does not need to join a Cloud Library")]
     JoinNotRequired,
@@ -279,6 +279,14 @@ impl ServiceContext {
                 {
                     if local_state.cloud_library_id.as_deref()
                         != Some(descriptor.library_id.as_str())
+                        || crate::cloud_sync::v2::DeletionRegistryRepository::new(
+                            operator.clone(),
+                            3,
+                        )
+                        .load()
+                        .await?
+                        .deleted_profiles
+                        .contains_key(&local_state.current_device_id)
                     {
                         return Ok(CloudLibraryStatus::ReconnectRequired {
                             game_count: shared_library.games.len(),
@@ -373,7 +381,7 @@ impl ServiceContext {
             &shared_library,
         )?;
         DeviceProfileRepository::new(operator, 3)
-            .publish(&local_state.current_device_id, &published)
+            .reconnect(&local_state.current_device_id, &published)
             .await?;
         crate::config::connect_cloud_library_local(
             &expected_library,

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -826,9 +826,9 @@
                 "incomplete": "Removal incomplete",
                 "remove_action": "Remove device",
                 "retry": "Retry cleanup",
-                "remove_title": "Permanently remove Device Profile?",
-                "remove_confirm": "Remove “{device}” from this cloud library? Its Device Profile and all of its progress pointers will be removed, and an offline stale copy cannot publish this Device ID again. Shared Snapshots and local or cloud Archive files are not deleted.",
-                "remove_success": "Device Profile removed; {count} progress pointer(s) cleared",
+                "remove_title": "Remove device from this cloud library?",
+                "remove_confirm": "Remove “{device}” and its progress positions from this cloud library? Local backups and cloud snapshots stay. Continuing sync requires confirmation on that device",
+                "remove_success": "Device removed",
                 "remove_incomplete": "Device removal is incomplete; retry remains available",
                 "load_failed": "Could not load cloud Devices"
             },
@@ -1048,10 +1048,10 @@
             "rebuild_failed": "Could not rebuild the Cloud Library",
             "rebuild_confirm": "This replaces the damaged Cloud Library with this device's games and re-uploads its available snapshots. Other devices will need to reconnect. Enter yes to confirm.",
             "reconnect": "Reconnect this device",
-            "reconnect_description": "The Cloud Library was rebuilt by another device. Reconnect this device to continue syncing.",
+            "reconnect_description": "This device needs to reconnect to the cloud library before continuing sync",
             "reconnect_success": "This device reconnected",
             "reconnect_failed": "Could not reconnect this device",
-            "reconnect_confirm": "Use the current Cloud Library on this device. Local snapshot files are kept and nothing in the cloud is deleted."
+            "reconnect_confirm": "Reconnect this device to the current cloud library? Local games and backups stay, and no cloud content or game saves are deleted"
         },
         "operations": {
             "tab": "Operations",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -826,9 +826,9 @@
                 "incomplete": "移除未完成",
                 "remove_action": "移除设备",
                 "retry": "重试清理",
-                "remove_title": "永久移除此设备 Profile 吗？",
-                "remove_confirm": "要从此云端资料库移除“{device}”吗？该设备的 Profile 和全部进度指针都会被移除，离线的陈旧副本也无法再次发布同一设备 ID。共享快照以及本地或云端存档文件不会被删除。",
-                "remove_success": "设备 Profile 已移除，并清除 {count} 个进度指针",
+                "remove_title": "从云端移除此设备？",
+                "remove_confirm": "从云端移除“{device}”及其进度位置？本地备份和云端快照都会保留，继续同步需要在该设备上确认重新连接",
+                "remove_success": "设备已移除",
                 "remove_incomplete": "设备移除尚未完成，仍可直接重试",
                 "load_failed": "无法读取云端设备"
             },
@@ -1048,10 +1048,10 @@
             "rebuild_failed": "无法重建云端资料库",
             "rebuild_confirm": "这会用此设备的游戏替换损坏的云端资料库，并重新上传此设备现有的存档快照。其他设备之后需要重新连接。输入 yes 确认。",
             "reconnect": "重新连接此设备",
-            "reconnect_description": "云端资料库已由另一台设备重建。重新连接此设备后即可继续同步。",
+            "reconnect_description": "此设备需要重新连接云端资料库后才能继续同步",
             "reconnect_success": "此设备已重新连接",
             "reconnect_failed": "无法重新连接此设备",
-            "reconnect_confirm": "在此设备上使用当前云端资料库。本地存档快照会保留，云端内容不会被删除。"
+            "reconnect_confirm": "将此设备重新连接到当前云端资料库？本地游戏与备份会保留，不会删除云端内容或游戏存档"
         },
         "operations": {
             "tab": "操作",


### PR DESCRIPTION
Depends on #542

A removed device can reconnect after confirmation on that device. Ordinary background publication still cannot clear its removal marker, and a stale profile file no longer hides the reconnect action

Validate the device identity, profile schema, and deleted-game references before reactivation. Only this device's marker is cleared; other removals, local-only games, existing backups, cloud archives, and live saves remain unchanged

Device removal and reconnect prompts now describe this reversible boundary without exposing profile terminology
