### PR TITLE
fix(backup): :bug: handle undo failures and briefly locked metadata

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -59,6 +59,7 @@ jobs:
           e2e/local-released-upgrade.spec.ts
           e2e/local-failure-surface.spec.ts
           e2e/local-extra-backup.spec.ts
+          e2e/local-undo-feedback.spec.ts
           e2e/local-overlay-feedback.spec.ts
           e2e/cloud-empty-create.spec.ts
           e2e/cloud-remove-device.spec.ts

--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm --dir apps/rgsm-gui exec playwright install chromium
 
+      - name: Test Windows file replacement
+        run: cargo test -p rgsm-core --lib atomic_file::tests
+
       - name: Run release-critical E2E
         run: >-
           pnpm --dir apps/rgsm-gui exec playwright test

--- a/apps/rgsm-gui/e2e/local-undo-feedback.spec.ts
+++ b/apps/rgsm-gui/e2e/local-undo-feedback.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { DEVICE_A_ID, GAME_NAME } from './support/constants';
+import { seedLocalConfig, writeSaveText } from './support/local-fixture';
+import { startLocalSession } from './support/local-session';
+import { createRunRoot } from './support/rgsm-instance';
+import { createSnapshotForGame } from './support/local-gui';
+import { expectLocalHead } from './support/local-assertions';
+import { openGame, snapshotRow } from './support/gui';
+
+for (const failure of ['files', 'position', 'connection'] as const) {
+  test(`undo reports ${failure} failure without claiming success`, async ({
+    browser,
+  }, testInfo) => {
+    const runRoot = await createRunRoot(`undo-${failure}`);
+    const device = await seedLocalConfig(runRoot);
+    await writeSaveText(device.savePath, 'first\n');
+    const session = await startLocalSession(browser, { runRoot, device, label: 'undo-feedback' });
+    let failed = false;
+    try {
+      const { page, host } = session;
+      const first = await createSnapshotForGame(host, GAME_NAME, 'first');
+      await writeSaveText(device.savePath, 'second\n');
+      await createSnapshotForGame(host, GAME_NAME, 'second');
+      await writeSaveText(device.savePath, 'unsaved\n');
+      await openGame(page);
+      await snapshotRow(page, first).getByRole('button', { name: 'Apply' }).click();
+      const undo = page.getByRole('button', { name: 'Undo last apply', exact: true });
+      await expect(undo).toBeEnabled();
+      await expect(page.locator('.global-loading-overlay')).toBeHidden();
+      await expectLocalHead(device.appDataDir, DEVICE_A_ID, first);
+
+      // Only the failing step is injected. Snapshot creation and file restoration
+      // otherwise use the real host and isolated save files.
+      let positionRequests = 0;
+      await page.route('**/api/v1/set-snapshot-head', async (route) => {
+        if (route.request().method() !== 'POST') return route.continue();
+        positionRequests += 1;
+        if (failure === 'connection') return route.abort('connectionfailed');
+        await route.fulfill({
+          status: 400,
+          json: { code: 'invalid_request', message: 'Access is denied' },
+        });
+      });
+      if (failure === 'files') {
+        await page.route('**/api/v1/restore-extra-backup', (route) =>
+          route.request().method() === 'POST'
+            ? route.fulfill({
+                status: 400,
+                json: { code: 'invalid_request', message: 'Read failed' },
+              })
+            : route.continue()
+        );
+      }
+      await undo.click();
+      await page
+        .getByRole('dialog', { name: 'Warning' })
+        .getByRole('button', { name: 'Confirm' })
+        .click();
+      const activity = page.locator('.activity-drawer');
+      await expect(
+        activity.getByText(
+          failure === 'files'
+            ? 'Failed to undo'
+            : 'Files restored, but the previous position could not be restored',
+          { exact: true }
+        )
+      ).toBeVisible();
+      await expect(activity.getByText('Successfully undone the last applied snapshot')).toHaveCount(
+        0
+      );
+      await expect(page.locator('.global-loading-overlay')).toBeHidden();
+      expect(await readFile(device.savePath, 'utf8')).toBe(
+        failure === 'files' ? 'first\n' : 'unsaved\n'
+      );
+      await expectLocalHead(device.appDataDir, DEVICE_A_ID, first);
+      expect(positionRequests).toBe(failure === 'files' ? 0 : 1);
+      if (failure === 'files') {
+        await expect(undo).toBeEnabled();
+      } else {
+        await expect(page.getByRole('button', { name: 'No recent apply to undo' })).toBeDisabled();
+      }
+      if (failure === 'position') {
+        await page.screenshot({
+          path: testInfo.outputPath('acceptance-undo-failure.png'),
+          animations: 'disabled',
+        });
+      }
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      await session.close(failed);
+    }
+  });
+}

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/cloudLibraryNotice.test.mjs src/ui/overlayDepth.test.mjs src/utils/appRoutes.test.mjs src/utils/gameName.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
+    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/cloudLibraryNotice.test.mjs src/ui/overlayDepth.test.mjs src/utils/appRoutes.test.mjs src/utils/gameName.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs src/components/management/undoRestore.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
     "web:e2e": "playwright test --project=browser",
     "web:e2e:desktop": "playwright test --project=desktop",
     "dev": "tauri dev -- --locked",

--- a/apps/rgsm-gui/src/components/management/undoRestore.test.mjs
+++ b/apps/rgsm-gui/src/components/management/undoRestore.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runUndoRestore } from './undoRestore.ts';
+
+test('undo succeeds only after files and position are restored in order', async () => {
+  const calls = [];
+  const result = await runUndoRestore(
+    async () => {
+      calls.push('files');
+      return { status: 'ok' };
+    },
+    async () => {
+      calls.push('position');
+      return { status: 'ok' };
+    }
+  );
+  assert.deepEqual(calls, ['files', 'position']);
+  assert.deepEqual(result, { status: 'ok' });
+});
+
+for (const stage of ['files', 'position']) {
+  for (const throws of [false, true]) {
+    test(`undo identifies ${stage} failure (${throws ? 'exception' : 'response'})`, async () => {
+      const calls = [];
+      const error = new Error('Access denied');
+      const step = (name) => async () => {
+        calls.push(name);
+        if (name !== stage) return { status: 'ok' };
+        if (throws) throw error;
+        return { status: 'error', error };
+      };
+      assert.deepEqual(await runUndoRestore(step('files'), step('position')), {
+        status: 'error',
+        stage,
+        error,
+      });
+      assert.deepEqual(calls, stage === 'files' ? ['files'] : ['files', 'position']);
+    });
+  }
+}

--- a/apps/rgsm-gui/src/components/management/undoRestore.ts
+++ b/apps/rgsm-gui/src/components/management/undoRestore.ts
@@ -1,0 +1,22 @@
+type StepResult = { status: 'ok' } | { status: 'error'; error: unknown };
+type RestoreStep = () => Promise<StepResult>;
+type UndoRestoreResult =
+  | { status: 'ok' }
+  | { status: 'error'; stage: 'files' | 'position'; error: unknown };
+
+/** Keep partial completion explicit; restoring files is not safe to repeat implicitly. */
+export async function runUndoRestore(
+  restoreFiles: RestoreStep,
+  restorePosition: RestoreStep
+): Promise<UndoRestoreResult> {
+  let stage: 'files' | 'position' = 'files';
+  try {
+    const files = await restoreFiles();
+    if (files.status === 'error') return { ...files, stage };
+    stage = 'position';
+    const position = await restorePosition();
+    return position.status === 'error' ? { ...position, stage } : { status: 'ok' };
+  } catch (error) {
+    return { status: 'error', stage, error };
+  }
+}

--- a/apps/rgsm-gui/src/pages/Management/[name].vue
+++ b/apps/rgsm-gui/src/pages/Management/[name].vue
@@ -20,6 +20,7 @@ import SnapshotTable from '../../components/management/SnapshotTable.vue';
 import { canApplySnapshot } from '../../components/management/snapshotAvailability';
 import { useDeviceHeads, type DeviceHeadEntry } from '../../components/management/useDeviceHeads';
 import { useSnapshotTransfers } from '../../components/management/useSnapshotTransfers';
+import { runUndoRestore } from '../../components/management/undoRestore';
 import { $t } from '../../i18n';
 import { error, info } from '../../utils/logger';
 import {
@@ -867,23 +868,30 @@ async function undo_last_apply() {
   const activityId = addActivity({ title: $t('manage.restoring_backup'), status: 'running' });
   try {
     await withLoading(async () => {
-      const result = await commands.restoreExtraBackup(game.value, extraBackupDate);
+      const result = await runUndoRestore(
+        () => commands.restoreExtraBackup(game.value, extraBackupDate),
+        async () => {
+          // Clearing an originally absent HEAD is not yet supported by the API.
+          return previousHead
+            ? commands.setSnapshotHead(game.value, previousHead)
+            : { status: 'ok' };
+        }
+      );
+      if (result.status === 'ok' || result.stage === 'position') {
+        // Files were restored. Do not offer another file overwrite to retry
+        // a failed position update.
+        undoInfo.value = null;
+      }
       if (result.status === 'error') {
-        updateActivity(activityId, { status: 'error', title: $t('manage.undo_failed') });
+        error(`Undo ${result.stage} failed: ${result.error}`);
+        updateActivity(activityId, {
+          status: 'error',
+          title: $t(
+            result.stage === 'position' ? 'manage.undo_position_failed' : 'manage.undo_failed'
+          ),
+        });
         return;
       }
-
-      // 恢复之前的 HEAD 指针
-      // TODO: 当 previousHead 为 null 时（首次应用前 HEAD 未设置），
-      // 需要后端支持 clearSnapshotHead 命令才能完全恢复状态
-      if (previousHead) {
-        const headResult = await commands.setSnapshotHead(game.value, previousHead);
-        if (headResult.status === 'error') {
-          error(`Failed to restore HEAD on undo: ${headResult.error}`);
-        }
-      }
-
-      undoInfo.value = null;
       updateActivity(activityId, { status: 'success', title: $t('manage.undo_success') });
     }, $t('manage.restoring_backup'));
   } catch {

--- a/crates/rgsm-core/src/atomic_file.rs
+++ b/crates/rgsm-core/src/atomic_file.rs
@@ -99,17 +99,29 @@ fn replace_file(source: &Path, target: &Path) -> io::Result<()> {
         .encode_wide()
         .chain(std::iter::once(0))
         .collect::<Vec<_>>();
-    let result = unsafe {
-        MoveFileExW(
-            source.as_ptr(),
-            target.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-        )
-    };
-    if result == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
+    // Windows readers without FILE_SHARE_DELETE can briefly block replacement
+    // with ACCESS_DENIED (not just SHARING_VIOLATION). Retry this filesystem
+    // operation only, for at most 310 ms of backoff; never delete the target.
+    let mut delays = [10, 20, 40, 80, 160].into_iter();
+    loop {
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                target.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result != 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if !matches!(error.raw_os_error(), Some(5 | 32)) {
+            return Err(error);
+        }
+        let Some(delay) = delays.next() else {
+            return Err(error);
+        };
+        std::thread::sleep(std::time::Duration::from_millis(delay));
     }
 }
 
@@ -126,6 +138,69 @@ mod tests {
         super::write_bytes_atomically(&path, b"new").unwrap();
 
         assert_eq!(fs::read(&path).unwrap(), b"new");
+        assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn replaces_file_after_a_short_lived_windows_reader_releases_it() {
+        use std::os::windows::fs::OpenOptionsExt;
+        let root = temp_dir::TempDir::new().unwrap();
+        let path = root.path().join("state.json");
+        fs::write(&path, b"old").unwrap();
+        // A reader that does not share DELETE prevents MoveFileExW from
+        // replacing the catalog even though the directory is writable.
+        let reader = fs::OpenOptions::new()
+            .read(true)
+            .share_mode(1)
+            .open(&path)
+            .unwrap();
+        let release = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            drop(reader);
+        });
+        let result = super::write_bytes_atomically(&path, b"new");
+        release.join().unwrap();
+        result.unwrap();
+        assert_eq!(fs::read(&path).unwrap(), b"new");
+        assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn locked_target_preserves_original_and_cleans_temporary_file() {
+        use std::os::windows::fs::OpenOptionsExt;
+        let root = temp_dir::TempDir::new().unwrap();
+        let path = root.path().join("state.json");
+        fs::write(&path, b"old").unwrap();
+        let _reader = fs::OpenOptions::new()
+            .read(true)
+            .share_mode(1)
+            .open(&path)
+            .unwrap();
+        let error = super::write_bytes_atomically(&path, b"new").unwrap_err();
+        assert!(matches!(error.raw_os_error(), Some(5 | 32)));
+        assert_eq!(fs::read(&path).unwrap(), b"old");
+        assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn readonly_target_is_not_removed_or_made_writable() {
+        let root = temp_dir::TempDir::new().unwrap();
+        let path = root.path().join("state.json");
+        fs::write(&path, b"old").unwrap();
+        let original_permissions = fs::metadata(&path).unwrap().permissions();
+        let mut permissions = original_permissions.clone();
+        permissions.set_readonly(true);
+        fs::set_permissions(&path, permissions.clone()).unwrap();
+        let result = super::write_bytes_atomically(&path, b"new");
+        let still_readonly = fs::metadata(&path).unwrap().permissions().readonly();
+        // Restore only this test's attribute so its temporary directory can clean up.
+        fs::set_permissions(&path, original_permissions).unwrap();
+        assert_eq!(result.unwrap_err().raw_os_error(), Some(5));
+        assert!(still_readonly);
+        assert_eq!(fs::read(&path).unwrap(), b"old");
         assert_eq!(fs::read_dir(root.path()).unwrap().count(), 1);
     }
 }

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -222,6 +222,7 @@
         "undo_last_apply": "Undo last apply",
         "undo_success": "Successfully undone the last applied snapshot",
         "undo_failed": "Failed to undo",
+        "undo_position_failed": "Files restored, but the previous position could not be restored",
         "undo_confirm": "Are you sure you want to undo the last applied snapshot and restore to the previous state?",
         "undo_not_available": "No recent apply to undo",
         "undo_requires_extra_backup": "Enable \"Extra backup before apply\" in Settings to use the undo feature",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -222,6 +222,7 @@
         "undo_last_apply": "撤销上次应用",
         "undo_success": "已成功撤销上次应用的快照",
         "undo_failed": "撤销失败",
+        "undo_position_failed": "存档文件已恢复，但未能恢复之前的位置",
         "undo_confirm": "确定要撤销上次应用的快照并恢复到之前的状态吗？",
         "undo_not_available": "没有可撤销的操作",
         "undo_requires_extra_backup": "请在设置中开启「应用前额外备份」以使用撤销功能",


### PR DESCRIPTION
Undo now distinguishes file restoration failures from position-update failures. If files were restored but the position update failed, show that partial result instead of success and consume the undo entry to avoid repeating the file overwrite. File-restoration failures retain the retry entry.

Windows metadata replacement retries access-denied and sharing violations with 310 ms of total backoff. Persistent failures still return an error, preserve the original file and permissions, and clean up temporary files.

Native Windows tests reproduce a briefly locked target and cover permanent locks and read-only targets. GUI regressions cover failed file restoration, rejected position updates, and a lost connection. The [original CI access-denied failure](https://github.com/mcthesw/game-save-manager/actions/runs/34257171378) did not identify the file holder; the native test establishes one reproducible cause of the same error, not proof of which process caused that CI failure.

[Failure-state screenshot](https://github.com/mcthesw/game-save-manager/actions/runs/34299613947/artifacts/10084557958) (`acceptance-undo-failure.png` in the GUI artifact)
