### PR TITLE
feat(acceptance): add optional human acceptance scaffolding

### DIFF
--- a/.agents/skills/rgsm-acceptance/SKILL.md
+++ b/.agents/skills/rgsm-acceptance/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: rgsm-acceptance
+description: Offer and prepare optional, change-specific human acceptance for RGSM after implementation, or when asked for an acceptance environment such as Linux compatibility, upgrade recovery, or multi-device use
+---
+
+# Optional RGSM acceptance
+
+Help the implementer decide whether human use can reveal something meaningful beyond
+the existing automatic checks, then prepare a small usable acceptance packet if wanted.
+This is not a mandatory PR gate, a replacement for tests, or a fixed scenario catalog.
+
+## Offer only when useful
+
+Inspect the actual change and existing verification. When human acceptance adds value,
+offer the proposed journey, environment requirements and approximate effort briefly.
+Wait for the implementer to opt in before building or starting the acceptance environment.
+A direct request to prepare an acceptance environment already opts in; do not ask again.
+If existing evidence is sufficient, skip the offer rather than manufacturing work.
+
+Match the environment to the claim. Linux path/permission behavior requires a Linux
+backend, not a Linux-labelled browser on Windows. Window, tray and file-picker behavior
+needs the actual desktop shell. Distinguish dev frontend, built web output and packaged app.
+For an unavailable platform, offer portable preparation materials and mark execution as
+not run. Do not install a VM, use a remote host, open desktop windows or use personal data
+without the corresponding authorization.
+
+## Prepare the packet
+
+Read `scripts/acceptance/README.md` from the repository root for the scaffolding command,
+lifecycle helpers and existing fixture locations. Use `pnpm acceptance:new <name> [platform]`
+when its structure fits. It produces local ignored output, not a permanent test case.
+
+Adapt `ACCEPTANCE.md` and `run.mjs` to the changed journey. Markdown explains player-visible
+state and results; trusted fixture code and small sample assets create actual state.
+Do not invent a JSON/YAML action language. A browser control page is useful for some
+multi-device tasks, but unnecessary for others. Prepare at most five focused scenarios
+by default; fewer is better when they cover the relevant behavior.
+
+Use artificial saves, isolated app data and local test cloud storage. Reuse existing
+fixtures and process helpers where practical; do not mirror product logic in the scaffold.
+Prepare prerequisites automatically, but leave the behavior being accepted for the human
+to exercise. Keep process counts and builds small, reuse valid builds, and avoid OS
+notifications or automatic browser/window launch. Stopping must preserve the reviewer's
+changes; a fresh baseline is a separate, explicit operation.
+
+Smoke-test the adapted setup before presenting it as ready. Confirm entry points, initial
+state, readiness and shutdown; verify restart retains modified test files. An unmodified
+generated script is only a scaffold. Record the actual source/artifact and environment,
+including uncommitted changes, rather than treating creation-time metadata as proof.
+
+## Hand off and follow up
+
+Give the entry point, short paired actions/expected results, stop/resume instructions and
+known coverage boundaries. The reviewer should not need to edit application configuration.
+Ask for the step number, actual outcome and a screenshot when helpful, not full logs with
+tokens. Separate setup checks, human results and not-run items in the final report.
+
+Follow up on reported issues within the implementation's scope. Promote a reusable helper,
+fixture or regression test into tracked source when real use justifies it; do not permanently
+add every generated packet. Never mark acceptance complete before the human reports results.

--- a/.agents/skills/rgsm-acceptance/SKILL.md
+++ b/.agents/skills/rgsm-acceptance/SKILL.md
@@ -1,60 +1,53 @@
 ---
 name: rgsm-acceptance
-description: Offer and prepare optional, change-specific human acceptance for RGSM after implementation, or when asked for an acceptance environment such as Linux compatibility, upgrade recovery, or multi-device use
+description: Offer and prepare optional, change-specific human acceptance for RGSM after implementation, or when asked for an acceptance environment for recovery, multi-device use or another changed journey
 ---
 
 # Optional RGSM acceptance
 
-Help the implementer decide whether human use can reveal something meaningful beyond
-the existing automatic checks, then prepare a small usable acceptance packet if wanted.
-This is not a mandatory PR gate, a replacement for tests, or a fixed scenario catalog.
+Offer useful human acceptance, then prepare a small usable packet if wanted.
+This is optional, not a PR gate, a replacement for tests or a fixed scenario catalog.
 
 ## Offer only when useful
 
-Inspect the actual change and existing verification. When human acceptance adds value,
-offer the proposed journey, environment requirements and approximate effort briefly.
-Wait for the implementer to opt in before building or starting the acceptance environment.
-A direct request to prepare an acceptance environment already opts in; do not ask again.
-If existing evidence is sufficient, skip the offer rather than manufacturing work.
+Inspect the change and existing verification. If human judgment adds value, briefly offer
+the journey, environment requirements and approximate effort; otherwise skip the offer.
+Wait for opt-in before preparing or starting an environment. A direct request already
+opts in; do not ask again. Overlap with automated coverage is fine when useful.
 
-Match the environment to the claim. Linux path/permission behavior requires a Linux
-backend, not a Linux-labelled browser on Windows. Window, tray and file-picker behavior
-needs the actual desktop shell. Distinguish dev frontend, built web output and packaged app.
-For an unavailable platform, offer portable preparation materials and mark execution as
-not run. Do not install a VM, use a remote host, open desktop windows or use personal data
-without the corresponding authorization.
+Match evidence to the environment: dev frontend, built web and packaged desktop are distinct.
+Tray/window behavior needs the desktop shell. Windows browser use is not Linux proof;
+this scaffold does not provision Linux. Mark unavailable execution as not run.
+Do not install VMs, use remote hosts, open windows or use personal data without authorization.
 
 ## Prepare the packet
 
-Read `scripts/acceptance/README.md` from the repository root for the scaffolding command,
-lifecycle helpers and existing fixture locations. Use `pnpm acceptance:new <name> [platform]`
-when its structure fits. It produces local ignored output, not a permanent test case.
+Read `scripts/acceptance/README.md` for commands, lifecycle helpers and fixture locations.
+Use `pnpm acceptance:new <name> [platform]` when it fits. Add `--example` on Windows for
+a runnable A/B + local Fs cloud + text-file starting point; freely trim or replace it.
+Generated packets are local ignored output, not permanent test cases.
 
-Adapt `ACCEPTANCE.md` and `run.mjs` to the changed journey. Markdown explains player-visible
-state and results; trusted fixture code and small sample assets create actual state.
-Do not invent a JSON/YAML action language. A browser control page is useful for some
-multi-device tasks, but unnecessary for others. Prepare at most five focused scenarios
-by default; fewer is better when they cover the relevant behavior.
+Adapt `ACCEPTANCE.md` and `run.mjs` to the change. Markdown describes initial state,
+numbered actions and observable results; its headings are suggestions, not a schema.
+Trusted fixture code and small synthetic assets create actual state, not a JSON/YAML
+action language. A control page is optional. Use at most five focused scenarios by default.
 
-Use artificial saves, isolated app data and local test cloud storage. Reuse existing
-fixtures and process helpers where practical; do not mirror product logic in the scaffold.
-Prepare prerequisites automatically, but leave the behavior being accepted for the human
-to exercise. Keep process counts and builds small, reuse valid builds, and avoid OS
-notifications or automatic browser/window launch. Stopping must preserve the reviewer's
-changes; a fresh baseline is a separate, explicit operation.
+Use isolated app data, artificial saves and local test cloud storage. Reuse fixture and
+process helpers; do not mirror product logic. Automate prerequisites, leaving the behavior
+being accepted for the human to exercise. Keep builds/process counts small and reuse valid
+builds. No OS notifications or automatic browser/window launch. Stop/resume must preserve
+reviewer changes; a fresh baseline is a separately named packet.
 
-Smoke-test the adapted setup before presenting it as ready. Confirm entry points, initial
-state, readiness and shutdown; verify restart retains modified test files. An unmodified
-generated script is only a scaffold. Record the actual source/artifact and environment,
-including uncommitted changes, rather than treating creation-time metadata as proof.
+Before handoff, smoke-test entry points, initial state, readiness, shutdown and restart
+with modified test files. Record the actual source/artifact, environment and dirty files;
+packet creation metadata and a runnable example alone do not prove the changed journey.
 
 ## Hand off and follow up
 
-Give the entry point, short paired actions/expected results, stop/resume instructions and
-known coverage boundaries. The reviewer should not need to edit application configuration.
-Ask for the step number, actual outcome and a screenshot when helpful, not full logs with
-tokens. Separate setup checks, human results and not-run items in the final report.
+Give links, short paired actions/results, stop/resume instructions and coverage boundaries.
+The reviewer should not need to edit app configuration. Ask for the step number, actual
+outcome and useful screenshots, not logs containing tokens. Separate setup checks, human
+results and not-run items; only the human's report establishes human acceptance.
 
-Follow up on reported issues within the implementation's scope. Promote a reusable helper,
-fixture or regression test into tracked source when real use justifies it; do not permanently
-add every generated packet. Never mark acceptance complete before the human reports results.
+Follow up within the implementation's scope. Promote helpers, fixtures or regression tests
+into tracked source when reuse justifies it; do not permanently add every generated packet.

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -53,8 +53,8 @@ jobs:
           node-version: 24
           cache: "pnpm"
 
-      - name: Run portable script tests
-        run: node --test scripts/portable.test.mjs
+      - name: Run repository script tests
+        run: node --test scripts/portable.test.mjs scripts/acceptance/acceptance.test.mjs
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -54,7 +54,7 @@ jobs:
           cache: "pnpm"
 
       - name: Run repository script tests
-        run: node --test scripts/portable.test.mjs scripts/acceptance/acceptance.test.mjs
+        run: node --test scripts/portable.test.mjs scripts/acceptance/acceptance.test.mjs apps/rgsm-gui/scripts/wait-http-host.test.mjs apps/rgsm-gui/scripts/acceptance/build-task.test.mjs
 
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile

--- a/apps/rgsm-gui/e2e/support/cloud-fixture.ts
+++ b/apps/rgsm-gui/e2e/support/cloud-fixture.ts
@@ -12,7 +12,7 @@ import {
   PARENT_SAVE_BYTES,
   PARENT_SNAPSHOT_ID,
   STORAGE_KEY,
-} from './constants';
+} from './constants.ts';
 
 const fixtureRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../fixtures/legacy-cloud-v1');
 

--- a/apps/rgsm-gui/e2e/support/rgsm-instance.ts
+++ b/apps/rgsm-gui/e2e/support/rgsm-instance.ts
@@ -5,11 +5,11 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { tmpdir } from 'node:os';
 import type { Browser, BrowserContext, Page } from '@playwright/test';
-import { setTimeout as delay } from 'node:timers/promises';
 import { finished } from 'node:stream/promises';
 import { hostCommand, spawnTestProcess } from './process';
 import { buildEnvironment, prepareBuild, preparedBinary } from './build-state';
 import { reportTiming } from './timing';
+import { waitForHttpHost } from '../../scripts/wait-http-host';
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const workspaceRoot = resolve(appRoot, '../..');
@@ -30,11 +30,6 @@ export type HostStartOptions = {
   logPath: string;
   env?: Record<string, string | undefined>;
   readyTimeoutMs?: number;
-};
-
-type HostFile = {
-  port: number;
-  api_token: string;
 };
 
 export function workspacePath(...parts: string[]): string {
@@ -174,43 +169,13 @@ export async function startRgsmHost(options: HostStartOptions): Promise<RgsmHost
     })());
 
   try {
-    const hostConfigPath = join(options.appDataDir, 'GameSaveManager.host.json');
-    const deadline = Date.now() + (options.readyTimeoutMs ?? 60_000);
-    let config: HostFile | undefined;
-    let lastError: unknown;
-    while (Date.now() < deadline) {
-      const failure = owned.failure();
-      if (failure) {
-        const tail = outputTail.trim() || (await readLogTail(options.logPath));
-        throw new Error(`RGSM Host for ${options.deviceId} failed: ${failure.message}.\n${tail}`);
-      }
-      try {
-        config = JSON.parse(await readFile(hostConfigPath, 'utf8')) as HostFile;
-        const response = await fetch(`http://127.0.0.1:${config.port}/api/v1/get-build-info`, {
-          method: 'POST',
-          headers: { Authorization: `Bearer ${config.api_token}` },
-          signal: AbortSignal.timeout(Math.max(1, Math.min(1_000, deadline - Date.now()))),
-        });
-        await response.body?.cancel();
-        if (response.ok) break;
-        lastError = new Error(`get-build-info returned HTTP ${response.status}`);
-        config = undefined;
-      } catch (error) {
-        lastError = error;
-        config = undefined;
-      }
-      await delay(Math.max(0, Math.min(250, deadline - Date.now())));
-    }
-    if (!config) {
-      throw new Error(
-        `Timed out waiting for RGSM Host ${options.deviceId}: ${String(lastError)}. See ${options.logPath}`
-      );
-    }
+    const runtime = await waitForHttpHost(options.appDataDir, {
+      timeoutMs: options.readyTimeoutMs,
+      failure: owned.failure,
+    });
     reportTiming(`HTTP host ready (${options.deviceId})`, startedAt);
     return {
-      apiBaseUrl: `http://127.0.0.1:${config.port}`,
-      token: config.api_token,
-      port: config.port,
+      ...runtime,
       appDataDir: options.appDataDir,
       deviceId: options.deviceId,
       logPath: options.logPath,
@@ -218,7 +183,8 @@ export async function startRgsmHost(options: HostStartOptions): Promise<RgsmHost
     };
   } catch (error) {
     await stop();
-    throw error;
+    const tail = outputTail.trim() || (await readLogTail(options.logPath));
+    throw new Error(`RGSM Host for ${options.deviceId} failed.\n${tail}`, { cause: error });
   }
 }
 

--- a/apps/rgsm-gui/scripts/acceptance/build-task.mjs
+++ b/apps/rgsm-gui/scripts/acceptance/build-task.mjs
@@ -1,0 +1,32 @@
+import { createWriteStream } from 'node:fs';
+import { once } from 'node:events';
+import { finished } from 'node:stream/promises';
+import { spawnTestProcess } from '../../e2e/support/process.ts';
+
+/** Await a one-shot build; cancellation also stops compiler subprocesses. */
+export async function runBuild(command, args, { signal, logPath, ...options }) {
+  signal.throwIfAborted();
+  const log = createWriteStream(logPath);
+  const logDone = finished(log);
+  logDone.catch(() => {}); // The finally block observes this even if spawning fails.
+  let owned;
+  try {
+    owned = spawnTestProcess(command, args, options);
+    owned.child.stdout.pipe(log, { end: false });
+    owned.child.stderr.pipe(log, { end: false });
+    const [code] = await Promise.race([
+      once(owned.child, 'close', { signal }),
+      logDone.then(() => {
+        throw new Error('Build log closed unexpectedly');
+      }),
+    ]);
+    if (code !== 0) throw new Error(`Build exited (${code}); see ${logPath}`);
+  } finally {
+    try {
+      await owned?.stop();
+    } finally {
+      log.end();
+      await logDone;
+    }
+  }
+}

--- a/apps/rgsm-gui/scripts/acceptance/build-task.test.mjs
+++ b/apps/rgsm-gui/scripts/acceptance/build-task.test.mjs
@@ -1,0 +1,61 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setTimeout as delay } from 'node:timers/promises';
+import { runBuild } from './build-task.mjs';
+
+test('one-shot builds capture output and reject failure', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'rgsm-build-task-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const options = { signal: new AbortController().signal, logPath: join(dir, 'build.log') };
+  await runBuild(process.execPath, ['-e', 'console.log("built")'], options);
+  assert.equal((await readFile(options.logPath, 'utf8')).trim(), 'built');
+  await assert.rejects(
+    runBuild(process.execPath, ['-e', 'process.exit(2)'], options),
+    /Build exited \(2\)/
+  );
+});
+
+test(
+  'cancelled Windows builds stop their subprocess tree before returning',
+  {
+    skip: process.platform !== 'win32' && 'Windows compiler subprocess cleanup',
+  },
+  async (t) => {
+    const dir = await mkdtemp(join(tmpdir(), 'rgsm-build-cancel-'));
+    t.after(() => rm(dir, { recursive: true, force: true }));
+    const logPath = join(dir, 'build.log');
+    const controller = new AbortController();
+    const task = runBuild(
+      process.execPath,
+      [
+        '-e',
+        `
+    const { spawn } = require('node:child_process');
+    const child = spawn(process.execPath, ['-e', 'setInterval(()=>{},1000)'], { windowsHide: true, stdio: 'ignore' });
+    console.log(child.pid);
+    setInterval(()=>{},1000);
+  `,
+      ],
+      { signal: controller.signal, logPath }
+    );
+    const rejected = assert.rejects(task, { name: 'AbortError' });
+    try {
+      let pid;
+      const deadline = Date.now() + 5_000;
+      while (!pid && Date.now() < deadline) {
+        pid = Number(await readFile(logPath, 'utf8').catch(() => ''));
+        if (!pid) await delay(20);
+      }
+      assert.ok(pid, 'child must have started before cancellation');
+      controller.abort();
+      await rejected;
+      assert.throws(() => process.kill(pid, 0), { code: 'ESRCH' });
+    } finally {
+      controller.abort();
+      await rejected;
+    }
+  }
+);

--- a/apps/rgsm-gui/scripts/acceptance/example.mjs
+++ b/apps/rgsm-gui/scripts/acceptance/example.mjs
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { waitForHttpHost } from '../wait-http-host.ts';
+import { serveDevice } from './serve-device.mjs';
+import { runBuild } from './build-task.mjs';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const repoRoot = resolve(appRoot, '../..');
+const execute = promisify(execFile);
+const viteCli = fileURLToPath(new URL('./bin/vite.js', import.meta.resolve('vite/package.json')));
+
+export async function buildExample(session) {
+  // Recheck source on each launch; Cargo reuses valid incremental output.
+  console.log('Preparing HTTP host and built GUI (no desktop windows)');
+  const options = {
+    cwd: repoRoot,
+    windowsHide: true,
+    signal: session.signal,
+    maxBuffer: 8 * 1024 * 1024,
+  };
+  await runBuild('cargo', ['build', '--locked', '-p', 'rgsm', '--bin', 'rgsm'], {
+    ...options,
+    logPath: join(session.logsDir, 'build.log'),
+    env: { ...process.env, CARGO_BUILD_JOBS: process.env.CARGO_BUILD_JOBS ?? '2' },
+  });
+  const outDir = join(session.root, 'web');
+  await runBuild(process.execPath, [viteCli, 'build', '--outDir', outDir, '--logLevel', 'warn'], {
+    ...options,
+    cwd: appRoot,
+    logPath: join(session.logsDir, 'web-build.log'),
+  });
+  session.signal.throwIfAborted();
+  const target = resolve(repoRoot, process.env.CARGO_TARGET_DIR ?? 'target');
+  const binary = join(target, 'debug', process.platform === 'win32' ? 'rgsm.exe' : 'rgsm');
+  const revision = (await execute('git', ['rev-parse', 'HEAD'], options)).stdout.trim();
+  const changes = (await execute('git', ['status', '--porcelain'], options)).stdout.trim();
+  await writeFile(
+    join(session.evidenceDir, 'runtime.json'),
+    JSON.stringify(
+      {
+        revision,
+        changes,
+        binary,
+        outDir,
+        platform: process.platform,
+        environment: 'HTTP-only host with built web GUI',
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2
+    ) + '\n'
+  );
+  return { binary, outDir, appRoot, repoRoot };
+}
+
+export async function startExampleDevice(session, device, artifacts) {
+  session.start(artifacts.binary, [], {
+    cwd: artifacts.repoRoot,
+    env: {
+      ...process.env,
+      RGSM_HTTP_HOST_ONLY: '1',
+      RGSM_E2E_APP_DATA_DIR: device.appDataDir,
+      RGSM_E2E_DEVICE_ID: device.id,
+      RUST_LOG: 'info',
+    },
+  });
+  const host = await waitForHttpHost(device.appDataDir, { signal: session.signal });
+  return serveDevice(session, device, artifacts, host);
+}

--- a/apps/rgsm-gui/scripts/acceptance/example.test.mjs
+++ b/apps/rgsm-gui/scripts/acceptance/example.test.mjs
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, expect } from '@playwright/test';
+import { spawnTestProcess } from '../../e2e/support/process.ts';
+import { deviceLayout, readSave } from '../../e2e/support/cloud-fixture.ts';
+import { createPacket } from '../../../../scripts/acceptance/create.mjs';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+test(
+  'generated example supports GUI A/B round trip, text panels and restart without reseeding',
+  {
+    skip: process.platform !== 'win32' && 'The runnable example is Windows-only',
+    timeout: 600_000,
+  },
+  async (t) => {
+    const root = await createPacket(`example-check-${Date.now()}`, { repoRoot, example: true });
+    const entryFile = join(root, 'entrypoints.json');
+    let owned;
+    let output = '';
+    let browser;
+    let passed = false;
+    async function start() {
+      await rm(entryFile, { force: true });
+      owned = spawnTestProcess(process.execPath, [join(root, 'run.mjs')], { cwd: repoRoot });
+      owned.child.stdout.on('data', (data) => {
+        output += data;
+      });
+      owned.child.stderr.on('data', (data) => {
+        output += data;
+      });
+      let entries;
+      await expect
+        .poll(
+          async () => {
+            if (owned.failure())
+              throw new Error(`Example failed: ${owned.failure().message}\n${output}`);
+            try {
+              entries = JSON.parse(await readFile(entryFile, 'utf8'));
+              return entries.length;
+            } catch (error) {
+              if (error.code !== 'ENOENT') throw error;
+              return 0;
+            }
+          },
+          { timeout: 300_000 }
+        )
+        .toBe(2);
+      return entries;
+    }
+    async function stop(panel, entries) {
+      await panel.getByRole('button', { name: 'Stop entire session' }).click();
+      await expect.poll(() => owned.child.exitCode, { timeout: 15_000 }).toBe(0);
+      for (const entry of entries) {
+        await assert.rejects(fetch(entry.gui, { signal: AbortSignal.timeout(1_000) }));
+      }
+      await assert.rejects(readFile(join(root, '.running')), { code: 'ENOENT' });
+    }
+    const saveA = deviceLayout(join(root, 'data'), 'a');
+    const saveB = deviceLayout(join(root, 'data'), 'b');
+    async function open(page, origin, path) {
+      await page.goto(origin + path);
+      await expect(
+        page.getByRole('heading', {
+          name: path === '/SyncSettings' ? 'Sync settings' : 'Echo Keep',
+          exact: true,
+        })
+      ).toBeVisible();
+    }
+    function row(page, description) {
+      return page.getByRole('row').filter({ has: page.getByText(description, { exact: true }) });
+    }
+    async function publish(page, origin, description) {
+      await open(page, origin, '/Management/Echo%20Keep');
+      await page.getByPlaceholder('New backup description').fill(description);
+      await page.getByRole('button', { name: 'Create new snapshot' }).click();
+      const snapshot = row(page, description);
+      const upload = snapshot.getByRole('button', { name: 'Upload to cloud' });
+      const uploaded = snapshot.getByRole('button', { name: 'Remove cloud copy' });
+      const action = await upload
+        .or(uploaded)
+        .first()
+        .getAttribute('aria-label', { timeout: 30_000 });
+      if (action === 'Upload to cloud') await upload.click();
+      await expect(uploaded).toBeVisible({ timeout: 30_000 });
+    }
+    async function restore(page, origin, description, device, contents) {
+      await open(page, origin, '/Management/Echo%20Keep');
+      const snapshot = row(page, description);
+      await snapshot.getByRole('button', { name: 'Download to this device' }).click();
+      await expect(snapshot.getByRole('button', { name: 'Remove from this device' })).toBeVisible({
+        timeout: 30_000,
+      });
+      await snapshot.getByRole('button', { name: 'Apply', exact: true }).click();
+      await expect.poll(() => readSave(device), { timeout: 30_000 }).toBe(contents);
+    }
+    try {
+      const entries = await start();
+      const [a, b] = entries;
+      // Explicit headless launch, no desktop shell or personal browser profile.
+      browser = await chromium.launch({ headless: true });
+      const pageA = await browser.newPage();
+      const pageB = await browser.newPage();
+      const panelA = await browser.newPage();
+      const panelB = await browser.newPage();
+      const pageErrors = [];
+      for (const page of [pageA, pageB, panelA, panelB])
+        page.on('pageerror', (error) => pageErrors.push(error.message));
+      await panelA.goto(a.panel);
+      await expect(panelA.getByRole('textbox')).toHaveValue('A: starting progress\n');
+      await panelB.goto(b.panel);
+      await expect(panelB.getByRole('textbox')).toHaveValue('B: starting progress\n');
+      assert.equal((await fetch(`${a.gui}/__acceptance/text`)).status, 401);
+      assert.equal(
+        (await fetch(a.panel, { headers: { Origin: 'https://example.invalid' } })).status,
+        403
+      );
+      assert.equal((await fetch(`${a.gui}/api/v1/get-build-info`, { method: 'POST' })).status, 401);
+
+      await open(pageA, a.gui, '/SyncSettings');
+      await pageA.getByRole('button', { name: 'Create library', exact: true }).click();
+      await expect(pageA.getByRole('textbox', { name: 'Search games' })).toBeVisible({
+        timeout: 30_000,
+      });
+      await publish(pageA, a.gui, 'A checkpoint');
+      await open(pageB, b.gui, '/SyncSettings');
+      await expect(pageB.getByRole('textbox', { name: 'Search games' })).toBeVisible({
+        timeout: 30_000,
+      });
+      await restore(pageB, b.gui, 'A checkpoint', saveB, 'A: starting progress\n');
+      await panelB.getByRole('button', { name: 'Read saved file' }).click();
+      await expect(panelB.getByRole('textbox')).toHaveValue('A: starting progress\n');
+      await panelB.getByRole('textbox').fill('B: new progress');
+      await panelB.getByRole('button', { name: 'Write edited text' }).click();
+      await expect(panelB.getByRole('status')).toHaveText('Written to disk');
+      assert.equal(await readSave(saveA), 'A: starting progress\n');
+      await publish(pageB, b.gui, 'B checkpoint');
+      await restore(pageA, a.gui, 'B checkpoint', saveA, 'B: new progress');
+      await panelA.getByRole('button', { name: 'Read saved file' }).click();
+      await expect(panelA.getByRole('textbox')).toHaveValue('B: new progress');
+      await panelA.screenshot({ path: join(root, 'evidence/panel.png') });
+      assert.deepEqual(pageErrors, []);
+      await stop(panelA, entries);
+
+      const resumed = await start();
+      await panelA.goto(resumed[0].panel);
+      await expect(panelA.getByRole('textbox')).toHaveValue('B: new progress');
+      await open(pageA, resumed[0].gui, '/Management/Echo%20Keep');
+      await expect(row(pageA, 'A checkpoint')).toBeVisible();
+      await expect(row(pageA, 'B checkpoint')).toBeVisible();
+      await stop(panelA, resumed);
+      passed = true;
+    } finally {
+      await browser?.close();
+      await owned?.stop();
+      await writeFile(join(root, 'evidence/launcher.log'), output);
+      if (passed) await rm(root, { recursive: true, force: true });
+      else t.diagnostic(`Failure evidence retained at ${root}`);
+    }
+  }
+);

--- a/apps/rgsm-gui/scripts/acceptance/panel.html
+++ b/apps/rgsm-gui/scripts/acceptance/panel.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Acceptance fixture</title>
+    <style>
+      body {
+        font: 16px system-ui;
+        max-width: 50rem;
+        margin: 3rem auto;
+        padding: 0 1rem;
+        color-scheme: light dark;
+      }
+      textarea {
+        box-sizing: border-box;
+        width: 100%;
+        height: 12rem;
+        margin: 0.5rem 0;
+      }
+      button,
+      a {
+        margin-right: 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1 id="device"></h1>
+    <p>
+      <a href="/" target="_blank" rel="noopener">Open RGSM</a>Artificial files only · no personal
+      saves or remote cloud
+    </p>
+    <label for="save">Simulated game progress (UTF-8 text, up to 64 KiB)</label>
+    <textarea id="save" spellcheck="false"></textarea>
+    <button id="read">Read saved file</button>
+    <button id="write">Write edited text</button>
+    <p id="status" role="status"></p>
+    <p>
+      Use RGSM to create, upload, download and apply snapshots<br />Writing here simulates playing
+      the game, not creating a snapshot
+    </p>
+    <button id="stop">Stop entire session</button>
+    <p>Data is retained · run the same launcher to continue · use the newly printed links</p>
+    <script>
+      const device = __DEVICE__;
+      document.getElementById('device').textContent = device.name;
+      const save = document.getElementById('save');
+      const status = document.getElementById('status');
+      async function request(action, method = 'GET', body) {
+        const response = await fetch(`/__acceptance/${action}`, {
+          method,
+          body,
+          headers: { Authorization: `Bearer ${device.token}` },
+        });
+        if (!response.ok) throw new Error(`Request failed (${response.status})`);
+        return response.text();
+      }
+      async function act(callback) {
+        try {
+          await callback();
+        } catch (error) {
+          status.textContent = error.message;
+        }
+      }
+      document.getElementById('read').onclick = () =>
+        act(async () => {
+          save.value = await request('text');
+          status.textContent = 'Read from disk';
+        });
+      document.getElementById('write').onclick = () =>
+        act(async () => {
+          await request('text', 'POST', save.value);
+          status.textContent = 'Written to disk';
+        });
+      document.getElementById('stop').onclick = () =>
+        act(async () => {
+          status.textContent = await request('stop', 'POST');
+        });
+      document.getElementById('read').click();
+    </script>
+  </body>
+</html>

--- a/apps/rgsm-gui/scripts/acceptance/serve-device.mjs
+++ b/apps/rgsm-gui/scripts/acceptance/serve-device.mjs
@@ -1,0 +1,105 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { preview } from 'vite';
+
+const jsonForScript = (value) => JSON.stringify(value).replaceAll('<', '\\u003c');
+
+/** A local fixture panel and the real built GUI, sharing one ephemeral origin. */
+export async function serveDevice(session, device, artifacts, host) {
+  const index = await readFile(join(artifacts.outDir, 'index.html'), 'utf8');
+  const panel = await readFile(new URL('./panel.html', import.meta.url), 'utf8');
+  const server = await preview({
+    configFile: false,
+    root: artifacts.appRoot,
+    build: { outDir: artifacts.outDir },
+    preview: {
+      host: '127.0.0.1',
+      port: 0,
+      open: false,
+      proxy: {
+        '/api/v1': {
+          target: host.apiBaseUrl,
+          configure(proxy) {
+            proxy.on('proxyReq', (request) => request.removeHeader('origin'));
+          },
+        },
+      },
+    },
+    plugins: [
+      {
+        name: 'acceptance-device',
+        configurePreviewServer(previewServer) {
+          previewServer.middlewares.use((req, res, next) => {
+            const origin = `http://127.0.0.1:${previewServer.httpServer.address().port}`;
+            const reject = (code) => {
+              res.writeHead(code).end();
+            };
+            // Do not expose local credentials/files to foreign sites or stale tabs.
+            if (
+              req.headers.host !== new URL(origin).host ||
+              (req.headers.origin && req.headers.origin !== origin) ||
+              req.headers['sec-fetch-site'] === 'cross-site'
+            )
+              return reject(403);
+            const path = new URL(req.url, origin).pathname;
+            const control = path.startsWith('/__acceptance/');
+            if (
+              (control || path.startsWith('/api/v1')) &&
+              req.headers.authorization !== `Bearer ${host.token}`
+            )
+              return reject(401);
+            res.setHeader('Cache-Control', 'no-store');
+            if (path.startsWith('/api/v1')) return next();
+            const html = (body) =>
+              res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' }).end(body);
+            if (req.method === 'GET' && path === '/__acceptance') {
+              return html(
+                panel.replace('__DEVICE__', jsonForScript({ name: device.name, token: host.token }))
+              );
+            }
+            if (control) {
+              void (async () => {
+                if (path === '/__acceptance/stop' && req.method === 'POST') {
+                  res.end('Stopped; data retained');
+                  session.stop();
+                } else if (path === '/__acceptance/text' && req.method === 'GET') {
+                  const content = await readFile(device.savePath);
+                  if (content.length > 65_536) return reject(413);
+                  res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' }).end(content);
+                } else if (path === '/__acceptance/text' && req.method === 'POST') {
+                  const chunks = [];
+                  let length = 0;
+                  for await (const chunk of req) {
+                    length += chunk.length;
+                    if (length > 65_536) return reject(413);
+                    chunks.push(chunk);
+                  }
+                  // Only this fixture's fixed file is writable; no path input or product API shortcuts.
+                  await writeFile(device.savePath, Buffer.concat(chunks));
+                  res.end('Written');
+                } else reject(404);
+              })().catch(() => {
+                if (!res.headersSent) res.writeHead(500);
+                res.end('Fixture operation failed; inspect local data');
+              });
+              return;
+            }
+            if (req.method === 'GET' && req.headers.accept?.includes('text/html')) {
+              return html(
+                index.replace(
+                  '<head>',
+                  `<head><script>window.__RGSM_RUNTIME__=${jsonForScript({ apiBaseUrl: origin, token: host.token })}</script>`
+                )
+              );
+            }
+            next();
+          });
+        },
+      },
+    ],
+  });
+  session.defer(() => server.close());
+  session.signal.throwIfAborted();
+  const origin = `http://127.0.0.1:${server.httpServer.address().port}`;
+  return { name: device.name, gui: origin, panel: `${origin}/__acceptance` };
+}

--- a/apps/rgsm-gui/scripts/wait-http-host.test.mjs
+++ b/apps/rgsm-gui/scripts/wait-http-host.test.mjs
@@ -1,0 +1,60 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { once } from 'node:events';
+import { waitForHttpHost } from './wait-http-host.ts';
+
+async function fixture(t, respond) {
+  const dir = await mkdtemp(join(tmpdir(), 'rgsm-host-ready-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const server = createServer(respond);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  t.after(
+    () =>
+      new Promise((resolve) => {
+        server.close(resolve);
+        server.closeAllConnections();
+      })
+  );
+  const port = server.address().port;
+  await writeFile(
+    join(dir, 'GameSaveManager.host.json'),
+    JSON.stringify({ port, api_token: 'fixture-token' })
+  );
+  return { dir, port };
+}
+
+test('host readiness checks the discovered endpoint with authentication and retries', async (t) => {
+  let requests = 0;
+  const { dir, port } = await fixture(t, (req, res) => {
+    assert.equal(req.url, '/api/v1/get-build-info');
+    assert.equal(req.method, 'POST');
+    assert.equal(req.headers.authorization, 'Bearer fixture-token');
+    res.writeHead(++requests === 1 ? 503 : 200).end('{}');
+  });
+  assert.deepEqual(await waitForHttpHost(dir, { timeoutMs: 3_000 }), {
+    apiBaseUrl: `http://127.0.0.1:${port}`,
+    token: 'fixture-token',
+    port,
+  });
+  assert.equal(requests, 2);
+});
+
+test('cancellation interrupts an in-flight readiness request', async (t) => {
+  const controller = new AbortController();
+  const { dir } = await fixture(t, () => controller.abort(new Error('setup cancelled')));
+  await assert.rejects(waitForHttpHost(dir, { signal: controller.signal }), /setup cancelled/);
+});
+
+test('hung requests respect the overall timeout and process failures stop polling', async (t) => {
+  const { dir } = await fixture(t, () => {});
+  await assert.rejects(waitForHttpHost(dir, { timeoutMs: 100 }), /Timed out/);
+  await assert.rejects(
+    waitForHttpHost(dir, { failure: () => new Error('host exited') }),
+    /host exited/
+  );
+});

--- a/apps/rgsm-gui/scripts/wait-http-host.ts
+++ b/apps/rgsm-gui/scripts/wait-http-host.ts
@@ -1,0 +1,51 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+/** Read only the specified profile and verify its authenticated HTTP endpoint. */
+export async function waitForHttpHost(
+  appDataDir: string,
+  {
+    signal,
+    timeoutMs = 60_000,
+    failure = () => undefined,
+  }: { signal?: AbortSignal; timeoutMs?: number; failure?: () => Error | undefined } = {}
+): Promise<{ apiBaseUrl: string; token: string; port: number }> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    signal?.throwIfAborted();
+    const processError = failure();
+    if (processError) throw processError;
+    try {
+      const config = JSON.parse(
+        await readFile(join(appDataDir, 'GameSaveManager.host.json'), 'utf8')
+      );
+      if (
+        !Number.isInteger(config.port) ||
+        config.port < 1 ||
+        config.port > 65535 ||
+        typeof config.api_token !== 'string' ||
+        !config.api_token
+      ) {
+        throw new Error('Invalid host discovery file');
+      }
+      const apiBaseUrl = `http://127.0.0.1:${config.port}`;
+      const timeout = AbortSignal.timeout(Math.max(1, Math.min(1_000, deadline - Date.now())));
+      const response = await fetch(`${apiBaseUrl}/api/v1/get-build-info`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${config.api_token}` },
+        signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+      });
+      await response.body?.cancel();
+      signal?.throwIfAborted();
+      if (response.ok) return { apiBaseUrl, token: config.api_token, port: config.port };
+      lastError = new Error(`get-build-info returned HTTP ${response.status}`);
+    } catch (error) {
+      signal?.throwIfAborted();
+      lastError = error;
+    }
+    await delay(Math.max(0, Math.min(250, deadline - Date.now())), undefined, { signal });
+  }
+  throw new Error(`Timed out waiting for RGSM HTTP host: ${String(lastError)}`);
+}

--- a/apps/rgsm-gui/tsconfig.json
+++ b/apps/rgsm-gui/tsconfig.json
@@ -10,6 +10,7 @@
     "isolatedModules": true,
     "skipLibCheck": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "types": ["node", "vite/client"],
     "rootDir": ".",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "acceptance:new": "node scripts/acceptance/create.mjs",
+    "acceptance:test": "node --test scripts/acceptance/acceptance.test.mjs",
     "dev": "pnpm --dir apps/rgsm-gui dev",
     "build": "pnpm --dir apps/rgsm-gui build",
     "web:dev": "pnpm --dir apps/rgsm-gui web:dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "acceptance:new": "node scripts/acceptance/create.mjs",
-    "acceptance:test": "node --test scripts/acceptance/acceptance.test.mjs",
+    "acceptance:test": "node --test scripts/acceptance/acceptance.test.mjs apps/rgsm-gui/scripts/wait-http-host.test.mjs apps/rgsm-gui/scripts/acceptance/build-task.test.mjs",
+    "acceptance:test:example": "node --test apps/rgsm-gui/scripts/acceptance/example.test.mjs",
     "dev": "pnpm --dir apps/rgsm-gui dev",
     "build": "pnpm --dir apps/rgsm-gui build",
     "web:dev": "pnpm --dir apps/rgsm-gui web:dev",

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -59,23 +59,40 @@ Packets are local, ignored output, not deployment bundles. If copying a packet, 
 Platform recording does not establish compatibility. This tool does not provision other
 machines or provide Linux acceptance support.
 
-## Reuse before adding adapters
+## Start from a runnable example when useful
 
-Existing fixture builders live in `apps/rgsm-gui/e2e/support/`: `released-upgrade.ts`,
-`local-fixture.ts`, and `cloud-fixture.ts`. HTTP host readiness and browser runtime wiring
-are in `rgsm-instance.ts`; process ownership is in `process.ts`. These TypeScript modules
-have different runtime dependencies: importing a fixture that transitively imports
-extensionless TS modules needs a compatible runner. Do not assume plain Node can run all
-E2E modules merely because it can strip TypeScript types.
+```sh
+pnpm acceptance:new cloud-journey --example
+node .rgsm-dev/acceptance/cloud-journey/run.mjs
+```
 
-Prefer a narrowly shared helper when repeated acceptance needs justify extracting one.
-Do not duplicate RGSM's cloud model, add a scenario DSL, or refactor all E2E support for
-an initial packet. An HTML control page, multiple devices, Playwright, and desktop launch
-are optional choices for the particular request, not requirements of the scaffold.
+Currently verified on Windows, with Node 24, installed pnpm dependencies and the repository's
+Rust build prerequisites. This builds one HTTP-only host binary and one web bundle, starts
+two isolated hosts with a shared local Fs cloud, and prints each device's GUI and text-panel
+links. Ports are assigned by the OS; existing dev servers are not adopted or stopped.
+No browser or desktop window opens automatically. The panel reads/writes only its fixed
+artificial save file, never arbitrary paths. It is local tooling, not a product UI.
 
-Linux file/permission behavior needs a Linux backend; tray and window behavior additionally
-need a real desktop session. An HTTP-only browser session does not establish either desktop
-compatibility or packaged-app startup. Existing `production-startup.spec.ts` covers built web
-startup separately. Do not install VMs or operate remote machines merely to fill a coverage gap.
+Edit the generated `run.mjs` directly: remove B, replace the seed, or change initial bytes.
+`ACCEPTANCE.md` is a suggested human outline, not machine-parsed input. Store actual state
+in fixture code and sample files, not Markdown/YAML encodings. Keep sample assets small and
+synthetic. The example intentionally leaves library creation, snapshots, transfers and
+restore for real RGSM interactions; it makes no WebDAV/S3 or desktop-shell claims.
 
-Run the lightweight scaffold/lifecycle tests with `pnpm acceptance:test`.
+`apps/rgsm-gui/scripts/acceptance/` contains the app-specific build/preview/text helpers.
+The example directly imports `e2e/support/cloud-fixture.ts`; readiness uses the same
+`scripts/wait-http-host.ts` helper as E2E, and process ownership uses `e2e/support/process.ts`.
+Other E2E fixture modules may require a compatible runner for extensionless TS imports:
+do not assume all E2E code runs in plain Node. No scenario registry or generic adapter layer
+is needed to write another packet.
+
+Each launch records the actual revision, dirty files, artifact and environment under
+`evidence/runtime.json`. Creation metadata alone is not execution evidence. Restart preserves
+data but rebuilds incrementally and prints new URLs/tokens; reload through the new links.
+Use either text panel's stop button or Ctrl+C. Generated configs/logs remain private local
+data and can contain credentials; share only redacted evidence.
+
+Run lightweight scaffold/readiness tests with `pnpm acceptance:test`. The opt-in
+`pnpm acceptance:test:example` additionally builds and exercises the generated example
+against the real backend with headless Chromium (Playwright browser installation required).
+Neither command records a human acceptance result.

--- a/scripts/acceptance/README.md
+++ b/scripts/acceptance/README.md
@@ -1,0 +1,81 @@
+# Optional human acceptance packets
+
+Node 24 and Git are sufficient to create a packet. No application starts implicitly:
+
+```sh
+pnpm acceptance:new save-restore
+```
+
+This creates `.rgsm-dev/acceptance/save-restore/` with an editable `ACCEPTANCE.md`,
+`run.mjs`, and preparation metadata. The author adapts the packet to the change, then
+checks its setup before offering it to a reviewer. The generated starter is deliberately
+labelled as a scaffold, not an RGSM environment or a passing acceptance test.
+
+Run the adapted packet from its repository checkout:
+
+```sh
+node .rgsm-dev/acceptance/save-restore/run.mjs
+```
+
+`withSession(entryUrl, callback)` provides isolated `dataDir`, `logsDir`, `evidenceDir`,
+and these small building blocks:
+
+- `prepare(seed)`: seed once; a successful marker preserves subsequent reviewer edits
+- `start(command, args, options)`: launch a long-running service without a shell;
+  output goes to local logs; process cleanup reuses the existing E2E process helper
+- `wait()`: keep the launcher alive until Ctrl+C or a child failure
+- `stop()`: request shutdown, useful in a setup smoke test
+- `signal`: cancellation for setup/readiness; pass it to awaited I/O and use bounded timeouts
+- `defer(close)`: register an owned server/resource for reverse-order cleanup
+
+`start()` treats even a successful service exit as unexpected. Use an ordinary awaited
+operation for one-shot preparation, for example:
+
+```js
+await promisify(execFile)(command, args, {
+  windowsHide: true,
+  signal: session.signal,
+});
+```
+
+Ctrl+C or a service failure aborts `signal`, including before `wait()`. Setup must cooperate
+with cancellation; JavaScript that ignores the signal cannot be forcibly interrupted safely.
+The launcher waits for setup to unwind before closing resources, so it cannot continue
+writing in the background after cleanup. Failed setup retains partial files for diagnosis;
+fix it idempotently or create a fresh named packet, never silently reseed existing progress.
+
+Child services must have explicit readiness checks and bind to loopback. Never pass a
+normal application profile to them. Use explicit isolated app-data and device IDs for
+RGSM, and disable notification/sound integrations in prepared configuration. Do not log
+tokens in acceptance results. The helper does not sandbox trusted fixture code.
+
+Stop and restart preserve data. A new packet name creates a fresh baseline; there is no
+implicit reset or recursive cleanup command. Concurrent launch is rejected. After a hard
+crash, confirm the old services have stopped before manually removing the empty `.running`
+directory. Cleanup never kills processes by reading a PID saved in a previous session.
+
+Packets are local, ignored output, not deployment bundles. If copying a packet, its
+`session.json` is also required; do not copy generated credentials or machine-specific data.
+Platform recording does not establish compatibility. This tool does not provision other
+machines or provide Linux acceptance support.
+
+## Reuse before adding adapters
+
+Existing fixture builders live in `apps/rgsm-gui/e2e/support/`: `released-upgrade.ts`,
+`local-fixture.ts`, and `cloud-fixture.ts`. HTTP host readiness and browser runtime wiring
+are in `rgsm-instance.ts`; process ownership is in `process.ts`. These TypeScript modules
+have different runtime dependencies: importing a fixture that transitively imports
+extensionless TS modules needs a compatible runner. Do not assume plain Node can run all
+E2E modules merely because it can strip TypeScript types.
+
+Prefer a narrowly shared helper when repeated acceptance needs justify extracting one.
+Do not duplicate RGSM's cloud model, add a scenario DSL, or refactor all E2E support for
+an initial packet. An HTML control page, multiple devices, Playwright, and desktop launch
+are optional choices for the particular request, not requirements of the scaffold.
+
+Linux file/permission behavior needs a Linux backend; tray and window behavior additionally
+need a real desktop session. An HTTP-only browser session does not establish either desktop
+compatibility or packaged-app startup. Existing `production-startup.spec.ts` covers built web
+startup separately. Do not install VMs or operate remote machines merely to fill a coverage gap.
+
+Run the lightweight scaffold/lifecycle tests with `pnpm acceptance:test`.

--- a/scripts/acceptance/acceptance.test.mjs
+++ b/scripts/acceptance/acceptance.test.mjs
@@ -1,0 +1,319 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtemp,
+  readFile,
+  writeFile,
+  mkdir,
+  rm,
+  access,
+  copyFile,
+  symlink,
+} from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+import { spawn, execFileSync } from "node:child_process";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { createPacket } from "./create.mjs";
+import { withSession } from "./session.mjs";
+
+async function fixture(t) {
+  const root = await mkdtemp(join(tmpdir(), "rgsm-acceptance-test-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await writeFile(
+    join(root, "session.json"),
+    JSON.stringify({ kind: "rgsm-acceptance", target: process.platform }),
+  );
+  return { root, url: pathToFileURL(join(root, "run.mjs")) };
+}
+
+test("stop cancels preparation before wait and does not mark partial data prepared", async (t) => {
+  const { root, url } = await fixture(t);
+  let child;
+  await withSession(url, async (session) => {
+    assert.ok(session.signal instanceof AbortSignal);
+    child = session.start(process.execPath, [
+      "-e",
+      'console.log("ready");setInterval(()=>{},1000)',
+    ]);
+    await once(child.stdout, "data");
+    await session.prepare(async ({ dataDir, signal }) => {
+      await writeFile(join(dataDir, "save.txt"), "keep partial evidence");
+      process.emit("SIGINT");
+      await delay(10_000, undefined, { signal });
+      assert.fail("cancelled setup must not continue");
+    });
+  });
+  assert.ok(child.exitCode !== null || child.signalCode !== null);
+  await assert.rejects(access(join(root, ".running")), { code: "ENOENT" });
+  await assert.rejects(access(join(root, "data/.prepared")), {
+    code: "ENOENT",
+  });
+  assert.equal(
+    await readFile(join(root, "data/save.txt"), "utf8"),
+    "keep partial evidence",
+  );
+});
+
+test("service failure cancels a pending readiness check", async (t) => {
+  const { root, url } = await fixture(t);
+  await assert.rejects(
+    withSession(url, async (session) => {
+      assert.ok(session.signal instanceof AbortSignal);
+      session.start(join(root, "missing-service"));
+      await delay(10_000, undefined, { signal: session.signal });
+    }),
+    /ENOENT/,
+  );
+  await assert.rejects(access(join(root, ".running")), { code: "ENOENT" });
+});
+
+test("awaited one-shot preparation succeeds before a long-running service", async (t) => {
+  const { url } = await fixture(t);
+  await withSession(url, async (session) => {
+    const result = await promisify(execFile)(
+      process.execPath,
+      ["-e", 'console.log("prepared")'],
+      {
+        windowsHide: true,
+        signal: session.signal,
+      },
+    );
+    assert.match(result.stdout, /prepared/);
+    const child = session.start(process.execPath, [
+      "-e",
+      'console.log("ready");setInterval(()=>{},1000)',
+    ]);
+    await once(child.stdout, "data");
+    session.stop();
+    await session.wait();
+  });
+});
+
+test("linked data directories are rejected without modifying their target", async (t) => {
+  const { root, url } = await fixture(t);
+  const outside = join(root, "outside");
+  await mkdir(outside);
+  await writeFile(join(outside, "save.txt"), "untouched");
+  await symlink(
+    outside,
+    join(root, "data"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
+  await assert.rejects(
+    withSession(url, () => assert.fail("must not seed")),
+    /directory is a link/,
+  );
+  assert.equal(await readFile(join(outside, "save.txt"), "utf8"), "untouched");
+});
+
+test("seed once, preserve reviewer edits, and release session ownership", async (t) => {
+  const { root, url } = await fixture(t);
+  let seeds = 0;
+  const run = () =>
+    withSession(url, async (session) => {
+      await session.prepare(async ({ dataDir }) => {
+        seeds++;
+        await writeFile(join(dataDir, "save.txt"), "initial");
+      });
+    });
+  await run();
+  await writeFile(join(root, "data/save.txt"), "reviewer progress");
+  await run();
+  assert.equal(seeds, 1);
+  assert.equal(
+    await readFile(join(root, "data/save.txt"), "utf8"),
+    "reviewer progress",
+  );
+  await assert.rejects(access(join(root, ".running")), { code: "ENOENT" });
+});
+
+test("concurrent launch is rejected without touching the active session", async (t) => {
+  const { root, url } = await fixture(t);
+  await withSession(url, async () => {
+    await assert.rejects(
+      withSession(url, () => assert.fail("must not run")),
+      /already running/,
+    );
+    await access(join(root, ".running"));
+  });
+});
+
+test("failed fixture keeps its evidence but is not marked prepared", async (t) => {
+  const { root, url } = await fixture(t);
+  await assert.rejects(
+    withSession(url, (session) =>
+      session.prepare(async ({ evidenceDir }) => {
+        await writeFile(join(evidenceDir, "failure.txt"), "diagnostic");
+        throw new Error("seed failed");
+      }),
+    ),
+    /seed failed/,
+  );
+  await assert.rejects(access(join(root, "data/.prepared")), {
+    code: "ENOENT",
+  });
+  assert.equal(
+    await readFile(join(root, "evidence/failure.txt"), "utf8"),
+    "diagnostic",
+  );
+});
+
+test("owned process stops while an unrelated process remains alive", async (t) => {
+  const { root, url } = await fixture(t);
+  const outsider = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  t.after(async () => {
+    if (outsider.exitCode === null && outsider.signalCode === null) {
+      const exit = once(outsider, "exit");
+      outsider.kill();
+      await exit;
+    }
+  });
+  let owned;
+  await withSession(url, async (session) => {
+    owned = session.start(process.execPath, [
+      "-e",
+      'console.log("ready");setInterval(()=>{},1000)',
+    ]);
+    await once(owned.stdout, "data");
+    session.stop();
+    await session.wait();
+  });
+  assert.ok(owned.exitCode !== null || owned.signalCode !== null);
+  assert.equal(outsider.exitCode, null);
+  assert.equal(outsider.signalCode, null);
+  assert.match(
+    await readFile(join(root, "logs/process-0.log"), "utf8"),
+    /ready/,
+  );
+});
+
+test("child startup failure rejects wait and releases ownership", async (t) => {
+  const { root, url } = await fixture(t);
+  await assert.rejects(
+    withSession(url, async (session) => {
+      session.start(join(root, "nonexistent-executable"));
+      await session.wait();
+    }),
+    /ENOENT/,
+  );
+  await assert.rejects(access(join(root, ".running")), { code: "ENOENT" });
+});
+
+test("setup failure closes services and preserves files", async (t) => {
+  const { root, url } = await fixture(t);
+  let child;
+  await assert.rejects(
+    withSession(url, async (session) => {
+      child = session.start(process.execPath, [
+        "-e",
+        'console.log("ready");setInterval(()=>{},1000)',
+      ]);
+      await once(child.stdout, "data");
+      await writeFile(join(session.dataDir, "save.txt"), "keep");
+      throw new Error("readiness failed");
+    }),
+    /readiness failed/,
+  );
+  assert.ok(child.exitCode !== null || child.signalCode !== null);
+  assert.equal(await readFile(join(root, "data/save.txt"), "utf8"), "keep");
+});
+
+test("packet generator records provenance, rejects traversal and never overwrites", async (t) => {
+  const { root } = await fixture(t);
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: root, stdio: "pipe", windowsHide: true });
+  git("init");
+  git(
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "--allow-empty",
+    "-m",
+    "test",
+  );
+  const packet = await createPacket("linux-paths", {
+    repoRoot: root,
+    target: "linux",
+  });
+  const meta = JSON.parse(await readFile(join(packet, "session.json"), "utf8"));
+  assert.equal(meta.target, "linux");
+  assert.equal(meta.preparedOn, process.platform);
+  assert.equal(meta.revision, git("rev-parse", "HEAD").toString().trim());
+  assert.equal(meta.dirty, true);
+  await writeFile(join(packet, "ACCEPTANCE.md"), "reviewer edits");
+  await assert.rejects(createPacket("linux-paths", { repoRoot: root }), {
+    code: "EEXIST",
+  });
+  assert.equal(
+    await readFile(join(packet, "ACCEPTANCE.md"), "utf8"),
+    "reviewer edits",
+  );
+  await assert.rejects(
+    createPacket("../outside", { repoRoot: root }),
+    /lowercase/,
+  );
+  await assert.rejects(
+    createPacket("bad-platform", { repoRoot: root, target: "unknown" }),
+    /Target/,
+  );
+});
+
+test("generated packet runs on its target, resumes edits, and rejects a different platform", async (t) => {
+  const { root } = await fixture(t);
+  const git = (...args) =>
+    execFileSync("git", args, { cwd: root, stdio: "pipe", windowsHide: true });
+  git("init");
+  git(
+    "-c",
+    "user.name=Test",
+    "-c",
+    "user.email=test@example.invalid",
+    "commit",
+    "--allow-empty",
+    "-m",
+    "test",
+  );
+  await mkdir(join(root, "scripts/acceptance"), { recursive: true });
+  await mkdir(join(root, "apps/rgsm-gui/e2e/support"), { recursive: true });
+  await copyFile(
+    new URL("./session.mjs", import.meta.url),
+    join(root, "scripts/acceptance/session.mjs"),
+  );
+  await copyFile(
+    new URL("../../apps/rgsm-gui/e2e/support/process.ts", import.meta.url),
+    join(root, "apps/rgsm-gui/e2e/support/process.ts"),
+  );
+  const packet = await createPacket("local-progress", { repoRoot: root });
+  const run = (path) =>
+    execFileSync(process.execPath, [join(path, "run.mjs")], {
+      encoding: "utf8",
+      windowsHide: true,
+      stdio: "pipe",
+    });
+  assert.match(run(packet), /no application was started/);
+  await writeFile(join(packet, "data/progress.txt"), "modified in acceptance");
+  run(packet);
+  assert.equal(
+    await readFile(join(packet, "data/progress.txt"), "utf8"),
+    "modified in acceptance",
+  );
+  const other = process.platform === "linux" ? "win32" : "linux";
+  const foreign = await createPacket("other-platform", {
+    repoRoot: root,
+    target: other,
+  });
+  assert.throws(() => run(foreign), /Run this packet on/);
+  await assert.rejects(access(join(foreign, "data/.prepared")), {
+    code: "ENOENT",
+  });
+});

--- a/scripts/acceptance/acceptance.test.mjs
+++ b/scripts/acceptance/acceptance.test.mjs
@@ -266,6 +266,27 @@ test("packet generator records provenance, rejects traversal and never overwrite
     createPacket("bad-platform", { repoRoot: root, target: "unknown" }),
     /Target/,
   );
+  const example = await createPacket("cloud-example", {
+    repoRoot: root,
+    target: "win32",
+    example: true,
+  });
+  const recipe = await readFile(join(example, "run.mjs"), "utf8");
+  assert.match(recipe, /cloud-fixture\.ts/);
+  assert.match(recipe, /startExampleDevice/);
+  assert.doesNotMatch(recipe, /__[A-Z_]+__/);
+  assert.match(
+    await readFile(join(example, "ACCEPTANCE.md"), "utf8"),
+    /Not run/,
+  );
+  await assert.rejects(
+    createPacket("unsupported-example", {
+      repoRoot: root,
+      target: "linux",
+      example: true,
+    }),
+    /win32/,
+  );
 });
 
 test("generated packet runs on its target, resumes edits, and rejects a different platform", async (t) => {

--- a/scripts/acceptance/create.mjs
+++ b/scripts/acceptance/create.mjs
@@ -8,15 +8,15 @@ const repository = resolve(scriptDir, "../..");
 
 export async function createPacket(
   name,
-  { repoRoot = repository, target = process.platform } = {},
+  { repoRoot = repository, target = process.platform, example = false } = {},
 ) {
   if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name ?? "")) {
-    throw new Error(
-      "Use a lowercase packet name, for example linux-save-paths",
-    );
+    throw new Error("Use a lowercase packet name, for example save-restore");
   }
   if (!["linux", "win32", "darwin"].includes(target))
     throw new Error("Target must be linux, win32 or darwin");
+  if (example && target !== "win32")
+    throw new Error("The runnable example currently targets win32");
   const root = join(repoRoot, ".rgsm-dev", "acceptance", name);
   await mkdir(dirname(root), { recursive: true });
   // Never overwrite an earlier acceptance session, including reviewer edits.
@@ -40,18 +40,33 @@ export async function createPacket(
     join(root, "session.json"),
     JSON.stringify(metadata, null, 2) + "\n",
   );
-  const runtime = relative(
-    root,
-    join(repoRoot, "scripts", "acceptance", "session.mjs"),
-  ).replaceAll("\\", "/");
-  const starter = await readFile(join(scriptDir, "run.template.mjs"), "utf8");
+  const modulePath = (path) =>
+    relative(root, join(repoRoot, path)).replaceAll("\\", "/");
+  const starter = await readFile(
+    join(scriptDir, example ? "run.example.mjs" : "run.template.mjs"),
+    "utf8",
+  );
   await writeFile(
     join(root, "run.mjs"),
-    starter.replace("__SESSION_MODULE__", runtime),
+    starter
+      .replace(
+        "__SESSION_MODULE__",
+        modulePath("scripts/acceptance/session.mjs"),
+      )
+      .replace(
+        "__FIXTURE_MODULE__",
+        modulePath("apps/rgsm-gui/e2e/support/cloud-fixture.ts"),
+      )
+      .replace(
+        "__EXAMPLE_MODULE__",
+        modulePath("apps/rgsm-gui/scripts/acceptance/example.mjs"),
+      ),
   );
   await writeFile(
     join(root, "ACCEPTANCE.md"),
-    await readFile(join(scriptDir, "packet.template.md")),
+    await readFile(
+      join(scriptDir, example ? "example.md" : "packet.template.md"),
+    ),
   );
   await mkdir(join(root, "evidence"));
   return root;
@@ -61,11 +76,15 @@ if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(resolve(process.argv[1])).href
 ) {
-  const [name, target, ...extra] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const example = args.includes("--example");
+  const [name, target, ...extra] = args.filter((arg) => arg !== "--example");
   try {
     if (extra.length || !name)
-      throw new Error("Usage: pnpm acceptance:new <name> [linux|win32|darwin]");
-    console.log(await createPacket(name, { target }));
+      throw new Error(
+        "Usage: pnpm acceptance:new <name> [linux|win32|darwin] [--example]",
+      );
+    console.log(await createPacket(name, { target, example }));
     console.log(
       "Scaffold only: adapt ACCEPTANCE.md and run.mjs before offering this packet for review",
     );

--- a/scripts/acceptance/create.mjs
+++ b/scripts/acceptance/create.mjs
@@ -1,0 +1,76 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repository = resolve(scriptDir, "../..");
+
+export async function createPacket(
+  name,
+  { repoRoot = repository, target = process.platform } = {},
+) {
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(name ?? "")) {
+    throw new Error(
+      "Use a lowercase packet name, for example linux-save-paths",
+    );
+  }
+  if (!["linux", "win32", "darwin"].includes(target))
+    throw new Error("Target must be linux, win32 or darwin");
+  const root = join(repoRoot, ".rgsm-dev", "acceptance", name);
+  await mkdir(dirname(root), { recursive: true });
+  // Never overwrite an earlier acceptance session, including reviewer edits.
+  await mkdir(root);
+  const git = (...args) =>
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      windowsHide: true,
+    }).trim();
+  const metadata = {
+    kind: "rgsm-acceptance",
+    name,
+    revision: git("rev-parse", "HEAD"),
+    dirty: Boolean(git("status", "--porcelain", "--untracked-files=normal")),
+    preparedOn: process.platform,
+    target,
+    createdAt: new Date().toISOString(),
+  };
+  await writeFile(
+    join(root, "session.json"),
+    JSON.stringify(metadata, null, 2) + "\n",
+  );
+  const runtime = relative(
+    root,
+    join(repoRoot, "scripts", "acceptance", "session.mjs"),
+  ).replaceAll("\\", "/");
+  const starter = await readFile(join(scriptDir, "run.template.mjs"), "utf8");
+  await writeFile(
+    join(root, "run.mjs"),
+    starter.replace("__SESSION_MODULE__", runtime),
+  );
+  await writeFile(
+    join(root, "ACCEPTANCE.md"),
+    await readFile(join(scriptDir, "packet.template.md")),
+  );
+  await mkdir(join(root, "evidence"));
+  return root;
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(resolve(process.argv[1])).href
+) {
+  const [name, target, ...extra] = process.argv.slice(2);
+  try {
+    if (extra.length || !name)
+      throw new Error("Usage: pnpm acceptance:new <name> [linux|win32|darwin]");
+    console.log(await createPacket(name, { target }));
+    console.log(
+      "Scaffold only: adapt ACCEPTANCE.md and run.mjs before offering this packet for review",
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/acceptance/example.md
+++ b/scripts/acceptance/example.md
@@ -1,0 +1,35 @@
+# A/B cloud and text example
+
+Editable starting point, not a required scenario catalog or a completed acceptance
+About 5 minutes once the environment is ready · Windows · HTTP-only host + built web GUI
+Does not cover desktop windows/tray, packaging, Linux, WebDAV or S3
+
+## Start and initial state
+
+Run `node .rgsm-dev/acceptance/<name>/run.mjs` from this checkout (Node 24, pnpm dependencies and Rust toolchain required)
+The first build may take longer; subsequent launches reuse Cargo's incremental output
+No windows open automatically · open the printed A/B GUI and text-panel links yourself
+
+Both devices have **Echo Keep**, no snapshots, different text saves, and the same empty local Fs cloud
+Use the panel to simulate playing by editing a file and to read the actual result of restoring it
+The launcher does not create a cloud library, snapshots, or transfer/restore them for you
+
+## Example journey — trim or replace for the actual change
+
+1. A: open Sync settings and create the cloud library, then open Echo Keep and create a snapshot named `A checkpoint`
+   Expected: the snapshot appears locally and in the cloud (use Upload if the transfer has not completed)
+2. B: open Sync settings and connect if prompted, then open Echo Keep, download `A checkpoint` and apply it
+   Expected: reading B's file in its panel shows `A: starting progress`, while A is unchanged
+3. B: write `B: new progress` in its panel, create/upload another snapshot in RGSM, then download/apply it on A
+   Expected: A's panel reads `B: new progress`; earlier snapshots remain selectable
+4. Stop using either panel's **Stop entire session** button or Ctrl+C, then run the same launcher
+   Expected: new links open the same saved progress and snapshot history, not a reset baseline
+
+For a fresh baseline generate a differently named packet; do not delete or reseed the current one
+`session.json` describes packet creation; `evidence/runtime.json` records the launch revision/artifact and dirty files
+Local logs/configuration can contain runtime credentials — do not paste them into issues
+
+## Result
+
+Not run · record step, observed result and useful screenshots under `evidence/`
+Keep automated setup checks, human results and untested environments separate

--- a/scripts/acceptance/packet.template.md
+++ b/scripts/acceptance/packet.template.md
@@ -1,0 +1,36 @@
+# Acceptance proposal
+
+Not ready for review until adapted to the actual change
+
+## Purpose and environment
+
+Describe the changed user journey, why manual acceptance adds value, required platform,
+estimated effort, and whether the frontend is development, built web output, or desktop
+Record the tested revision and dirty-tree caveat from session.json; refresh this evidence
+if the source or binary changes before the reviewer runs it
+
+## Preparation and entry point
+
+Explain the artificial initial state and how to start the prepared run.mjs from the repository
+Name any requirements the reviewer must provide; do not claim unavailable platforms were tested
+The generated script only seeds an example text file until it has been adapted
+
+## Actions and expected results
+
+Write a few numbered actions in user terms, pairing each with an observable result
+Identify device A/B and expected file contents only when the scenario needs them
+Keep setup out of the reviewer's steps; do not repeat assertions already covered adequately by CI
+
+## Stop and continue
+
+Ctrl+C stops processes owned by the launcher; the session data and evidence remain
+Run the same script to continue, not to reset
+For a fresh baseline create a new named packet; do not overwrite the reviewer's current session
+
+## Result
+
+Not run
+
+Record environment, step, actual result, and useful screenshots under evidence/
+Separate automatic preparation checks from human results and untested boundaries
+Do not include runtime tokens, personal saves, or cloud credentials

--- a/scripts/acceptance/packet.template.md
+++ b/scripts/acceptance/packet.template.md
@@ -1,5 +1,7 @@
 # Acceptance proposal
 
+Suggested outline, not a required format; delete sections that do not help this change
+
 Not ready for review until adapted to the actual change
 
 ## Purpose and environment
@@ -19,7 +21,7 @@ The generated script only seeds an example text file until it has been adapted
 
 Write a few numbered actions in user terms, pairing each with an observable result
 Identify device A/B and expected file contents only when the scenario needs them
-Keep setup out of the reviewer's steps; do not repeat assertions already covered adequately by CI
+Keep setup out of the reviewer's steps; overlap with automated tests is fine when useful for human judgment
 
 ## Stop and continue
 

--- a/scripts/acceptance/run.example.mjs
+++ b/scripts/acceptance/run.example.mjs
@@ -1,0 +1,42 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { withSession } from "__SESSION_MODULE__";
+import {
+  seedEmptyCloudWithLocalGame,
+  deviceLayout,
+  writeSave,
+} from "__FIXTURE_MODULE__";
+import { buildExample, startExampleDevice } from "__EXAMPLE_MODULE__";
+
+await withSession(import.meta.url, async (session) => {
+  if (process.platform !== "win32" || session.metadata.target !== "win32") {
+    throw new Error(
+      "This example is verified on Windows only; it does not provision other platforms",
+    );
+  }
+  const artifacts = await buildExample(session);
+  await session.prepare(async ({ dataDir }) => {
+    // Freely replace the seed/assets for the change. Do not pre-execute the acceptance actions.
+    const { deviceA, deviceB } = await seedEmptyCloudWithLocalGame(dataDir);
+    await writeSave(deviceA, "A: starting progress\n");
+    await writeSave(deviceB, "B: starting progress\n");
+  });
+  const entries = [];
+  // Delete 'b' for a one-device journey; fixture layout is stable across restarts.
+  for (const key of ["a", "b"]) {
+    const device = deviceLayout(session.dataDir, key);
+    const entry = await startExampleDevice(session, device, artifacts);
+    entries.push(entry);
+    console.log(
+      `${entry.name}\n  GUI: ${entry.gui}\n  Text panel: ${entry.panel}`,
+    );
+  }
+  await writeFile(
+    join(session.root, "entrypoints.json"),
+    JSON.stringify(entries, null, 2) + "\n",
+  );
+  console.log(
+    "Ready for manual use; no acceptance result has been recorded. Ctrl+C stops this session and preserves data.",
+  );
+  await session.wait();
+});

--- a/scripts/acceptance/run.template.mjs
+++ b/scripts/acceptance/run.template.mjs
@@ -1,0 +1,29 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { withSession } from "__SESSION_MODULE__";
+
+// Replace this seed with the artificial files/configuration needed for this change.
+// Keep setup separate from the actions the reviewer is meant to perform in RGSM.
+await withSession(import.meta.url, async (session) => {
+  if (process.platform !== session.metadata.target) {
+    throw new Error(
+      `Run this packet on ${session.metadata.target}; current platform is ${process.platform}`,
+    );
+  }
+  await session.prepare(async ({ dataDir }) => {
+    await writeFile(
+      join(dataDir, "progress.txt"),
+      "artificial starting progress\n",
+      { flag: "wx" },
+    );
+  });
+
+  // Add the task-specific launcher here. For long-running processes:
+  // session.start(command, args, { cwd, env });
+  // await an actual readiness check, then print the reviewer entry point
+  // await session.wait(); // Ctrl+C stops owned processes and retains data
+  console.log(`Fixture directory: ${session.dataDir}`);
+  console.log(
+    "Scaffold only: no application was started and no acceptance has been performed",
+  );
+});

--- a/scripts/acceptance/session.mjs
+++ b/scripts/acceptance/session.mjs
@@ -1,0 +1,140 @@
+import {
+  mkdir,
+  readFile,
+  realpath,
+  lstat,
+  rmdir,
+  writeFile,
+} from "node:fs/promises";
+import { createWriteStream } from "node:fs";
+import { finished } from "node:stream/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  spawnTestProcess,
+  closeResources,
+} from "../../apps/rgsm-gui/e2e/support/process.ts";
+
+async function directory(path) {
+  await mkdir(path, { recursive: true });
+  if ((await lstat(path)).isSymbolicLink())
+    throw new Error(`Session directory is a link: ${path}`);
+  return path;
+}
+
+/** Run trusted, task-specific setup without deleting its data or rediscovering saved PIDs. */
+export async function withSession(entryUrl, run) {
+  const root = await realpath(dirname(fileURLToPath(entryUrl)));
+  const metadata = JSON.parse(
+    await readFile(join(root, "session.json"), "utf8"),
+  );
+  if (metadata.kind !== "rgsm-acceptance")
+    throw new Error("Not an acceptance packet");
+  const lock = join(root, ".running");
+  try {
+    await mkdir(lock);
+  } catch (error) {
+    if (error.code === "EEXIST") {
+      throw new Error(
+        "Session already running; after an interrupted process, confirm it stopped before removing .running",
+      );
+    }
+    throw error;
+  }
+  const closers = [];
+  const wake = Promise.withResolvers();
+  const controller = new AbortController();
+  const { signal } = controller;
+  let stopping = false;
+  let childError;
+  const requestStop = () => {
+    stopping = true;
+    controller.abort(new DOMException("Session stopped", "AbortError"));
+    wake.resolve();
+  };
+  const fail = (error) => {
+    if (stopping) return;
+    childError ??= error;
+    controller.abort(childError);
+    wake.resolve();
+  };
+  process.once("SIGINT", requestStop);
+  process.once("SIGTERM", requestStop);
+  try {
+    const dataDir = await directory(join(root, "data"));
+    const logsDir = await directory(join(root, "logs"));
+    const evidenceDir = await directory(join(root, "evidence"));
+    const context = { root, dataDir, logsDir, evidenceDir, metadata, signal };
+    await run({
+      ...context,
+      defer(close) {
+        closers.push(close);
+      },
+      async prepare(seed) {
+        signal.throwIfAborted();
+        const marker = join(dataDir, ".prepared");
+        try {
+          await readFile(marker);
+          return;
+        } catch (error) {
+          if (error.code !== "ENOENT") throw error;
+        }
+        await seed(context);
+        signal.throwIfAborted();
+        await writeFile(
+          marker,
+          "Prepared by run.mjs; restart preserves this data\n",
+          { flag: "wx" },
+        );
+      },
+      start(command, args = [], options = {}) {
+        signal.throwIfAborted();
+        const log = createWriteStream(
+          join(logsDir, `process-${closers.length}.log`),
+          { flags: "a" },
+        );
+        const logFinished = finished(log);
+        // Attach immediately; stream errors must not become unhandled rejections.
+        logFinished.catch(fail);
+        let owned;
+        closers.push(async () => {
+          try {
+            await owned?.stop();
+          } finally {
+            log.end();
+            await logFinished;
+          }
+        });
+        owned = spawnTestProcess(command, args, {
+          cwd: root,
+          ...options,
+        });
+        owned.child.stdout.pipe(log, { end: false });
+        owned.child.stderr.pipe(log, { end: false });
+        const failed = () => {
+          fail(owned.failure() ?? new Error("Session service exited"));
+        };
+        owned.child.once("error", failed);
+        owned.child.once("exit", failed);
+        return owned.child;
+      },
+      async wait() {
+        await wake.promise;
+        if (childError) throw childError;
+      },
+      stop: requestStop,
+    });
+    if (childError) throw childError;
+  } catch (error) {
+    if (childError) throw childError;
+    if (!(stopping && signal.aborted && error.name === "AbortError"))
+      throw error;
+  } finally {
+    stopping = true;
+    process.removeListener("SIGINT", requestStop);
+    process.removeListener("SIGTERM", requestStop);
+    // Retain the lock if cleanup fails: another launcher must not silently overlap it.
+    await closeResources(closers);
+    await rmdir(lock);
+  }
+}


### PR DESCRIPTION
Add optional acceptance packets and an editable A/B example with a local test cloud and text-save controls. Sessions own their services and preserve reviewer changes on restart.

Refs #546
