### PR TITLE
fix(registry): restore archived values to current device targets

### DIFF
--- a/apps/rgsm-gui/e2e/local-registry-target.spec.ts
+++ b/apps/rgsm-gui/e2e/local-registry-target.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { DEVICE_A_ID, GAME_NAME } from './support/constants';
+import { seedLocalConfig } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+import { createSnapshotForGame, getLocalGame } from './support/local-gui';
+import { openGame, snapshotRow, expectActivity } from './support/gui';
+import { createRunRoot } from './support/rgsm-instance';
+
+test('registry Apply follows the edited target; a missing target is saved with a warning', async ({
+  browser,
+}) => {
+  test.skip(process.platform !== 'win32', 'Windows registry integration');
+  const owned = `HKEY_CURRENT_USER\\Software\\RGSM_TEST_${randomUUID()}`;
+  const original = `${owned}\\OldName`;
+  const target = `${owned}\\NewName`;
+  const registry = (...args: string[]) =>
+    execFileSync('reg.exe', args, { windowsHide: true, encoding: 'utf8' });
+  const runRoot = await createRunRoot('registry-target');
+  const device = await seedLocalConfig(runRoot, {
+    games: [{ name: GAME_NAME, units: [{ type: 'WinRegistry', path: original }] }],
+    settings: { extra_backup_when_apply: false },
+  });
+  registry('add', original, '/v', 'Progress', '/d', 'saved-progress', '/f');
+  let failed = false;
+  let session: Awaited<ReturnType<typeof startLocalSession>> | undefined;
+  try {
+    session = await startLocalSession(browser, { runRoot, device, label: 'registry-target' });
+    const { page, host } = session;
+    const snapshot = await createSnapshotForGame(host, GAME_NAME, 'registry snapshot');
+    registry('add', original, '/v', 'Progress', '/d', 'live-original', '/f');
+    await openGame(page);
+    await page.getByRole('button', { name: 'View managed files' }).click();
+    const drawer = page.getByRole('dialog');
+    await drawer.locator('.pvi-editor').last().fill(target);
+    await drawer.getByRole('button', { name: 'save', exact: true }).click();
+    await expectActivity(
+      page,
+      'Some save locations are unavailable on this device; the configuration can still be saved'
+    );
+    await expect
+      .poll(async () => {
+        const unit = (await getLocalGame(host, GAME_NAME)).save_paths[0];
+        return unit?.source.type === 'concrete' ? unit.source.paths[DEVICE_A_ID] : undefined;
+      })
+      .toBe(target);
+    await snapshotRow(page, snapshot).getByRole('button', { name: 'Apply' }).click();
+    await expect
+      .poll(() => {
+        try {
+          return registry('query', target, '/v', 'Progress');
+        } catch {
+          return '';
+        }
+      })
+      .toContain('saved-progress');
+    expect(registry('query', original, '/v', 'Progress')).toContain('live-original');
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await session?.close(failed);
+    // Only this test's freshly generated subtree is owned by the test.
+    registry('delete', owned, '/f');
+  }
+});

--- a/apps/rgsm-gui/e2e/support/local-fixture.ts
+++ b/apps/rgsm-gui/e2e/support/local-fixture.ts
@@ -4,7 +4,7 @@ import { DEVICE_A_ID, DEVICE_A_NAME, GAME_NAME } from './constants';
 import { deviceLayout, type DeviceLayout } from './cloud-fixture';
 
 export type LocalUnitSeed = {
-  type: 'File' | 'Folder';
+  type: 'File' | 'Folder' | 'WinRegistry';
   /** Absolute path for the current device. */
   path: string;
   deleteBeforeApply?: boolean;

--- a/apps/rgsm-gui/src/api/generated/types.gen.ts
+++ b/apps/rgsm-gui/src/api/generated/types.gen.ts
@@ -929,6 +929,10 @@ export type PathCheckResult =
     }
   | {
       /**
+       * Optional portable spelling for this process's own user, never another SID.
+       */
+      currentUserPath?: string | null;
+      /**
        * Whether the registry key exists (always `false` on non-Windows).
        */
       exists: boolean;

--- a/apps/rgsm-gui/src/components/AddGameDrawer.vue
+++ b/apps/rgsm-gui/src/components/AddGameDrawer.vue
@@ -20,11 +20,13 @@ import GameBatchImportDialog from './GameBatchImportDialog.vue';
 import { KAlert, KButton, KDrawer, KInput, KTag, KTagInput } from '../ui/kit';
 import { concreteSaveUnit, manifestSaveUnit, saveUnitPaths, saveUnitType } from '../utils/saveUnit';
 import { useAddGameDrawer } from '../composables/useAddGameDrawer';
+import { useSaveLocationCheck } from '../composables/useSaveLocationCheck';
 import { createGameFavorite, collectFavoriteGameIds } from './favoriteTreeContext';
 import { hasGameNameConflict } from '../utils/gameName';
 import { resolveGameReference } from '../utils/appRoutes';
 
 const feedback = useFeedback();
+const { warnUnavailableLocations } = useSaveLocationCheck();
 const { config, refreshConfig, saveConfig } = useConfig();
 const { visible, editGameName, close } = useAddGameDrawer();
 
@@ -256,15 +258,6 @@ async function add_registry_key() {
     const path = result.value?.trim();
     if (!path) return;
     if (!check_save_unit_unique(path)) return;
-
-    // Validate registry path on current platform
-    const checkResult = await commands.checkPaths([path], null, null, null);
-    if (checkResult.status === 'ok') {
-      const [check] = checkResult.data;
-      if (check && check.status === 'registryPath' && !check.supported) {
-        notifyWarning($t('addgame.registry_non_windows_warning'));
-      }
-    }
 
     save_paths.push(generate_save_unit('WinRegistry', path));
   } catch {
@@ -767,6 +760,10 @@ async function save() {
   if (hasGameNameConflict(config.value.games, game_name.value, editingGame.value)) {
     notifyError($t('addgame.duplicated_name_error'));
     return;
+  }
+
+  if (currentDevice.value) {
+    await warnUnavailableLocations(save_paths, currentDevice.value.id);
   }
 
   const game: GameDraft = {

--- a/apps/rgsm-gui/src/components/PathVariableInput.vue
+++ b/apps/rgsm-gui/src/components/PathVariableInput.vue
@@ -3,7 +3,7 @@ import { ref, watch, onMounted, onUnmounted, nextTick, computed } from 'vue';
 import { $t } from '../i18n';
 import { commands } from '../api/commands';
 import { LAYER } from '../ui/layers';
-import { KTooltip } from '../ui/kit';
+import { KButton, KTooltip } from '../ui/kit';
 
 type PathStatus = 'idle' | 'resolving' | 'ok' | 'not-found' | 'error';
 
@@ -448,11 +448,19 @@ defineExpose({ insertAtCursor });
 
 const pathStatus = ref<PathStatus>('idle');
 const resolvedPathText = ref('');
+const currentUserPath = ref<string | null>(null);
 let resolveTimer: ReturnType<typeof setTimeout> | null = null;
+let resolveGeneration = 0;
 
 function scheduleResolve(path: string) {
-  if (effectiveStatusMode.value === 'none') return;
+  const generation = ++resolveGeneration;
+  currentUserPath.value = null;
   if (resolveTimer) clearTimeout(resolveTimer);
+  if (effectiveStatusMode.value === 'none') {
+    pathStatus.value = 'idle';
+    resolvedPathText.value = '';
+    return;
+  }
 
   if (!path) {
     pathStatus.value = 'idle';
@@ -471,7 +479,7 @@ function scheduleResolve(path: string) {
         props.steamId
       );
       // Guard against stale responses
-      if (path !== props.modelValue) return;
+      if (generation !== resolveGeneration || path !== props.modelValue) return;
       if (result.status === 'error') {
         resolvedPathText.value = result.error;
         pathStatus.value = 'error';
@@ -496,6 +504,7 @@ function scheduleResolve(path: string) {
           pathStatus.value = 'error';
           break;
         case 'registryPath':
+          currentUserPath.value = check.currentUserPath ?? null;
           if (check.supported) {
             resolvedPathText.value = check.rawPath;
             pathStatus.value = check.exists ? 'ok' : 'not-found';
@@ -506,7 +515,7 @@ function scheduleResolve(path: string) {
           break;
       }
     } catch {
-      if (path !== props.modelValue) return;
+      if (generation !== resolveGeneration || path !== props.modelValue) return;
       pathStatus.value = 'error';
       resolvedPathText.value = '';
     }
@@ -530,6 +539,7 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  resolveGeneration += 1;
   window.removeEventListener('scroll', onWindowScroll, true);
   if (resolveTimer) clearTimeout(resolveTimer);
 });
@@ -545,7 +555,12 @@ watch(
 );
 
 watch(
-  () => [props.storeUserId, props.steamId, props.installDirs.join('\u0000')],
+  () => [
+    props.storeUserId,
+    props.steamId,
+    props.installDirs.join('\u0000'),
+    effectiveStatusMode.value,
+  ],
   () => {
     scheduleResolve(props.modelValue);
   }
@@ -592,6 +607,15 @@ watch(
     >
       <span class="pvi-status-dot" />
       <span class="pvi-status-text">{{ resolvedPathText }}</span>
+    </div>
+    <div
+      v-if="currentUserPath && effectiveStatusMode !== 'none'"
+      class="mt-1 text-xs text-text-muted"
+    >
+      {{ $t('path_variable.current_user_hint') }}
+      <KButton size="sm" @click="emit('update:modelValue', currentUserPath)">
+        {{ $t('path_variable.use_current_user') }}
+      </KButton>
     </div>
   </div>
 

--- a/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
+++ b/apps/rgsm-gui/src/components/SaveLocationDrawer.vue
@@ -12,6 +12,7 @@ import type {
 } from '../api/commands';
 import { commands } from '../api/commands';
 import { useConfig } from '../composables/useConfig';
+import { useSaveLocationCheck } from '../composables/useSaveLocationCheck';
 import { usePathResolution } from '../composables/usePathResolution';
 import PathVariableInput from './PathVariableInput.vue';
 import ResourceMultiSelect from './ResourceMultiSelect.vue';
@@ -21,6 +22,7 @@ import { KAlert, KButton, KDrawer, KInput, KSelect, KSwitch, KTag, KTooltip } fr
 
 const { config } = useConfig();
 const feedback = useFeedback();
+const { warnUnavailableLocations } = useSaveLocationCheck();
 const { resourceLabel } = usePathResolution();
 
 const props = defineProps<{
@@ -294,7 +296,7 @@ function switchDeleteBeforeApply(_unit: SaveUnit) {
   hasUnsavedChanges.value = true;
 }
 
-function saveChanges() {
+async function saveChanges() {
   const trimmedName = tempGame.value.name.trim();
   if (!trimmedName) {
     notifyError($t('addgame.no_name_error'));
@@ -307,6 +309,9 @@ function saveChanges() {
   }
 
   tempGame.value.name = trimmedName;
+  if (currentDevice.value) {
+    await warnUnavailableLocations(tempGame.value.save_paths, currentDevice.value.id);
+  }
   emits('saveChanges', JSON.parse(JSON.stringify(tempGame.value)));
   hasUnsavedChanges.value = false;
 }
@@ -392,18 +397,6 @@ async function addSaveFile() {
   }
 }
 
-async function validateRegistryPath(path: string) {
-  const checkResult = await commands.checkPaths([path], null, null, null);
-  if (checkResult.status !== 'ok') {
-    return;
-  }
-
-  const [check] = checkResult.data;
-  if (check && check.status === 'registryPath' && !check.supported) {
-    notifyWarning($t('addgame.registry_non_windows_warning'));
-  }
-}
-
 async function promptRegistryPath(initialValue = '') {
   try {
     const result = await feedback.prompt(
@@ -427,7 +420,6 @@ async function addRegistryKey() {
     return;
   }
 
-  await validateRegistryPath(path);
   tempGame.value.save_paths.push(createSaveUnit('WinRegistry', path));
   hasUnsavedChanges.value = true;
 }
@@ -453,7 +445,6 @@ async function chooseUnitPath(unit: SaveUnit) {
       return;
     }
 
-    await validateRegistryPath(path);
     updateDevicePath(unit, selectedDeviceId.value, path);
     return;
   }
@@ -643,7 +634,7 @@ async function handleOpenPath(e: MouseEvent, path: string, unit?: SaveUnit) {
         </div>
         <PathVariableInput
           :model-value="getGameLaunchPath(selectedDeviceId)"
-          status-mode="below"
+          :status-mode="selectedDeviceId === currentDevice?.id ? 'below' : 'none'"
           @update:model-value="updateGameLaunchPath(selectedDeviceId, String($event ?? ''))"
         />
       </section>
@@ -713,7 +704,7 @@ async function handleOpenPath(e: MouseEvent, path: string, unit?: SaveUnit) {
 
           <PathVariableInput
             :model-value="getDevicePath(unit, selectedDeviceId)"
-            status-mode="tooltip"
+            :status-mode="selectedDeviceId === currentDevice?.id ? 'tooltip' : 'none'"
             @update:model-value="updateDevicePath(unit, selectedDeviceId, String($event ?? ''))"
           />
 
@@ -791,7 +782,7 @@ async function handleOpenPath(e: MouseEvent, path: string, unit?: SaveUnit) {
 
             <PathVariableInput
               :model-value="getDevicePath(unit, selectedDeviceId)"
-              status-mode="tooltip"
+              :status-mode="selectedDeviceId === currentDevice?.id ? 'tooltip' : 'none'"
               @update:model-value="updateDevicePath(unit, selectedDeviceId, String($event ?? ''))"
             />
 

--- a/apps/rgsm-gui/src/composables/useSaveLocationCheck.ts
+++ b/apps/rgsm-gui/src/composables/useSaveLocationCheck.ts
@@ -1,0 +1,40 @@
+import { commands, type SaveUnit, type SaveUnitDraft } from '../api/commands';
+import { $t } from '../i18n';
+import { notifyWarning } from './useActivityCenter';
+
+/** Availability is a warning, not a condition for saving device configuration. */
+export function useSaveLocationCheck() {
+  async function warnUnavailableLocations(
+    units: (SaveUnit | SaveUnitDraft)[],
+    deviceId: string
+  ): Promise<void> {
+    const paths = units.flatMap((unit) => {
+      if (unit.enabled === false || unit.source.type !== 'concrete') return [];
+      const path = unit.source.paths?.[deviceId]?.trim();
+      return path ? [path] : [];
+    });
+    if (!paths.length) return;
+    try {
+      const result = await commands.checkPaths(paths, null, null, null);
+      if (result.status === 'error') {
+        notifyWarning($t('path_variable.check_unavailable'));
+        return;
+      }
+      const details = result.data.flatMap((check) => {
+        if (check.status === 'ok') return [];
+        if (check.status === 'registryPath' && check.supported && check.exists) return [];
+        const reason =
+          check.status === 'resolveFailed'
+            ? check.error
+            : check.status === 'registryPath' && !check.supported
+              ? $t('path_variable.registry_not_supported')
+              : $t('path_variable.not_found');
+        return [`${check.rawPath}: ${reason}`];
+      });
+      if (details.length) notifyWarning($t('path_variable.saved_unavailable'), details.join('\n'));
+    } catch {
+      notifyWarning($t('path_variable.check_unavailable'));
+    }
+  }
+  return { warnUnavailableLocations };
+}

--- a/crates/rgsm-core/Cargo.toml
+++ b/crates/rgsm-core/Cargo.toml
@@ -54,7 +54,7 @@ uuid.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg.workspace = true
-windows-sys.workspace = true
+windows-sys = { workspace = true, features = ["Win32_Security", "Win32_Security_Authorization", "Win32_System_Threading"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc.workspace = true

--- a/crates/rgsm-core/src/backup/archive/decompress.rs
+++ b/crates/rgsm-core/src/backup/archive/decompress.rs
@@ -290,7 +290,7 @@ fn restore_registry_capture(
     let data = crate::backup::registry::deserialize_reg_file(&bytes).map_err(|error| {
         CompressError::Single(BackupFileError::RegistryError(error.to_string()))
     })?;
-    crate::backup::registry::import_registry_data(&data)
+    crate::backup::registry::import_registry_data(&data, &entry.target_path.to_string_lossy())
         .map_err(|error| CompressError::Single(BackupFileError::RegistryError(error.to_string())))
 }
 
@@ -503,6 +503,7 @@ fn restore_registry_unit(
     unit: &SaveUnit,
     version: ArchiveVersion,
     temp_root: &Path,
+    path_ctx: Option<&PathContext>,
 ) -> Result<RestoreOutcome, BackupFileError> {
     use crate::backup::registry;
 
@@ -528,7 +529,8 @@ fn restore_registry_unit(
             .map_err(|e| BackupFileError::Unexpected(e.into()))?
     };
 
-    match registry::import_registry_data(&reg_data) {
+    let target = unit.resolve_path_for_current_device(path_ctx)?;
+    match registry::import_registry_data(&reg_data, &target.to_string_lossy()) {
         Ok(()) => Ok(RestoreOutcome::Restored),
         Err(registry::RegistryError::UnsupportedPlatform) => {
             Ok(RestoreOutcome::Skipped(SkipReason::UnsupportedPlatform))
@@ -574,7 +576,7 @@ fn restore_save_unit_from_temp(
     path_ctx: Option<&PathContext>,
 ) -> Result<RestoreOutcome, BackupFileError> {
     if matches!(unit.unit_type(), Some(SaveUnitType::WinRegistry)) {
-        return restore_registry_unit(unit, version, temp_root);
+        return restore_registry_unit(unit, version, temp_root, path_ctx);
     }
 
     let unit_path = unit.resolve_path_for_current_device(path_ctx)?;

--- a/crates/rgsm-core/src/backup/archive/seven_z.rs
+++ b/crates/rgsm-core/src/backup/archive/seven_z.rs
@@ -251,8 +251,13 @@ pub(super) fn restore_capture_plan(plan: &RestorePlan, path: &Path) -> Result<()
                 source.read_to_end(&mut bytes)?;
                 let data = crate::backup::registry::deserialize_reg_file(&bytes)
                     .map_err(|error| sevenz_io(error.to_string()))?;
-                crate::backup::registry::import_registry_data(&data)
+                for (planned, _) in matches {
+                    crate::backup::registry::import_registry_data(
+                        &data,
+                        &planned.target_path.to_string_lossy(),
+                    )
                     .map_err(|error| sevenz_io(error.to_string()))?;
+                }
                 return Ok(true);
             }
 

--- a/crates/rgsm-core/src/backup/registry.rs
+++ b/crates/rgsm-core/src/backup/registry.rs
@@ -11,7 +11,11 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+#[cfg(any(windows, test))]
+mod current_user;
 mod reg_file;
+#[cfg(windows)]
+pub use current_user::suggest_current_user_path;
 
 pub use reg_file::{deserialize_reg_file, serialize_reg_file};
 
@@ -426,9 +430,10 @@ mod platform {
         }
     }
 
-    /// Import `RegistryData` back into the Windows Registry.
-    pub fn import_registry_data(data: &RegistryData) -> Result<(), RegistryError> {
-        let (hive, base_subkey) = parse_registry_path(&data.root_key)?;
+    /// Restore relative keys and values under an explicitly selected device target.
+    /// The archived root records origin only; value contents are never rewritten.
+    pub fn import_registry_data(data: &RegistryData, target: &str) -> Result<(), RegistryError> {
+        let (hive, base_subkey) = parse_registry_path(target)?;
         let root = RegKey::predef(hive);
 
         for entry in &data.entries {
@@ -459,7 +464,7 @@ mod platform {
         Err(RegistryError::UnsupportedPlatform)
     }
 
-    pub fn import_registry_data(_data: &RegistryData) -> Result<(), RegistryError> {
+    pub fn import_registry_data(_data: &RegistryData, _target: &str) -> Result<(), RegistryError> {
         Err(RegistryError::UnsupportedPlatform)
     }
 }
@@ -552,35 +557,41 @@ mod tests {
     #[cfg(target_os = "windows")]
     mod windows_tests {
         use super::*;
-        use std::sync::Mutex;
         use winreg::RegKey;
         use winreg::enums::*;
 
-        const TEST_KEY: &str = "HKEY_CURRENT_USER\\Software\\RGSM_TEST";
-        static TEST_MUTEX: Mutex<()> = Mutex::new(());
-
-        fn cleanup_test_key() {
-            let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-            let _ = hkcu.delete_subkey_all("Software\\RGSM_TEST");
+        struct TestKey(String);
+        impl TestKey {
+            fn path(&self) -> String {
+                format!("HKEY_CURRENT_USER\\{}", self.0)
+            }
+            fn clear(&self) {
+                let _ = RegKey::predef(HKEY_CURRENT_USER).delete_subkey_all(&self.0);
+            }
+        }
+        impl Drop for TestKey {
+            fn drop(&mut self) {
+                self.clear();
+            }
         }
 
-        fn setup_test_key() {
-            cleanup_test_key();
+        fn setup_test_key() -> TestKey {
+            let owned = TestKey(format!("Software\\RGSM_TEST_{}", uuid::Uuid::new_v4()));
             let hkcu = RegKey::predef(HKEY_CURRENT_USER);
-            let (key, _) = hkcu.create_subkey("Software\\RGSM_TEST").unwrap();
+            let (key, _) = hkcu.create_subkey(&owned.0).unwrap();
             key.set_value("TestString", &"hello").unwrap();
             key.set_value("TestDword", &42u32).unwrap();
-            let (child, _) = hkcu.create_subkey("Software\\RGSM_TEST\\Child").unwrap();
+            let (child, _) = key.create_subkey("Child").unwrap();
             child.set_value("ChildVal", &"world").unwrap();
+            owned
         }
 
         #[test]
         fn export_and_import_roundtrip() {
-            let _guard = TEST_MUTEX.lock().unwrap();
-            setup_test_key();
+            let owned = setup_test_key();
 
             // Export
-            let data = export_registry_key(TEST_KEY).unwrap();
+            let data = export_registry_key(&owned.path()).unwrap();
             assert_eq!(data.format_version, 1);
             assert!(!data.entries.is_empty());
 
@@ -594,27 +605,25 @@ mod tests {
             assert!(child_entry.values.iter().any(|v| matches!(v, RegistryValue::Sz { name, data } if name == "ChildVal" && data == "world")));
 
             // Clean and re-import
-            cleanup_test_key();
-            import_registry_data(&data).unwrap();
+            owned.clear();
+            import_registry_data(&data, &data.root_key).unwrap();
 
             // Verify re-imported data matches
-            let reimported = export_registry_key(TEST_KEY).unwrap();
+            let reimported = export_registry_key(&owned.path()).unwrap();
             assert_eq!(data.entries.len(), reimported.entries.len());
-
-            cleanup_test_key();
         }
 
         #[test]
         fn export_nonexistent_key_errors() {
-            let _guard = TEST_MUTEX.lock().unwrap();
-            let result =
-                export_registry_key("HKEY_CURRENT_USER\\Software\\RGSM_NONEXISTENT_KEY_12345");
+            let result = export_registry_key(&format!(
+                "HKEY_CURRENT_USER\\Software\\RGSM_TEST_{}",
+                uuid::Uuid::new_v4()
+            ));
             assert!(result.is_err());
         }
 
         #[test]
         fn parse_ludusavi_registry_prefix() {
-            let _guard = TEST_MUTEX.lock().unwrap();
             let (_, subkey) =
                 platform::parse_registry_path("REGISTRY:HKEY_CURRENT_USER/Software/Game").unwrap();
             assert_eq!(subkey, "Software\\Game");
@@ -622,11 +631,10 @@ mod tests {
 
         #[test]
         fn export_ludusavi_style_path_uses_normalized_subkey() {
-            let _guard = TEST_MUTEX.lock().unwrap();
-            setup_test_key();
-            let result = export_registry_key("REGISTRY:HKEY_CURRENT_USER/Software/RGSM_TEST");
+            let owned = setup_test_key();
+            let result =
+                export_registry_key(&format!("REGISTRY:{}", owned.path().replace('\\', "/")));
             assert!(result.is_ok());
-            cleanup_test_key();
         }
     }
 }

--- a/crates/rgsm-core/src/backup/registry/current_user.rs
+++ b/crates/rgsm-core/src/backup/registry/current_user.rs
@@ -1,0 +1,114 @@
+#[cfg(any(windows, test))]
+use super::normalize_registry_path;
+
+/// Offer a portable root only when the explicit SID belongs to this process.
+/// Never change another user's path or silently rewrite the saved value.
+#[cfg(windows)]
+pub fn suggest_current_user_path(path: &str) -> Option<String> {
+    let normalized = normalize_registry_path(path);
+    if !normalized.to_ascii_uppercase().starts_with("HKEY_USERS\\") {
+        return None;
+    }
+    portable_path(&normalized, &current_sid().ok()?)
+}
+
+#[cfg(any(windows, test))]
+fn portable_path(path: &str, current_sid: &str) -> Option<String> {
+    let normalized = normalize_registry_path(path);
+    let mut parts = normalized.splitn(3, '\\');
+    if !parts.next()?.eq_ignore_ascii_case("HKEY_USERS")
+        || !parts.next()?.eq_ignore_ascii_case(current_sid)
+    {
+        return None;
+    }
+    let subkey = parts.next()?.trim_start_matches('\\');
+    (!subkey.is_empty()).then(|| format!("HKEY_CURRENT_USER\\{subkey}"))
+}
+
+#[cfg(windows)]
+fn current_sid() -> std::io::Result<String> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle, OwnedHandle};
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::{
+            Authorization::ConvertSidToStringSidW, GetTokenInformation, TOKEN_QUERY, TOKEN_USER,
+            TokenUser,
+        },
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
+    };
+    // SAFETY: query only this process's token. OwnedHandle closes it on every
+    // return path; the aligned buffer remains alive while its SID is read.
+    unsafe {
+        let mut token = std::ptr::null_mut();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let token = OwnedHandle::from_raw_handle(token);
+        let mut length = 0;
+        GetTokenInformation(
+            token.as_raw_handle(),
+            TokenUser,
+            std::ptr::null_mut(),
+            0,
+            &mut length,
+        );
+        if length == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut buffer = vec![0usize; (length as usize).div_ceil(size_of::<usize>())];
+        if GetTokenInformation(
+            token.as_raw_handle(),
+            TokenUser,
+            buffer.as_mut_ptr().cast(),
+            length,
+            &mut length,
+        ) == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        let user = &*buffer.as_ptr().cast::<TOKEN_USER>();
+        let mut text = std::ptr::null_mut();
+        if ConvertSidToStringSidW(user.User.Sid, &mut text) == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut count = 0;
+        while *text.add(count) != 0 {
+            count += 1;
+        }
+        let sid = String::from_utf16_lossy(std::slice::from_raw_parts(text, count));
+        LocalFree(text.cast());
+        Ok(sid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn suggestion_matches_the_entire_sid_and_preserves_subkeys() {
+        assert_eq!(
+            portable_path(
+                "REGISTRY:HKEY_USERS/S-1-5-21-123/SOFTWARE/Game",
+                "S-1-5-21-123"
+            ),
+            Some("HKEY_CURRENT_USER\\SOFTWARE\\Game".into())
+        );
+        for path in [
+            "HKEY_USERS/S-1-5-21-1234/SOFTWARE/Game",
+            "HKEY_USERS/S-1-5-21-other/SOFTWARE/Game",
+            "HKEY_USERS/S-1-5-21-123_Classes/Game",
+            "HKEY_CURRENT_USER/SOFTWARE/Game",
+        ] {
+            assert_eq!(portable_path(path, "S-1-5-21-123"), None);
+        }
+    }
+    #[cfg(windows)]
+    #[test]
+    fn process_sid_can_offer_a_current_user_path_without_registry_writes() {
+        let sid = current_sid().unwrap();
+        assert_eq!(
+            suggest_current_user_path(&format!("HKEY_USERS\\{sid}\\Software\\Example")),
+            Some("HKEY_CURRENT_USER\\Software\\Example".into())
+        );
+    }
+}

--- a/crates/rgsm-core/src/backup/restore_plan.rs
+++ b/crates/rgsm-core/src/backup/restore_plan.rs
@@ -65,8 +65,17 @@ impl RestorePlan {
                     save_unit_id: group.save_unit_id,
                     group_id: group.id,
                     archive_path: group.archive_path.clone(),
-                    target_path: PathBuf::from(&candidate.logical_anchor)
-                        .join(PathBuf::from(&group.relative_path)),
+                    target_path: if group.kind == CaptureSourceKind::Registry {
+                        candidate.exact_target_path().ok_or_else(|| {
+                            RestorePlanError::MappingRequired {
+                                save_unit_id: group.save_unit_id,
+                                group_id: group.id,
+                                source_dimensions: group.dimensions.clone(),
+                            }
+                        })?
+                    } else {
+                        PathBuf::from(&candidate.logical_anchor).join(&group.relative_path)
+                    },
                     kind: group.kind,
                     delete_before_apply: group.delete_before_apply,
                 });
@@ -219,6 +228,23 @@ mod tests {
                 .collect(),
             locations: Vec::new(),
             diagnostics: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn registry_target_uses_current_key_even_when_its_name_changed() {
+        let mut capture = group();
+        capture.kind = CaptureSourceKind::Registry;
+        capture.relative_path = "OldName".into();
+        let target = "HKEY_CURRENT_USER/Software/NewName";
+        let mut current = report(&[("registry", "HKEY_CURRENT_USER/Software")]);
+        current.candidates[0].expression = target.into();
+        let reports = BTreeMap::from([(7, current)]);
+        for plan in [
+            RestorePlan::build(&[capture.clone()], &reports, &[]),
+            RestorePlan::build_legacy_v2(&[capture], &reports, &[]),
+        ] {
+            assert_eq!(plan.unwrap().entries[0].target_path, PathBuf::from(target));
         }
     }
 

--- a/crates/rgsm-core/src/backup/tests/registry_archive.rs
+++ b/crates/rgsm-core/src/backup/tests/registry_archive.rs
@@ -32,6 +32,136 @@ mod tests {
     }
 
     #[test]
+    fn registry_restore_uses_device_target_not_archived_root()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backup::registry::{
+            RegistryData, RegistryKeyEntry, RegistryValue, serialize_reg_file,
+        };
+
+        let _config_lock = lock_config_file();
+        let _config_guard = ConfigFileGuard::write_default_config()?;
+        let temp = temp_dir::TempDir::new()?;
+        let (owned_subkey, owned_path) = unique_registry_path("RGSM_TEST")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let source_path = format!("{owned_path}\\OldName");
+            let target_path = format!("{owned_path}\\NewName");
+            let (source, _) = hkcu.create_subkey(format!("{owned_subkey}\\OldName"))?;
+            source.set_value("Untouched", &"original")?;
+            let data = RegistryData {
+                format_version: 1,
+                root_key: source_path,
+                entries: vec![
+                    RegistryKeyEntry {
+                        subkey: String::new(),
+                        values: vec![],
+                    },
+                    RegistryKeyEntry {
+                        subkey: "Nested".into(),
+                        values: vec![RegistryValue::Sz {
+                            name: "Value".into(),
+                            data: "S-1-5-21-old-user-must-stay".into(),
+                        }],
+                    },
+                ],
+            };
+            for (date, filename, bytes) in [
+                ("reg", "registry.reg", serialize_reg_file(&data)?),
+                ("json", "registry.json", serde_json::to_vec(&data)?),
+            ] {
+                let mut writer =
+                    ZipWriter::new(File::create(temp.path().join(format!("{date}.zip")))?);
+                writer.start_file(format!("0/{filename}"), SimpleFileOptions::default())?;
+                writer.write_all(&bytes)?;
+                writer.set_comment(ArchiveMeta::new(CompressionPreset::Standard).to_comment());
+                writer.finish()?;
+                decompress_from_file(
+                    &[build_registry_save_unit_with_id(&target_path, 0)],
+                    temp.path(),
+                    date,
+                    None,
+                )?;
+                let restored = hkcu.open_subkey(format!("{owned_subkey}\\NewName\\Nested"))?;
+                assert_eq!(
+                    restored.get_value::<String, _>("Value")?,
+                    "S-1-5-21-old-user-must-stay"
+                );
+                assert!(source.open_subkey("Nested").is_err());
+                assert_eq!(source.get_value::<String, _>("Untouched")?, "original");
+                hkcu.delete_subkey_all(format!("{owned_subkey}\\NewName"))?;
+            }
+            Ok(())
+        })();
+        let _ = hkcu.delete_subkey_all(&owned_subkey);
+        result
+    }
+
+    #[test]
+    fn capture_archives_restore_registry_to_each_mapped_target()
+    -> Result<(), Box<dyn std::error::Error>> {
+        use crate::backup::archive::{ArchiveBackend, SevenZBackend, ZipBackend};
+        use crate::backup::{
+            CaptureGroup, CapturePlan, CaptureSourceKind, RestoreEntry, RestorePlan,
+        };
+        let temp = temp_dir::TempDir::new()?;
+        let (owned_subkey, owned_path) = unique_registry_path("RGSM_TEST")?;
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let result = (|| -> Result<(), Box<dyn std::error::Error>> {
+            let (source, _) = hkcu.create_subkey(format!("{owned_subkey}\\OldName\\Nested"))?;
+            let capture = CapturePlan {
+                groups: vec![CaptureGroup {
+                    id: 0,
+                    save_unit_id: 0,
+                    candidate_id: "source".into(),
+                    dimensions: Default::default(),
+                    logical_anchor: owned_path.clone().into(),
+                    source_path: format!("{owned_path}\\OldName"),
+                    relative_path: "OldName".into(),
+                    archive_path: "0/0/data/registry.reg".into(),
+                    kind: CaptureSourceKind::Registry,
+                    delete_before_apply: false,
+                }],
+            };
+            for backend in [&ZipBackend as &dyn ArchiveBackend, &SevenZBackend] {
+                source.set_value("Value", &"archived")?;
+                let archive = temp.path().join(format!("capture.{}", backend.extension()));
+                backend.compress_capture_plan(
+                    &capture,
+                    &archive,
+                    CompressionPreset::Standard,
+                    None,
+                )?;
+                source.set_value("Value", &"live-unchanged")?;
+                let targets = ["FirstTarget", "SecondTarget"];
+                let restore = RestorePlan {
+                    entries: targets
+                        .iter()
+                        .map(|name| RestoreEntry {
+                            save_unit_id: 0,
+                            group_id: 0,
+                            archive_path: "0/0/data/registry.reg".into(),
+                            target_path: format!("{owned_path}\\{name}").into(),
+                            kind: CaptureSourceKind::Registry,
+                            delete_before_apply: false,
+                        })
+                        .collect(),
+                    ..Default::default()
+                };
+                backend.restore_capture_plan(&restore, &archive)?;
+                for name in targets {
+                    let restored = hkcu.open_subkey(format!("{owned_subkey}\\{name}\\Nested"))?;
+                    assert_eq!(restored.get_value::<String, _>("Value")?, "archived");
+                    hkcu.delete_subkey_all(format!("{owned_subkey}\\{name}"))?;
+                }
+                assert_eq!(source.get_value::<String, _>("Value")?, "live-unchanged");
+            }
+            Ok(())
+        })();
+        let _ = hkcu.delete_subkey_all(&owned_subkey);
+        result
+    }
+
+    #[test]
     fn registry_snapshot_writes_reg_file() -> Result<(), Box<dyn std::error::Error>> {
         use crate::backup::registry;
 

--- a/crates/rgsm-core/src/path_resolver.rs
+++ b/crates/rgsm-core/src/path_resolver.rs
@@ -63,6 +63,9 @@ pub enum PathCheckResult {
         exists: bool,
         /// Whether registry operations are supported on this platform.
         supported: bool,
+        /// Optional portable spelling for this process's own user, never another SID.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        current_user_path: Option<String>,
     },
     /// Failed to resolve path variables
     #[serde(rename_all = "camelCase")]
@@ -75,11 +78,20 @@ pub fn check_path(raw_path: &str, ctx: Option<&PathContext>, _config: &Config) -
     if crate::backup::registry::is_registry_path(raw_path) {
         #[cfg(target_os = "windows")]
         {
-            let exists = crate::backup::registry::registry_key_exists(raw_path).unwrap_or(false);
+            let exists = match crate::backup::registry::registry_key_exists(raw_path) {
+                Ok(exists) => exists,
+                Err(error) => {
+                    return PathCheckResult::ResolveFailed {
+                        raw_path: raw_path.to_string(),
+                        error: error.to_string(),
+                    };
+                }
+            };
             return PathCheckResult::RegistryPath {
                 raw_path: raw_path.to_string(),
                 exists,
                 supported: true,
+                current_user_path: crate::backup::registry::suggest_current_user_path(raw_path),
             };
         }
         #[cfg(not(target_os = "windows"))]
@@ -88,6 +100,7 @@ pub fn check_path(raw_path: &str, ctx: Option<&PathContext>, _config: &Config) -
                 raw_path: raw_path.to_string(),
                 exists: false,
                 supported: false,
+                current_user_path: None,
             };
         }
     }

--- a/crates/rgsm-core/src/services/path_resolution.rs
+++ b/crates/rgsm-core/src/services/path_resolution.rs
@@ -438,8 +438,10 @@ fn resolve_concrete(
             SaveUnitType::File => source.is_file(),
             SaveUnitType::Folder => source.is_dir(),
             SaveUnitType::WinRegistry => {
-                crate::backup::registry::registry_key_exists(&resolved.to_string_lossy())
-                    .unwrap_or(false)
+                match crate::backup::registry::registry_key_exists(&resolved.to_string_lossy()) {
+                    Ok(exists) => exists,
+                    Err(error) => return blocked_report(path, &error.to_string()),
+                }
             }
         };
         if !exists {

--- a/docs/adr/0008-restore-registry-data-to-device-targets.md
+++ b/docs/adr/0008-restore-registry-data-to-device-targets.md
@@ -1,0 +1,17 @@
+# Restore registry data to device targets
+
+Status: accepted
+
+A registry Save Unit restores its captured subtree to the target configured for
+the current Device, rather than treating the archived absolute root as the
+restore destination. Use Windows' native `HKEY_CURRENT_USER` root for
+current-user locations instead of introducing an RGSM SID variable; explicitly
+configured other-user roots must not be silently redirected to the current
+user. This keeps old Archives usable after a target change without rewriting
+their data or replacing SID strings stored inside registry values.
+
+Saving a location checks only the current Device and reports a missing or
+unreadable target without preventing the configuration from being saved.
+Malformed locations are distinct from temporarily unavailable ones. RGSM does
+not select another Windows account, elevate privileges, or load another user's
+registry hive; capture and restore still check their own access requirements.

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -1234,6 +1234,10 @@
         "resolved_to": "Resolved to: {path}",
         "resolving": "Resolving…",
         "not_found": "path not found",
+        "current_user_hint": "This key belongs to your Windows account; use HKEY_CURRENT_USER to follow the account running the app",
+        "use_current_user": "Use current Windows user",
+        "saved_unavailable": "Some save locations are unavailable on this device; the configuration can still be saved",
+        "check_unavailable": "Could not check save locations; the configuration can still be saved",
         "registry_not_supported": "Registry paths are not supported",
         "editor_badge_tooltip": "This field supports path variables. Type < to autocomplete.",
         "placeholder": "Path, or type < for variables"

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -1234,6 +1234,10 @@
         "resolved_to": "解析结果: {path}",
         "resolving": "解析中…",
         "not_found": "路径不存在",
+        "current_user_hint": "此键属于当前 Windows 用户，可改用 HKEY_CURRENT_USER，随运行应用的用户解析",
+        "use_current_user": "使用当前 Windows 用户",
+        "saved_unavailable": "部分存档位置在本机不可用，仍可保存配置",
+        "check_unavailable": "暂时无法检查存档位置，仍可保存配置",
         "registry_not_supported": "不支持注册表路径",
         "editor_badge_tooltip": "此字段支持路径变量，输入 < 可自动补全。",
         "placeholder": "输入路径，或键入 < 插入变量"


### PR DESCRIPTION
Restore registry subtrees under the current device target for legacy ZIP, capture ZIP, and 7z archives. Archived root paths remain provenance; SID strings inside values are not rewritten. Restore mappings can target multiple keys.

Check save locations on the current device without blocking configuration saves. Offer HKEY_CURRENT_USER only when the configured SID belongs to the running Windows user, and require an explicit click. Other-user paths are untouched; no elevation or hive loading is introduced.

Regression coverage restores into isolated Windows registry keys and exercises target editing and missing-target warnings through the GUI. See ADR 0008 for the restore boundary.