### PR TITLE
feat(testing): add a scoped GUI acceptance workflow

### DIFF
--- a/.agents/skills/rgsm-gui-acceptance/SKILL.md
+++ b/.agents/skills/rgsm-gui-acceptance/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: rgsm-gui-acceptance
+description: Prepare change-specific RGSM GUI acceptance environments and short manual scenarios when the user wants to try a change locally. Uses isolated saves and the real Rust backend; not a mandatory gate for every PR or a replacement for automated tests.
+---
+
+# RGSM GUI acceptance
+
+Deliver working GUI links, a small set of numbered scenarios, and a clear way to stop the owned services. The user performs acceptance; preparing fixtures or passing an automated smoke is not their approval.
+
+## Select the scenarios
+
+Read the relevant diff, current API, locale labels, and existing tests. Pin the tested revision, including any local combination of unmerged PRs. Preserve the user's checkout and other running environments.
+
+Aim for at most five short scenarios unless the user asks for more. Cover the changed behavior and its next useful action: for example, retaining a local game after joining a library is incomplete coverage unless the user can subsequently enable its sync and transfer a snapshot.
+
+Use real files or fixture generators for save state. Markdown describes that state and references its files; it does not serialize archives, registry data, or an execution graph. Start from [the scenario card](assets/scenario.md), adapting or removing fields that do not help this review.
+
+## Prepare an isolated packet
+
+Put generated scenario code, data, logs, and evidence under `.rgsm-dev/acceptance/<task>/`. Reuse helpers under `apps/rgsm-gui/e2e/support/`, especially `local-fixture.ts`, `cloud-fixture.ts`, and `process.ts`, rather than copying product schemas. Use current APIs for subsequent mutations. Never seed real save paths or cloud credentials.
+
+Choose the lightest environment that exercises the behavior:
+
+- For frontend/business flows, build the frontend once and use the real HTTP-only host. [The thin device launcher](scripts/device.mjs) serves the built GUI, injects runtime authentication, and owns one isolated host. It does not seed data, run scenarios, or rebuild on startup
+- For tray, hotkeys, window lifecycle, WebView, or installer changes, request or prepare the actual desktop environment instead; browser success cannot prove those behaviors
+- For cloud flows, use isolated local test storage. A mock WebDAV transport is suitable for join/metadata UX but does not prove remote provider compatibility
+
+Read [launcher usage](references/environment.md) before using the helper. Keep test-specific setup and controls local to the packet. Do not grow a YAML DSL, scenario registry, generic fault engine, or permanent fixture catalog from one acceptance request.
+
+Do not open visible windows automatically. Respect existing ports and services. Limit concurrent builds/hosts, reuse valid build artifacts, and disable notifications and sounds in test configs. Keep cloud credentials, join codes, and API tokens out of console output and screenshots.
+
+## Verify before handing over
+
+Exercise the numbered operations in an owned browser context. Inspect current accessibility labels before choosing selectors. Wait for actual responses and refreshed state, not incidental sleeps. Check real save contents and effective configuration, not only success notifications.
+
+For partial failures, show which user-visible outcome succeeded and which failed. A real isolated fault is preferable when safe and repeatable; disclose any mocked failure. Record unexpected behavior instead of hiding it behind an altered scenario.
+
+Use a separate smoke dataset from the user dataset. Do not reset or modify an environment the user has started accepting without permission. Verify stop/restart behavior, distinguishing a device restart from recreating an ephemeral cloud fixture.
+
+## Hand over and close
+
+Provide the entry links, numbered actions and expected results, tested revision, and any relevant known limits. Distinguish automated smoke, pending human acceptance, and untested platforms. A small landing page with state inspection is useful when file effects are otherwise hard to see, but is optional.
+
+Keep the environment available until the user finishes or asks to stop. Closing a browser tab does not stop the host. Report exactly which owned services were stopped; only delete task data when requested, after validating the targets. Do not merge PRs or close issues merely because acceptance passed.

--- a/.agents/skills/rgsm-gui-acceptance/agents/openai.yaml
+++ b/.agents/skills/rgsm-gui-acceptance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RGSM GUI acceptance"
+  short_description: "Prepare isolated GUI scenarios for human acceptance"
+  default_prompt: "Use $rgsm-gui-acceptance to prepare a small local acceptance packet for these changes"

--- a/.agents/skills/rgsm-gui-acceptance/assets/scenario.md
+++ b/.agents/skills/rgsm-gui-acceptance/assets/scenario.md
@@ -1,0 +1,22 @@
+# <Number> · <User behavior>
+
+## Starting point
+
+- GUI: <device link>
+- State: <what the user should initially see>
+- Fixture: <file or setup script that produces the save state>
+
+## Actions and expected results
+
+1. <GUI action using current labels> → <observable outcome>
+2. <The next useful action> → <observable outcome>
+
+## Verify the effect
+
+<How to inspect the actual test file, configuration, or other device; include what must remain unchanged>
+
+## Finish
+
+<Undo an injected fault if needed; explain whether retry/restart preserves the scenario>
+
+Result: awaiting human acceptance

--- a/.agents/skills/rgsm-gui-acceptance/references/environment.md
+++ b/.agents/skills/rgsm-gui-acceptance/references/environment.md
@@ -1,0 +1,25 @@
+# Thin device launcher
+
+The launcher requires Node 24. It reuses the repository's owned-process helper and starts a debug Rust binary in HTTP-only mode. It serves the built frontend, with no Vite watcher or desktop window.
+
+Before launch:
+
+1. Build the intended checkout with `pnpm web:build` and `cargo build --locked -p rgsm --bin rgsm`. Limit `CARGO_BUILD_JOBS` when sharing the user's computer
+2. Prepare an existing data directory under `.rgsm-dev/acceptance/<task>/` using a small task-specific script. Set `settings.locale`, `quick_action.enable_sound=false`, and `quick_action.enable_notification=false`. Use test-only device IDs, saves, backup directories, and cloud storage
+3. The data directory must contain `GameSaveManager.config.json`. All paths inside it remain the preparer's responsibility: the launcher confines its own writes, but cannot certify arbitrary fixture configuration
+
+From the repository root:
+
+```text
+node .agents/skills/rgsm-gui-acceptance/scripts/device.mjs .rgsm-dev/acceptance/example/device-a review-a 5188
+```
+
+The arguments are the prepared data directory, simulated device ID, and an unused loopback port. The launcher fails on a busy port instead of adopting or stopping its owner. It copies the binary into the data directory so subsequent builds do not overwrite the running executable.
+
+Wait for the printed ready URL before opening the GUI. Use the printed `/__acceptance` stop page for reliable shutdown, including when the launcher runs in a hidden window. Keep the process supervised; Ctrl+C in a normal terminal also requests shutdown, but force-terminating a supervisor may bypass cleanup. Closing the browser does not stop it. For an embedded packet/control page, import `startAcceptanceDevice({ dataDir, deviceId, port })`, retain the returned handle, and await `handle.stop()` during cleanup.
+
+The helper never resets data. Restart with the same directory to retain user edits. A second launcher for the same directory is rejected by `.acceptance-running`. After an abnormal termination, inspect the original process before removing that empty lock directory; never use a saved PID as authority to kill a process.
+
+For multiple devices, start only those required by the current scenario. Keep a local cloud fixture alive across device restarts when testing connection persistence. If the fixture itself is ephemeral, explicitly state that stopping it invalidates its join codes and remote contents.
+
+This is a lifecycle/transport helper, not a scenario runner. Use ordinary fixture files or setup code for saves and ordinary Markdown for the reviewer. Use `node --test .agents/skills/rgsm-gui-acceptance/scripts/device.test.mjs` for the helper's path and argument checks.

--- a/.agents/skills/rgsm-gui-acceptance/scripts/device.mjs
+++ b/.agents/skills/rgsm-gui-acceptance/scripts/device.mjs
@@ -1,0 +1,256 @@
+import { createServer, request } from "node:http";
+import { createWriteStream } from "node:fs";
+import {
+  copyFile,
+  mkdir,
+  readFile,
+  realpath,
+  rmdir,
+  stat,
+} from "node:fs/promises";
+import { registerHooks } from "node:module";
+import { dirname, extname, join, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { setTimeout as delay } from "node:timers/promises";
+
+// Existing E2E helpers use extensionless TS imports. Node 24 strips their types.
+registerHooks({
+  resolve(specifier, context, next) {
+    try {
+      return next(specifier, context);
+    } catch (error) {
+      if (
+        error.code !== "ERR_MODULE_NOT_FOUND" ||
+        !specifier.startsWith(".") ||
+        extname(specifier)
+      )
+        throw error;
+      return next(`${specifier}.ts`, context);
+    }
+  },
+});
+const repo = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const { spawnTestProcess, hostCommand } = await import(
+  pathToFileURL(join(repo, "apps/rgsm-gui/e2e/support/process.ts"))
+);
+const dist = join(repo, "apps/rgsm-gui/dist");
+
+export async function validateDataDir(dataDir, workspace = repo) {
+  const root = await realpath(join(workspace, ".rgsm-dev/acceptance"));
+  const actual = await realpath(resolve(dataDir));
+  if (!actual.startsWith(root + sep))
+    throw new Error("Data must be inside .rgsm-dev/acceptance/<task>/");
+  if (!(await stat(join(actual, "GameSaveManager.config.json"))).isFile())
+    throw new Error("Seed the test configuration first");
+  return actual;
+}
+export function validateOptions({ deviceId, port }) {
+  if (!/^[a-zA-Z0-9_-]{1,80}$/.test(deviceId ?? ""))
+    throw new Error("Use a short test device ID");
+  if (!Number.isInteger(port) || port < 1024 || port > 65535)
+    throw new Error("Choose a port between 1024 and 65535");
+}
+
+export async function startAcceptanceDevice(options) {
+  validateOptions(options);
+  const data = await validateDataDir(options.dataDir);
+  const lock = join(data, ".acceptance-running");
+  await mkdir(lock); // Exclusive ownership; never clear another launcher's lock.
+  const origin = `http://127.0.0.1:${options.port}`;
+  let runtime, host, log, stopped;
+  const server = createServer(async (req, res) => {
+    const fail = (status, text) => {
+      res.writeHead(status, { "Content-Type": "text/plain" });
+      res.end(text);
+    };
+    try {
+      if (
+        req.headers.host !== `127.0.0.1:${options.port}` ||
+        (req.headers.origin && req.headers.origin !== origin)
+      )
+        return fail(403, "Forbidden");
+      if (!runtime) return fail(503, "Starting test host");
+      const url = new URL(req.url, origin);
+      if (url.pathname === "/__acceptance" && req.method === "GET") {
+        res.writeHead(200, {
+          "Content-Type": "text/html; charset=utf-8",
+          "Cache-Control": "no-store",
+        });
+        res.end(
+          `<title>Acceptance device</title><a href="/">Open GUI</a> <button id="stop">Stop this test device</button><script>document.getElementById('stop').onclick=async()=>{await fetch('/__acceptance/stop',{method:'POST',headers:{Authorization:${JSON.stringify(`Bearer ${runtime.api_token}`)}}});document.body.textContent='Test device stopped; data preserved'}</script>`,
+        );
+        return;
+      }
+      if (url.pathname === "/__acceptance/stop" && req.method === "POST") {
+        if (req.headers.authorization !== `Bearer ${runtime.api_token}`)
+          return fail(401, "Unauthorized");
+        res.writeHead(200);
+        res.end("Stopping");
+        setTimeout(() => {
+          void stop().catch((error) => {
+            console.error(error.message);
+            process.exitCode = 1;
+          });
+        }, 100);
+        return;
+      }
+      if (url.pathname.startsWith("/api/v1/")) {
+        if (req.headers.authorization !== `Bearer ${runtime.api_token}`)
+          return fail(401, "Reload the test page");
+        const upstream = request(
+          `http://127.0.0.1:${runtime.port}${url.pathname}${url.search}`,
+          {
+            method: req.method,
+            headers: {
+              Authorization: `Bearer ${runtime.api_token}`,
+              Origin: "http://localhost:5173",
+              "Content-Type": req.headers["content-type"] ?? "application/json",
+              ...(req.headers["last-event-id"]
+                ? { "Last-Event-ID": req.headers["last-event-id"] }
+                : {}),
+            },
+          },
+          (response) => {
+            res.writeHead(response.statusCode, response.headers);
+            response.pipe(res);
+          },
+        );
+        upstream.on("error", () => {
+          if (!res.headersSent) fail(502, "Test host unavailable");
+          else res.destroy();
+        });
+        res.on("close", () => upstream.destroy());
+        req.pipe(upstream);
+        return;
+      }
+      let path = resolve(dist, "." + decodeURIComponent(url.pathname));
+      if (path !== dist && !path.startsWith(dist + sep))
+        return fail(403, "Forbidden");
+      if (!(await stat(path).catch(() => null))?.isFile())
+        path = join(dist, "index.html");
+      let bytes = await readFile(path);
+      if (path === join(dist, "index.html")) {
+        const injection = JSON.stringify({
+          apiBaseUrl: origin,
+          token: runtime.api_token,
+        }).replaceAll("<", "\\u003c");
+        bytes = Buffer.from(
+          bytes
+            .toString()
+            .replace(
+              "</head>",
+              `<script>window.__RGSM_RUNTIME__=${injection}</script></head>`,
+            ),
+        );
+      }
+      const mime =
+        {
+          ".html": "text/html; charset=utf-8",
+          ".js": "text/javascript",
+          ".css": "text/css",
+          ".svg": "image/svg+xml",
+          ".png": "image/png",
+          ".woff": "font/woff",
+          ".woff2": "font/woff2",
+        }[extname(path)] ?? "application/octet-stream";
+      res.writeHead(200, { "Content-Type": mime, "Cache-Control": "no-store" });
+      res.end(bytes);
+    } catch {
+      if (!res.headersSent) fail(500, "Could not serve the test page");
+      else res.destroy();
+    }
+  });
+  const stop = () =>
+    (stopped ??= (async () => {
+      runtime = undefined;
+      server.closeAllConnections();
+      await new Promise((resolve) => server.close(resolve));
+      await host?.stop();
+      log?.end();
+      await rmdir(lock);
+    })());
+  try {
+    // Reserve the user's requested port before starting any backend process.
+    await new Promise((ok, fail) => {
+      server.once("error", fail);
+      server.listen(options.port, "127.0.0.1", ok);
+    });
+    await stat(join(dist, "index.html"));
+    const executable = process.platform === "win32" ? "rgsm.exe" : "rgsm";
+    const binary = join(data, `.acceptance-${executable}`);
+    await copyFile(join(repo, "target/debug", executable), binary);
+    log = createWriteStream(join(data, ".acceptance-host.log"), { flags: "a" });
+    const launch = hostCommand(binary, process.platform);
+    host = spawnTestProcess(launch.command, launch.args, {
+      cwd: repo,
+      env: {
+        ...process.env,
+        RGSM_HTTP_HOST_ONLY: "1",
+        RGSM_E2E_APP_DATA_DIR: data,
+        RGSM_E2E_DEVICE_ID: options.deviceId,
+      },
+    });
+    host.child.stdout.pipe(log);
+    host.child.stderr.pipe(log);
+    const deadline = Date.now() + 60000;
+    while (Date.now() < deadline) {
+      options.signal?.throwIfAborted();
+      if (host.failure()) throw host.failure();
+      try {
+        const candidate = JSON.parse(
+          await readFile(join(data, "GameSaveManager.host.json"), "utf8"),
+        );
+        const response = await fetch(
+          `http://127.0.0.1:${candidate.port}/api/v1/get-build-info`,
+          {
+            method: "POST",
+            headers: { Authorization: `Bearer ${candidate.api_token}` },
+            signal: AbortSignal.timeout(1000),
+          },
+        );
+        if (response.ok) {
+          runtime = candidate;
+          return { url: origin, stop };
+        }
+      } catch {
+        /* Host is still starting. */
+      }
+      await delay(100);
+    }
+    throw new Error(
+      "Test host did not become ready; inspect .acceptance-host.log",
+    );
+  } catch (error) {
+    await stop();
+    throw error;
+  }
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  let session;
+  const controller = new AbortController();
+  const stop = async () => {
+    controller.abort();
+    await session?.stop();
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  try {
+    const [dataDir, deviceId, port] = process.argv.slice(2);
+    session = await startAcceptanceDevice({
+      dataDir,
+      deviceId,
+      port: Number(port),
+      signal: controller.signal,
+    });
+    console.log(
+      `Ready: ${session.url}\nStop: ${session.url}/__acceptance\nData is preserved when this device stops`,
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/.agents/skills/rgsm-gui-acceptance/scripts/device.test.mjs
+++ b/.agents/skills/rgsm-gui-acceptance/scripts/device.test.mjs
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateDataDir, validateOptions } from "./device.mjs";
+
+test("requires an explicit test identity and non-privileged port", () => {
+  assert.doesNotThrow(() =>
+    validateOptions({ deviceId: "review-b", port: 5188 }),
+  );
+  for (const port of [0, 80, 65536, NaN, 1234.5])
+    assert.throws(() => validateOptions({ deviceId: "review-b", port }));
+  for (const deviceId of ["", "../real-device", undefined])
+    assert.throws(() => validateOptions({ deviceId, port: 5188 }));
+});
+
+test("only launches prepared data inside the task area", async () => {
+  const root = await mkdtemp(join(tmpdir(), "rgsm-launcher-test-"));
+  try {
+    const data = join(root, ".rgsm-dev/acceptance/task/device");
+    await mkdir(data, { recursive: true });
+    await assert.rejects(validateDataDir(data, root));
+    await writeFile(join(data, "GameSaveManager.config.json"), "{}");
+    assert.equal(await validateDataDir(data, root), await realpath(data));
+    for (const outside of [
+      root,
+      join(root, ".rgsm-dev/acceptance"),
+      join(root, ".rgsm-dev/acceptance-other"),
+    ]) {
+      await mkdir(outside, { recursive: true });
+      await assert.rejects(validateDataDir(outside, root));
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "pnpm --dir apps/rgsm-gui build",
     "web:dev": "pnpm --dir apps/rgsm-gui web:dev",
     "web:build": "pnpm --dir apps/rgsm-gui web:build",
-    "web:test": "pnpm --dir apps/rgsm-gui web:test",
+    "web:test": "pnpm --dir apps/rgsm-gui web:test && node --test .agents/skills/rgsm-gui-acceptance/scripts/device.test.mjs",
     "web:e2e": "pnpm --dir apps/rgsm-gui web:e2e",
     "web:e2e:desktop": "pnpm --dir apps/rgsm-gui web:e2e:desktop",
     "web:typecheck": "pnpm --dir apps/rgsm-gui web:typecheck",


### PR DESCRIPTION
Add an optional repository skill for preparing small, change-specific GUI acceptance packets

- Markdown scenario cards describe operations and reference real fixture files or setup scripts
- A thin launcher serves the built GUI against an isolated Rust HTTP host, with explicit ports, owned-process shutdown, and preserved test data
- Reuse existing E2E helpers; keep scenario setup local to each packet rather than introducing a scenario DSL or maintained fixture catalog

Browser acceptance covers business flows, not desktop-shell behavior. Automated smoke results remain distinct from human approval
