### PR TITLE
docs(sync): align release contracts and regression coverage

### DIFF
--- a/apps/rgsm-gui/e2e/README.md
+++ b/apps/rgsm-gui/e2e/README.md
@@ -33,215 +33,34 @@ CI 自动输出这些阶段耗时。Linux 全量套件分到两个独立 runner�
 
 需要复现某个 CI 分片时可用 `pnpm web:e2e --shard=1/2`。调整超时、增加重试或在本机同时运行多套 E2E 不是默认加速手段；推送前仍须运行改动涉及的场景，发布前运行完整套件。
 
-## 云端同步端到端测试
-
-覆盖旧版云配置/存档升级到新版，以及设备各自与云交互。
-
-### V1 to V2 cutover interrupts, resumes, and stays idempotent
-
-云端已有一份旧版配置和两份存档。升级迁完第一份存档后被打断。
-
-- 云端那份旧配置和两份存档字节不变
-- 重启后能接着升完
-- 再重启不会多出配置或存档
-
-### two V1 devices cut over, join, and keep V2 device boundaries
-
-1. A、B 本地都是旧版配置，共用云端同一份旧配置和两份存档。A 往云上传存档，B 从云下载同一份
-2. A 的本地配置升到新版，B 的本地配置仍是旧版，B 被提示加入
-3. B 在加入里选 Keep the cloud version；A、B 本地配置都变成新版
-4. 这款游戏在 A、B 上都是 Cloud Backup。A 在存档列表点 Upload to cloud；B 点 Download to this device 后，B 本机多出这份文件，游戏目录还没变；B 再点 Apply，游戏文件才变成这份
-5. A 把这款游戏改成 Manual，B 仍是 Cloud Backup
-6. A、B 都改成 Multi-device Sync。两边先停在云上同一份，再各自新建并上传，两边都还没吃到对方那份。A 点 Progress diverged, compare，再点 Use this progress：A 的游戏文件变成 B 那份，只有 A 的当前指针移动，B 的指针不变
-7. A 删掉当前这份存档：A 的当前指针回到上一份，游戏文件不变；云上这份被标记删除，B 不能再把它拉回本地
-8. A、B 重启后，两边的同步模式、当前指针、本机和云上的存档文件，都与重启前一致
-
-### empty cloud creates library then first snapshot uploads
-
-云端文件夹是空的。A 本地已有一款游戏和一份本机存档。
-
-- 点 Create library，再点 Create and switch
-- A 的本地配置变成新版，云端出现新版配置，还没有存档
-- A 在存档列表点 Upload to cloud：云上多出这一份，字节与本机一致
-- B 本地是旧版配置、没有这款游戏。B 点 Join library 后，能在存档列表点 Download to this device 拿到这一份
-
-### per-game upload download disable re-enable
-
-A、B 都已在新版资料库里管理同一款游戏，两边都是 Cloud Backup，云上已有一份双方都有的存档。
-
-- A 新建一份本机存档，在存档列表点 Upload to cloud：云上多出这一份，B 本地还没有
-- B 点 Download to this device：B 本地出现相同字节，游戏文件不变，云上这份还在
-- A 关掉这款游戏的 Cloud sync 开关：A 的本地配置里这款游戏不再上传，模式仍是 Cloud Backup；B 仍是 Cloud Backup 且开着；云上已有存档还在
-- A 此时再新建本机存档：云上不会多出这一份
-- A 重新打开 Cloud sync：之后新建的本机存档可以再上传
-
-### sync modes and enable catch-up
-
-A、B 都已在新版资料库里管理同一款游戏，云上已有若干存档。
-
-- A 在概览 Sync mode 里改成 Manual：新本机存档不会自动出现在云上，要手点 Upload to cloud；不会自动 Apply
-- A 改成 Cloud Backup，打开对话框里选 Keep in cloud，再点 Enable：之后新本机存档会自动出现在云上；打开时不会把云上已有存档拉到本机；不会自动 Apply
-- B 改成 Cloud Backup，打开对话框里选 Download to this device，再点 Enable：云上已有存档出现在 B 本机，游戏文件不变
-- B 再改成 Multi-device Sync：当云上只有一份可前进的存档时，B 会自动下载并 Apply 到游戏文件
-
-### evict local or cloud copy without deleting snapshot
-
-云上和 A 本地都有同一份存档。
-
-- A 在存档列表点 Remove local copy：本机文件没了，云上这份还在，存档记录还在
-- A 再点 Download to this device：本机文件回来，字节与云上一致
-- A 点 Remove cloud copy：云上文件没了，A 本机这份还在，存档记录还在
-- B 不能再 Download to this device
-- A 再点 Upload to cloud：云上文件回来
-
-### keep local instead of taking the other device save
-
-A、B 都已在新版资料库，这款游戏两边都是 Multi-device Sync。两边先停在云上同一份，再各自新建并上传。
-
-- 概览上出现 Progress diverged, compare，不能自动套用任何一边
-- A 在比较里选 Keep this device：云上仍有 A、B 各一份；A 本地游戏文件仍是 A 自己的；B 当前指向的仍是 B 那份
-
-### download all missing cloud copies
-
-A 本机缺若干云上已有的存档。
-
-- A 在共享存档历史点 Download all to this device：缺的那些出现在 A 本机，已有的不重复，游戏文件不变
-- 中途打断后再点 Resume download：能从停下的地方拉完
-
-### permanently delete shared game
-
-A、B 都已在新版资料库里管理同一款游戏，云上有这款游戏的存档。
-
-- A 在概览这款游戏旁点 Permanently delete shared game：云上这款游戏的配置和存档都没了，A 本地这款游戏也不再被管理
-- B 下次检查云端后，不能再把这款游戏或那些存档拉回来
-
-### remove other device from library
-
-A、B 都在同一份新版资料库里。设置页的 Library devices 列出两台设备。
-
-- A 对 B 点 Remove device：B 从 Library devices 消失；双方已经上传的存档还在
-
-### protect automatic snapshot and set retention
-
-A 已在新版资料库，这款游戏有若干自动存档。
-
-- A 在某一份自动存档上点 Keep：这份带上保护，不会被自动清理算进去
-- A 在自动存档设置里打开 Shared retention limit，填一个较小的数并保存：超出的未保护自动存档从云和本机消失，被 Keep 的那份和当前指针还在
-
-### repeated upload download round trips stay consistent
-
-A、B 都已在新版资料库，这款游戏两边都是 Multi-device Sync。连续三轮：
-
-- A 改存档、新建并上传；B 下载这份并 Apply，B 的游戏文件变成 A 的内容
-- B 改存档、新建并上传；A 下载这份并 Apply，A 的游戏文件变成 B 的内容
-- 每轮结束后：云上和两台本机都留有每一轮的存档文件，两边游戏文件一致，两边的当前指针各自指向自己最后上传的那份
-
-### broken library reset and recreate
-
-A 已在新版资料库，本地还有这款游戏。云端新版配置被删掉，只剩残缺对象。
-
-- A 检查后不能当正常资料库用
-- A 点 Reset and recreate 并输入 yes：云端按 A 当前游戏列表重建一份新资料库，残缺对象没了
-
-## 杂项测试
-
-### A/B Hosts isolate device id, token, port, and browser traffic
-
-同时开两套本机：
-
-- 设备 ID 不同
-- 本机配置目录不同
-- A 的本机配置里没有 B 的设备配置
-- 用 B 的 API token 访问 A 的本机接口会被拒绝
-- A 的界面只读写 A 这份本机配置，B 同理
-
-## 本地操作端到端测试
-
-云端关闭的单机环境，覆盖不依赖云的玩家路径。
-
-### main path: create, apply latest, apply old snapshot, confirmations, delete
-
-- 新建两份存档（第二份带描述），游戏文件与当前指针跟随
-- 取消 Apply latest 的确认框：什么都不变；确认后游戏文件变成最新存档
-- 应用一份旧存档：游戏文件回到旧内容，当前指针指向旧存档
-- 删除一份存档：记录和压缩包一起消失，当前指针按规则回退
-
-### snapshot tree: branch on apply-then-create, set head, delete head fallbacks
-
-- 应用旧存档后再新建：新存档挂在旧存档下，形成分支，分支视图可见
-- 删除分支头：当前指针回退到最近的存活祖先；子节点重新挂到存活祖先
-
-### save units: disable skips backup and restore; delete-before-overwrite clears extras
-
-- 停用某个存档单元后：新建存档不包含它，应用也不碰它的文件
-- 单元目录里多出的无关文件：不开"覆盖前删除"时保留，打开后被清掉
-
-### edit save path: apply follows the current path, invalid path fails then fix works
-
-- 在"View managed files"里把存档路径改到新位置：Apply 落到新路径，不回到旧绝对路径
-- 路径无效（父级是个文件）：报 Recovery failed，当前指针不动；改好后同一份存档能正常应用
-
-### apply preserves file and nested directory mtimes
-
-- 应用存档后：文件和嵌套目录的修改时间与备份时一致（秒级）
-
-### restore permissions matrix (POSIX chmod, Windows hidden/read-only)
-
-- POSIX（CI Linux）：恢复目录/文件的权限位按预期落地
-- Windows：覆盖隐藏文件两种模式都成功；覆盖只读文件在不开"覆盖前删除"时失败且内容不动，打开后成功
-
-### extra backups: created on apply, undo restores content and head, retention trims
-
-- 带着未保存进度应用旧存档：先自动留一份额外备份
-- 点 Undo last apply：被覆盖的进度恢复，当前指针回到应用前
-- 在 Extra backups 抽屉里 Apply 一份额外备份：只改游戏文件，不动当前指针、不新建存档
-- max_extra_backup_count=2 时连续应用：只留最新两份额外备份
-- 关掉 Extra backup before apply：应用不再留额外备份，Undo 按钮禁用并带提示
-
-### extra backups: deleting one from the drawer
-
-- 抽屉里点 Delete，确认后额外备份精确减一
-
-### batch delete removes selected snapshots and rewires the tree
-
-- 勾选链中间两份存档批删（输入 yes 确认）：幸存者重挂到最近存活祖先，压缩包删除，当前指针不动
-- 勾选当前指针所在存档及其父级批删：指针回退到最近存活祖先
-
-### compression presets all capture and restore correctly
-
-- Store/Fast/Standard/Best 四档逐一：建出来是 7z，应用后内容与备份时一致，文件修改时间保留
-
-### legacy zip backup from an old version restores and joins the tree
-
-- 旧版应用留下的扁平 zip 存档（无注释、根目录平铺、legacy head 字段）：列表里可见可应用，内容恢复，当前指针指向它
-- 在它之后新建存档：新存档挂到这份旧存档下
-
-### favorites: star persists to device config, survives reload, unstar removes
-
-- 在游戏行点星收藏：写入本机设备私有配置（private_favorites），刷新页面后收藏树仍在
-- 取消收藏：配置与界面同步移除
-
-### backup all and apply all operate on every game
-
-- Settings → Backup settings → Backup all saves（输入 yes 确认）：每款游戏都新建一份存档
-- Apply all saves（输入 yes 确认）：每款游戏的文件都回到各自最新存档内容
-
-### failure surface: missing archive, corrupted archive, missing save on create
-
-- 归档文件从磁盘删掉后 Apply：Recovery failed，游戏文件不动，当前指针不动
-- 归档被篡改（开启完整性校验）后 Apply：弹 Archive Corrupted，游戏文件不动，当前指针不动
-- 存档文件丢失时新建存档：Backup failed，不留下新存档；补回文件后可正常新建
-
-### ludusavi import: search manifest, customize paths, game joins the library
-
-- Add game → Detect local games → 关掉 Show only locally installed games → 搜索并勾选 Stardew Valley → Import → Customize 对话框里 Select all 后 Confirm
-- 游戏出现在游戏列表，存档路径按清单落地
-
-## 未覆盖
-
-- 两台设备同时改云上同一份清单
-- S3、WebDAV
-- 自动存档定时器自己触发清理（本地自动 retention 只有桌面定时器入口，web 宿主无此玩家路径）
-- 换云端位置时带走未完成的升级进度
-- Stop managing here、隐藏游戏（界面没有入口）
-- Windows 注册表存档单元的备份/恢复（平台限定且有副作用）
+## 功能与迁移覆盖
+
+这些场景使用真实 Rust HTTP API、SSE、临时存档文件和 Fs 云目录，不替换业务接口为 mock。具体断言以同目录的测试文件为准，UI 不应自动下载或应用远端进度
+
+| 发布边界           | 主要场景                                                                                                   | 验证内容                                                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| 1.7/1.8 → 1.9      | `local-released-upgrade`、`local-v1-8-upgrade`                                                             | 启动后不手工修配置；保留 Save Unit 类型、ID、旧分支位置和收藏；旧 ZIP 恢复、新建、重启后再恢复；旧归档字节不变                    |
+| 覆盖方式与恢复失败 | `local-save-units`、`local-path-relocation`、`local-failure-surface`、`local-restore-permissions`          | 直接覆盖保留额外文件；删除后覆盖移除额外文件；禁用单元不参与；缺失、损坏或不可写目标报错                                          |
+| 本地备份与自动化   | `local-main-path`、`local-extra-backup`、`local-auto-backup`、`local-compression`                          | 新建、恢复、额外备份、撤销、清理和压缩；同名游戏定时器独立运行；后台备份不重置设置草稿                                            |
+| 游戏与快照身份     | `local-game-identity`、`local-favorites`、`local-ludusavi-import`、`cloud-snapshot-choice`                 | 同名游戏不会串路径、收藏或快捷操作；迟到的路径检查不覆盖导入选择；快照 ID 与时间、创建来源分离                                    |
+| 旧云端迁移         | `cloud-library-cutover`、`cloud-library-two-v1-devices`                                                    | 旧对象字节保留；中断后继续；重复连接不重复迁移；设备设置与进度各自独立                                                            |
+| 发现与定义选择     | `cloud-library-late-game`、`cloud-local-games`、`cloud-definition-choices`                                 | 自动显示云端游戏；本地独有游戏离线仍可用；同 ID 定义不同时由玩家选择，刷新不代替选择                                              |
+| 元数据刷新         | `cloud-catalog-read`、`cloud-refresh`                                                                      | 读取不迁移或传输归档；并发刷新共用请求；旧连接响应不写入新状态；前后台刷新不覆盖编辑草稿                                          |
+| 玩家确认同步       | `cloud-sync-modes`、`cloud-per-game-sync`、`cloud-progress-prompts`、`cloud-keep-local`、`cloud-ping-pong` | Manual 只发布记录，Cloud Backup 增加上传，Multi-device Sync 增加提示；Later 去重；下载不改游戏存档，Apply 必须由玩家选择          |
+| 副本与全端删除     | `cloud-evict-copies`、`cloud-library-two-v1-devices`、`cloud-deleted-ancestor`、`local-delete-recovery`    | 删除本地/云端副本保留历史；最后副本明确警告；后续自动上传不恢复主动删除的云端副本；全端删除收敛且不动游戏存档；已删祖先不阻断后代 |
+| 设备移除与重连     | `cloud-remove-device`、`cloud-reset-library`                                                               | 普通后台写入不能重新注册被移除的设备；用户确认后重连；其他移除标记、已有归档和游戏存档不变                                        |
+| 保留策略与批量传输 | `cloud-protect-retention`、`cloud-download-all`、`local-batch-delete`                                      | 手动、当前进度和受保护快照不误清理；下载全部是明确操作；批删位置回退                                                              |
+| 宿主边界           | `host-isolation`、`harness-lifecycle`、`desktop-window-lifecycle`                                          | HTTP token 与设备数据隔离；只清理测试拥有的进程；桌面专用场景验证销毁/重建、单实例唤醒、有效 API runtime 和退出设置               |
+
+Rust 侧的 `config_upgrade_compatibility` 和 `cloud_sync_v2_fs` 集成测试补充历史格式与文件传输验证；核心单元测试覆盖解析器、缺失/多目标恢复边界、元数据短暂不完整读取以及设备重连校验
+
+## 发布前检查与证据边界
+
+先完成相关场景，再在同一个最终提交上跑完整 browser 套件及工作区检查。GitHub 四类门禁为 Backend Tests、Style & Lint、GUI Cloud Fs E2E（两分片汇总）和 Windows Release E2E。绿灯只证明实际执行的场景，不代表以下边界已验证
+
+- 兼容目标为正式 1.7/1.8 升级到 1.9；1.7 目前依据历史源码结构制作 fixture，没有已确认的发布包。V2 ZIP 已用于 1.8，不能当作仅有 1.9 测试版需要兼容
+- 不默认覆盖所有历史 1.9 中间配置或直接降级回 1.8；也不承诺跨文件和云端的原子事务或自动回滚
+- Fs 覆盖不能替代真实 S3/WebDAV 账号和网络条件验证；短暂 JSON 覆写回归不等于任意多写者一致性保证
+- HTTP-only 测试不验证系统通知实际送达、托盘、全局快捷键或 WebView 行为；桌面专用场景应单独执行，不能靠 browser 绿灯替代
+- Windows 注册表存档单元的真实备份/恢复仍未在 E2E 中执行，以免修改测试机注册表
+- Stop managing、隐藏游戏以及更换云端位置时迁移未完成记录的完整交互，尚无专门 E2E

--- a/docs/adr/0003-require-atomic-snapshot-capture.md
+++ b/docs/adr/0003-require-atomic-snapshot-capture.md
@@ -1,10 +1,12 @@
-# Require atomic snapshot capture
+# Preflight snapshot capture without a transaction guarantee
 
 Status: accepted
 
 Snapshot creation preflights every enabled Save Unit and is rejected before
 archive output when resolution is ambiguous, stale, syntactically invalid, or
 missing required context. Valid patterns with no current matches may contribute no data,
-but an entirely empty operation creates no Snapshot. Any capture I/O failure
-rolls back the archive and metadata. Best-effort partial output is not presented
-as a trustworthy Snapshot.
+but an entirely empty operation creates no Snapshot. Failed or partial output must
+not be advertised as a successful Snapshot; retain useful cleanup and report the
+error. Cleanup is best effort, not a guarantee of rollback across archive files,
+catalogs and cloud metadata. This boundary keeps the application simple and
+practical without adding a transaction or recovery framework.

--- a/docs/sync-model.md
+++ b/docs/sync-model.md
@@ -1,8 +1,8 @@
 # Synchronization model
 
-**Status:** design in progress
+**Status:** accepted 1.9 behavior
 
-This document records the product model while the synchronization experience is being redesigned. Confirmed decisions are normative; open questions must not be implemented as assumptions.
+This document records the agreed synchronization behavior. Local backup, cloud transfer, and restoring live game saves remain separate operations.
 
 ## User journeys
 
@@ -153,7 +153,7 @@ The Game management page contains no Permanent Shared Game Deletion entry; it is
 
 Global deletion is distinct from Local Archive eviction and Cloud Archive removal. It first commits a durable Tombstone, then removes available Archive copies locally and in cloud storage. Offline Devices process the Tombstone on their next connection, delete matching Local Archives, and cannot resurrect the Snapshot.
 
-If the initiating Device's Current Position targets the Snapshot, deletion requires an explicit precondition choice: protected Apply to another Snapshot, capture the current live save as a new Snapshot, or clear Current Position while preserving live save data.
+If the initiating Device's Current Position targets the Snapshot, the confirmation explains that its position falls back to the nearest remaining ancestor, or clears when no ancestor remains. This changes only the position: it does not restore older game saves or require an extra capture. Batch deletion follows the same rule as each selected Snapshot is removed.
 
 Matching positions on other Devices do not block deletion. They are cleared when those Devices observe the Tombstone; each affected Device can select an existing Snapshot or capture its current live save. No remote position automatically falls back to an ancestor.
 
@@ -164,7 +164,6 @@ Matching positions on other Devices do not block deletion. They are cleared when
 - [Syncthing](https://docs.syncthing.net/v1.29.0/intro/gui.html) treats pause as retained configuration and local data with synchronization activity stopped.
 - [Dropbox global deletion](https://help.dropbox.com/delete-restore/delete-files) and [OneDrive Files On-Demand](https://support.microsoft.com/en-us/office/save-disk-space-with-onedrive-files-on-demand-for-windows-0e6860d3-d9f3-4971-b321-7092438fb38e) distinguish account-wide deletion from local-copy eviction.
 - [Syncthing deletion propagation](https://docs.syncthing.net/v1.22.2/users/syncing.html) motivates a stricter durable Tombstone so stale offline Devices cannot resurrect a deleted Snapshot.
-- [Git branch deletion](https://git-scm.com/docs/git-branch/2.50.0.html) protects a checked-out worktree, supporting an explicit initiating-Device Current Position decision before deletion.
 - [Dropbox selective sync](https://help.dropbox.com/sync/selective-sync-overview) removes local copies when deselected, demonstrating why local eviction must remain separate from sync enablement.
 - [Ludusavi](https://github.com/mtkennerly/ludusavi/blob/master/docs/cli.md) keeps local backup and restore independent from cloud checks and transfer.
 - [Syncthing folder types](https://docs.syncthing.net/v1.27.2/users/foldertypes.html) expose send/receive direction because Syncthing is a generic replication tool; RGSM intentionally keeps those mechanics behind intent presets.
@@ -191,7 +190,15 @@ Matching positions on other Devices do not block deletion. They are cleared when
 - Disabling cloud sync is not Stop Managing or a deletion choice.
 - The Game management page contains no Game-level lifecycle deletion entry.
 - The Game overview uses four mutually exclusive current-Device × cloud Archive availability counts; unavailable/unavailable distinguishes another Device's last-reported copy from no known copy.
-- Global Snapshot Deletion requires the initiating Device to resolve a matching Current Position before deletion; the default is falling back to the deleted Snapshot's parent. Other Devices do not block deletion and select or capture progress after their matching positions are cleared.
-- Global Snapshot Deletion moves the initiating Device's Current Position to the deleted Snapshot's parent (or clears it if no parent exists). Other Devices' positions are cleared without automatic ancestor fallback.
+- Global Snapshot Deletion moves a matching initiating-Device Current Position to the nearest remaining ancestor, or clears it if none remains. Other Devices' matching positions clear without ancestor fallback; no live save files change.
 - Local and Cloud Archive eviction use consequence warnings rather than requiring a verified replacement copy.
 - Evicting the last known Archive leaves the Snapshot visible but unavailable; it is not Global Snapshot Deletion.
+- Removing a Device blocks ordinary background publication until the player confirms reconnecting on that Device. Reconnecting clears only its own removal marker and preserves local-only Games, backups and live saves.
+
+## Reliability and upgrade boundary
+
+Keep the model simple and practical: perform useful preflight checks, report failures, and preserve existing cleanup where possible, without promising a transaction across files, metadata and cloud storage. A failed operation may need a retry or player-directed recovery from an existing backup; a new rollback framework is not a release requirement.
+
+Restoring by overwrite keeps unrelated destination files. Delete-before-overwrite removes the selected destination first and therefore removes its extra files. Neither option promises an atomic swap of all save paths.
+
+The compatibility target is official 1.7/1.8 data upgrading to 1.9. Historical 1.7 source fixtures cover its flat archives and single position; the repository has no identified published 1.7 package. The V2 ZIP layout already exists in 1.8 and is not exclusive to a 1.9 beta. Save Unit identity and declared file/folder/registry type survive migration. Historical 1.9 intermediate configurations and direct downgrade to 1.8 do not receive a blanket compatibility promise.


### PR DESCRIPTION
Depends on #544

Align the synchronization contract with player-confirmed restore, the three deletion scopes, and explicit device reconnection

Replace the blanket atomic-capture promise with preflight validation and best-effort cleanup. Document the 1.7/1.8 upgrade boundary, including 1.8 V2 ZIP support, without promising every 1.9 beta schema or downgrade compatibility

Replace outdated E2E walkthroughs with a concise functional coverage map, a quiet local testing workflow, and explicit platform/provider gaps
