### PR TITLE
fix: repair released cloud upgrades and duplicate game roots

### DIFF
--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -58,6 +58,7 @@ jobs:
           e2e/local-v1-8-upgrade.spec.ts
           e2e/local-released-upgrade.spec.ts
           e2e/cloud-released-upgrade.spec.ts
+          e2e/local-game-roots.spec.ts
           e2e/local-failure-surface.spec.ts
           e2e/local-extra-backup.spec.ts
           e2e/local-undo-feedback.spec.ts

--- a/.github/workflows/windows-release-e2e.yml
+++ b/.github/workflows/windows-release-e2e.yml
@@ -57,6 +57,7 @@ jobs:
           e2e/local-legacy-archive.spec.ts
           e2e/local-v1-8-upgrade.spec.ts
           e2e/local-released-upgrade.spec.ts
+          e2e/cloud-released-upgrade.spec.ts
           e2e/local-failure-surface.spec.ts
           e2e/local-extra-backup.spec.ts
           e2e/local-undo-feedback.spec.ts

--- a/apps/rgsm-gui/e2e/cloud-released-upgrade.spec.ts
+++ b/apps/rgsm-gui/e2e/cloud-released-upgrade.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID, GAME_NAME, PARENT_SNAPSHOT_ID } from './support/constants';
+import { seedReleasedUpgrade } from './support/released-upgrade';
+import {
+  confirmCutover,
+  expectCutoverSuccess,
+  openApp,
+  openGame,
+  openSyncSettings,
+  snapshotRow,
+} from './support/gui';
+import { waitForCommand } from './support/command-result';
+import { getLocalGame } from './support/local-gui';
+import {
+  createRunRoot,
+  newDeviceContext,
+  removeRunRoot,
+  startRgsmHost,
+  type RgsmHost,
+} from './support/rgsm-instance';
+
+for (const version of ['1.7.0', '1.8.0'] as const) {
+  test(`released ${version} cloud configuration upgrades and restores without manual repair`, async ({
+    browser,
+  }) => {
+    const runRoot = await createRunRoot(`cloud-released-${version}`);
+    const scene = await seedReleasedUpgrade(runRoot, version);
+    const configPath = join(scene.appDataDir, 'GameSaveManager.config.json');
+    const config = JSON.parse(await readFile(configPath, 'utf8'));
+    config.games = config.games.slice(0, 1);
+    config.quick_action.quick_action_game = null;
+    const cloudRoot = join(runRoot, 'cloud');
+    config.settings.cloud_settings.backend = { type: 'Fs' };
+    config.settings.cloud_settings.root_path = cloudRoot;
+    config.settings.cloud_settings.auto_sync_interval = 0;
+    const cloudArchiveRoot = join(cloudRoot, 'save_data', GAME_NAME);
+    await mkdir(cloudArchiveRoot, { recursive: true });
+    const originalConfig = Buffer.from(JSON.stringify(config));
+    await writeFile(configPath, originalConfig);
+    await writeFile(join(cloudRoot, 'GameSaveManager.config.json'), originalConfig);
+    const originalCatalog = await readFile(join(scene.archiveDir, 'Backups.json'));
+    await writeFile(join(cloudArchiveRoot, 'Backups.json'), originalCatalog);
+    for (const [archive, bytes] of scene.originalArchives) {
+      await writeFile(join(cloudArchiveRoot, archive.split(/[\\/]/).at(-1)!), bytes);
+    }
+    expect(config.games[0]).not.toHaveProperty('storage_key');
+    expect(config.version).toBe(version);
+    let host: RgsmHost | undefined;
+    let context;
+    let failed = false;
+    try {
+      host = await startRgsmHost({
+        appDataDir: scene.appDataDir,
+        deviceId: DEVICE_A_ID,
+        logPath: join(runRoot, 'host.log'),
+      });
+      const started = await newDeviceContext(browser, host);
+      context = started.context;
+      const page = started.page;
+      await openApp(page);
+      await openSyncSettings(page);
+      await confirmCutover(page);
+      await expectCutoverSuccess(page);
+      const game = await getLocalGame(host, GAME_NAME);
+      expect(game.storage_key).toBe(GAME_NAME);
+      expect(game.save_paths.map((unit) => unit.id)).toEqual(scene.ids);
+      await openGame(page);
+      await snapshotRow(page, PARENT_SNAPSHOT_ID).getByRole('button', { name: 'Apply' }).click();
+      await waitForCommand(page, '/api/v1/restore-snapshot', PARENT_SNAPSHOT_ID, () =>
+        page
+          .getByRole('dialog', { name: 'Warning' })
+          .getByRole('button', { name: 'Confirm' })
+          .click()
+      );
+      for (const path of scene.savePaths)
+        expect(await readFile(path, 'utf8')).toBe(`saved-${PARENT_SNAPSHOT_ID}`);
+      expect(await readFile(join(cloudRoot, 'GameSaveManager.config.json'))).toEqual(
+        originalConfig
+      );
+      expect(await readFile(join(cloudArchiveRoot, 'Backups.json'))).toEqual(originalCatalog);
+      for (const [archive, bytes] of scene.originalArchives) {
+        const filename = archive.split(/[\\/]/).at(-1)!;
+        expect(await readFile(join(cloudArchiveRoot, filename))).toEqual(bytes);
+        expect(await readFile(join(cloudRoot, 'v2', 'archives', GAME_NAME, filename))).toEqual(
+          bytes
+        );
+      }
+    } catch (error) {
+      failed = true;
+      throw error;
+    } finally {
+      await context?.close();
+      await host?.stop();
+      if (!failed) await removeRunRoot(runRoot);
+    }
+  });
+}

--- a/apps/rgsm-gui/e2e/local-game-roots.spec.ts
+++ b/apps/rgsm-gui/e2e/local-game-roots.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { DEVICE_A_ID } from './support/constants';
+import { seedLocalConfig } from './support/local-fixture';
+import { openApp } from './support/gui';
+import {
+  createRunRoot,
+  hostPost,
+  newDeviceContext,
+  removeRunRoot,
+  startRgsmHost,
+  type RgsmHost,
+} from './support/rgsm-instance';
+import type { Config } from '../src/api/commands';
+
+test('auto-detection merges existing Windows root aliases and preserves bindings across reload', async ({
+  browser,
+}) => {
+  const runRoot = await createRunRoot('game-roots');
+  const device = await seedLocalConfig(runRoot);
+  const configPath = join(device.appDataDir, 'GameSaveManager.config.json');
+  const config = JSON.parse(await readFile(configPath, 'utf8'));
+  config.devices[DEVICE_A_ID].resources = [
+    { id: 2, source: 'manual', kind: { type: 'gameRoot', store: 'steam', path: 'C:/Steam' } },
+    { id: 5, source: 'detected', kind: { type: 'gameRoot', store: 'steam', path: 'c:\\steam\\' } },
+    {
+      id: 6,
+      source: 'manual',
+      kind: {
+        type: 'gameInstallation',
+        root_id: 5,
+        store: 'steam',
+        install_dir: 'Test',
+        path: 'C:/Steam/steamapps/common/Test',
+      },
+    },
+  ];
+  config.devices[DEVICE_A_ID].next_resource_id = 9;
+  config.games[0].device_bindings = { [DEVICE_A_ID]: { rootIds: [5] } };
+  await writeFile(configPath, JSON.stringify(config));
+  let host: RgsmHost | undefined;
+  let context;
+  let failed = false;
+  try {
+    host = await startRgsmHost({
+      appDataDir: device.appDataDir,
+      deviceId: DEVICE_A_ID,
+      logPath: join(runRoot, 'host.log'),
+    });
+    const started = await newDeviceContext(browser, host);
+    context = started.context;
+    const page = started.page;
+    // Only OS discovery is controlled; editing, saving and reloading use the real host.
+    await page.route('**/api/v1/detect-game-roots', (route) =>
+      route.fulfill({
+        json: ['C:/Steam/', 'c:\\steam', 'D:/Games', 'd:\\games\\'],
+      })
+    );
+    await openApp(page);
+    await page.getByRole('button', { name: 'Settings', exact: true }).click();
+    await page.getByRole('button', { name: 'Auto Scan', exact: true }).click();
+    const roots = page.getByRole('textbox', { name: 'e.g. D:\\Steam', exact: true });
+    await expect(roots).toHaveCount(2);
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const saved = page.waitForResponse((response) =>
+        response.url().endsWith('/api/v1/set-config')
+      );
+      await page.getByRole('button', { name: 'Auto-detect', exact: true }).click();
+      expect((await saved).ok()).toBe(true);
+      await expect(roots).toHaveCount(2);
+      await expect(roots.nth(0)).toHaveValue('C:/Steam');
+      await expect(roots.nth(1)).toHaveValue('D:/Games');
+    }
+    const stored = await hostPost<Config>(host, '/api/v1/get-local-config');
+    expect(stored.ok, stored.raw).toBe(true);
+    const storedDevice = stored.data.devices![DEVICE_A_ID]!;
+    expect(storedDevice.resources!.map((resource) => resource.id)).toEqual([2, 6, 9]);
+    expect(storedDevice.next_resource_id).toBe(10);
+    expect(stored.data.games[0]!.device_bindings?.[DEVICE_A_ID]?.rootIds).toEqual([2]);
+    const installation = storedDevice.resources!.find((resource) => resource.id === 6)!;
+    expect(installation.kind.type === 'gameInstallation' && installation.kind.root_id).toBe(2);
+    await page.reload();
+    await page.getByRole('button', { name: 'Auto Scan', exact: true }).click();
+    await expect(roots).toHaveCount(2);
+    await expect(roots.nth(1)).toHaveValue('D:/Games');
+    await page.screenshot({
+      path: test.info().outputPath('game-roots.png'),
+      animations: 'disabled',
+    });
+  } catch (error) {
+    failed = true;
+    throw error;
+  } finally {
+    await context?.close();
+    await host?.stop();
+    if (!failed) await removeRunRoot(runRoot);
+  }
+});

--- a/apps/rgsm-gui/package.json
+++ b/apps/rgsm-gui/package.json
@@ -6,7 +6,7 @@
     "web:build": "vite build",
     "web:dev": "pnpm web:generate-api && node scripts/web-dev.mjs",
     "web:preview": "vite preview",
-    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/cloudLibraryNotice.test.mjs src/ui/overlayDepth.test.mjs src/utils/appRoutes.test.mjs src/utils/gameName.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs src/components/management/undoRestore.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
+    "web:test": "node --test src/api/eventDispatcher.test.mjs src/utils/cloudNamespace.test.mjs src/utils/cloudLibraryNotice.test.mjs src/ui/overlayDepth.test.mjs src/utils/appRoutes.test.mjs src/utils/gameName.test.mjs src/utils/gameRoots.test.mjs src/utils/saveUnit.test.mjs src/utils/snapshotPresentation.test.mjs src/utils/devicePositions.test.mjs src/utils/gameOrder.test.mjs src/components/management/snapshotAvailability.test.mjs src/components/management/undoRestore.test.mjs e2e/support/build-state.test.mjs e2e/support/http-probe.test.mjs e2e/support/cdp-page.test.mjs e2e/support/process.test.mjs e2e/support/shards.test.mjs e2e/support/command-result.test.mjs",
     "web:e2e": "playwright test --project=browser",
     "web:e2e:desktop": "playwright test --project=desktop",
     "dev": "tauri dev -- --locked",

--- a/apps/rgsm-gui/src/pages/Settings.vue
+++ b/apps/rgsm-gui/src/pages/Settings.vue
@@ -48,6 +48,7 @@ import { error, info } from '../utils/logger';
 import type { CloudNamespaceGeneration, Device } from '../api/commands';
 import { saveUnitPaths } from '../utils/saveUnit';
 import { applyGameOrder } from '../utils/gameOrder';
+import { mergeDuplicateGameRoots, newGameRootPaths } from '../utils/gameRoots';
 
 const isDark = useDark();
 const { config, refreshConfig, saveConfig } = useConfig();
@@ -504,7 +505,10 @@ function addGameRoot() {
 let gameRootsSaveQueue = Promise.resolve();
 
 function saveGameRoots() {
-  gameRootsSaveQueue = gameRootsSaveQueue.then(() => persistDeviceInfo(false));
+  gameRootsSaveQueue = gameRootsSaveQueue.then(() => {
+    mergeDuplicateGameRoots(currentDevice.value, config.value.games);
+    return persistDeviceInfo(false);
+  });
   return gameRootsSaveQueue;
 }
 
@@ -541,9 +545,9 @@ async function autoDetectGameRoots() {
   try {
     const result = await commands.detectGameRoots();
     if (result.status === 'ok') {
-      const existing = new Set(getCurrentGameRoots());
-      const newRoots = result.data.filter((r) => !existing.has(r));
+      const newRoots = newGameRootPaths(getCurrentGameRoots(), result.data);
       if (newRoots.length === 0) {
+        await saveGameRoots();
         notifyInfo($t('settings.game_roots_no_new'));
         return;
       }

--- a/apps/rgsm-gui/src/utils/gameRoots.test.mjs
+++ b/apps/rgsm-gui/src/utils/gameRoots.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { gameRootPathKey, mergeDuplicateGameRoots, newGameRootPaths } from './gameRoots.ts';
+
+test('Steam detection compares Windows path identity and deduplicates the incoming batch', () => {
+  assert.deepEqual(
+    newGameRootPaths(
+      ['c:\\program files (x86)\\steam'],
+      ['C:/Program Files (x86)/Steam/', 'D:/Games', 'd:\\games\\']
+    ),
+    ['D:/Games']
+  );
+});
+
+test('Unix root paths remain case-sensitive', () => {
+  assert.deepEqual(newGameRootPaths(['/games'], ['/games/', '/Games']), ['/Games']);
+  assert.notEqual(gameRootPathKey('c:'), gameRootPathKey('C:/'));
+  assert.equal(gameRootPathKey('/'), '/');
+});
+
+test('merging roots preserves IDs, bindings, installations, other stores and empty drafts', () => {
+  const root = (id, path, store = 'steam') => ({
+    id,
+    source: 'manual',
+    kind: { type: 'gameRoot', store, path },
+  });
+  const device = {
+    id: 'pc',
+    next_resource_id: 20,
+    resources: [
+      root(2, 'C:/Steam'),
+      root(5, 'c:\\steam\\'),
+      root(8, 'C:/Steam', 'other'),
+      root(9, ''),
+      root(10, ''),
+      {
+        id: 12,
+        kind: { type: 'gameInstallation', root_id: 5, path: 'C:/Steam/steamapps/common/Test' },
+      },
+    ],
+  };
+  const games = [{ device_bindings: { pc: { rootIds: [5, 2, 8] }, other: { rootIds: [5] } } }];
+  mergeDuplicateGameRoots(device, games);
+  assert.deepEqual(
+    device.resources.map((resource) => resource.id),
+    [2, 8, 9, 10, 12]
+  );
+  assert.equal(device.next_resource_id, 20);
+  assert.equal(device.resources.at(-1).kind.root_id, 2);
+  assert.deepEqual(games[0].device_bindings.pc.rootIds, [2, 8]);
+  assert.deepEqual(games[0].device_bindings.other.rootIds, [5]);
+  const once = structuredClone({ device, games });
+  mergeDuplicateGameRoots(device, games);
+  assert.deepEqual({ device, games }, once);
+});

--- a/apps/rgsm-gui/src/utils/gameRoots.ts
+++ b/apps/rgsm-gui/src/utils/gameRoots.ts
@@ -1,0 +1,47 @@
+import type { Device, Game } from '../api/commands';
+
+export function gameRootPathKey(path: string): string {
+  const windowsPath =
+    /^[a-z]:[\\/]/i.test(path) || path.startsWith('\\\\') || path.startsWith('//');
+  const normalized = windowsPath ? path.replaceAll('\\', '/').toLowerCase() : path;
+  const key = normalized.replace(/\/+$/, '') || '/';
+  return windowsPath && /^[a-z]:$/i.test(key) ? `${key}/` : key;
+}
+
+export function newGameRootPaths(existing: string[], detected: string[]): string[] {
+  const paths = new Set(existing.map(gameRootPathKey));
+  return detected.filter((path) => {
+    const key = gameRootPathKey(path);
+    if (paths.has(key)) return false;
+    paths.add(key);
+    return true;
+  });
+}
+
+/** Keep stable resource IDs and retarget bindings before dropping duplicate roots. */
+export function mergeDuplicateGameRoots(device: Device, games: Game[]): void {
+  const roots = new Map<string, number>();
+  const replacements = new Map<number, number>();
+  device.resources = (device.resources ?? []).filter((resource) => {
+    if (resource.kind.type !== 'gameRoot' || !resource.kind.path.trim()) return true;
+    const key = `${resource.kind.store}:${gameRootPathKey(resource.kind.path)}`;
+    const retained = roots.get(key);
+    if (retained === undefined) {
+      roots.set(key, resource.id);
+      return true;
+    }
+    replacements.set(resource.id, retained);
+    return false;
+  });
+  for (const resource of device.resources) {
+    if (resource.kind.type === 'gameInstallation') {
+      resource.kind.root_id = replacements.get(resource.kind.root_id) ?? resource.kind.root_id;
+    }
+  }
+  for (const game of games) {
+    const binding = game.device_bindings?.[device.id];
+    if (binding?.rootIds) {
+      binding.rootIds = [...new Set(binding.rootIds.map((id) => replacements.get(id) ?? id))];
+    }
+  }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/legacy_config_tests.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/legacy_config_tests.rs
@@ -1,0 +1,84 @@
+use super::{CloudNamespaceClassification, CloudNamespaceClassifier};
+use crate::{cloud_sync::V1_CONFIG_PATH, config::ConfigurationOwners};
+use opendal::{Operator, services};
+
+const RELEASED_18: &str = include_str!("../../../tests/fixtures/config-upgrade/config_v1_8_0.json");
+
+#[test]
+fn legacy_cloud_identity_preserves_directory_names_and_existing_keys() {
+    let mut raw: serde_json::Value = serde_json::from_str(RELEASED_18).unwrap();
+    raw["games"][0]["name"] = "A__B".into();
+    let config = crate::updater::decode_legacy_cloud_config(&raw.to_string()).unwrap();
+    assert_eq!(config.games[0].storage_key, "A__B");
+
+    raw["games"][0]["storage_key"] = "existing-folder".into();
+    let config = crate::updater::decode_legacy_cloud_config(&raw.to_string()).unwrap();
+    assert_eq!(config.games[0].storage_key, "existing-folder");
+
+    raw["version"] = "1.9.0".into();
+    raw["games"][0]["storage_key"] = "".into();
+    let config = crate::updater::decode_legacy_cloud_config(&raw.to_string()).unwrap();
+    assert!(
+        config.games[0].storage_key.is_empty(),
+        "do not invent identities for invalid current-format data"
+    );
+}
+
+#[test]
+fn legacy_cloud_schema_preserves_declared_types_and_explicit_root_bindings() {
+    let mut raw: serde_json::Value = serde_json::from_str(RELEASED_18).unwrap();
+    raw["games"][0]["save_paths"][1]["paths"]["desktop-gamma"] = "<root>/Saved".into();
+    raw["devices"]["desktop-gamma"]["game_roots"] = serde_json::json!(["D:/Games"]);
+    let config = crate::updater::decode_legacy_cloud_config(&raw.to_string()).unwrap();
+    let game = &config.games[0];
+    assert_eq!(
+        game.save_paths[0].unit_type(),
+        Some(&crate::backup::SaveUnitType::WinRegistry)
+    );
+    assert_eq!(
+        game.save_paths[1].unit_type(),
+        Some(&crate::backup::SaveUnitType::Folder)
+    );
+    assert!(matches!(
+        &game.save_paths[1].source,
+        crate::backup::SaveUnitSource::ManifestPattern { .. }
+    ));
+    let root_id = game.device_bindings["desktop-gamma"]
+        .root_ids
+        .as_ref()
+        .unwrap()[0];
+    assert!(matches!(
+        &config.devices["desktop-gamma"].resource(root_id).unwrap().kind,
+        crate::device::DeviceResourceKind::GameRoot { path, .. } if path == "D:/Games"
+    ));
+}
+
+#[tokio::test]
+async fn released_cloud_configs_have_usable_game_identities_without_remote_writes() {
+    for bytes in [
+        include_bytes!("../../../tests/fixtures/config-upgrade/config_v1_7_0.json").as_slice(),
+        include_bytes!("../../../tests/fixtures/config-upgrade/config_v1_8_0.json").as_slice(),
+    ] {
+        let op = Operator::new(services::Memory::default()).unwrap().finish();
+        op.write(V1_CONFIG_PATH, bytes.to_vec()).await.unwrap();
+        let CloudNamespaceClassification::V1Only { config } =
+            CloudNamespaceClassifier::new(op.clone())
+                .classify()
+                .await
+                .unwrap()
+        else {
+            panic!("released configuration should remain in the V1 namespace");
+        };
+        for game in &config.games {
+            assert_eq!(game.storage_key, game.name);
+            assert!(
+                game.next_save_unit_id > game.save_paths.iter().map(|unit| unit.id).max().unwrap()
+            );
+        }
+        ConfigurationOwners::from_legacy(&config, &"reader".into())
+            .validate()
+            .unwrap();
+        assert_eq!(op.read(V1_CONFIG_PATH).await.unwrap().to_vec(), bytes);
+        assert!(op.list("v2/").await.unwrap().is_empty());
+    }
+}

--- a/crates/rgsm-core/src/cloud_sync/v2/mod.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/mod.rs
@@ -8,6 +8,8 @@ mod game_comparison;
 pub(crate) mod game_deletion;
 mod integrity;
 mod join;
+#[cfg(test)]
+mod legacy_config_tests;
 mod local_eviction;
 mod manifest;
 mod materialization;

--- a/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
+++ b/crates/rgsm-core/src/cloud_sync/v2/namespace.rs
@@ -216,7 +216,9 @@ impl<T: NamespaceTransport> CloudNamespaceClassifier<T> {
         }
 
         if let Some(bytes) = self.read_object(V1_CONFIG_PATH).await? {
-            let config = parse_json(V1_CONFIG_PATH, &bytes)?;
+            let raw: serde_json::Value = parse_json(V1_CONFIG_PATH, &bytes)?;
+            let config = crate::updater::decode_legacy_cloud_config(&raw.to_string())
+                .map_err(|error| CloudNamespaceError::LegacyConfiguration(error.to_string()))?;
             return Ok(CloudNamespaceClassification::V1Only {
                 config: Box::new(config),
             });
@@ -277,6 +279,8 @@ fn parse_json<T: for<'de> Deserialize<'de>>(
 
 #[derive(Debug, Error)]
 pub enum CloudNamespaceError {
+    #[error("Cannot migrate legacy cloud configuration: {0}")]
+    LegacyConfiguration(String),
     #[error("Cloud namespace transport error: {0}")]
     Transport(#[from] opendal::Error),
     #[error("Malformed cloud object {path}: {source}")]

--- a/crates/rgsm-core/src/steam.rs
+++ b/crates/rgsm-core/src/steam.rs
@@ -11,6 +11,9 @@ use log::{debug, warn};
 use serde::Deserialize;
 use thiserror::Error;
 
+mod libraries;
+pub use libraries::get_steam_library_paths;
+
 /// Errors specific to Steam integration.
 #[derive(Debug, Error)]
 pub enum SteamError {
@@ -107,49 +110,6 @@ impl StringOrNumber {
 pub fn get_steam_root() -> Result<PathBuf, SteamError> {
     let root = crate::path_resolver::get_steam_root().map_err(|_| SteamError::SteamNotFound)?;
     Ok(PathBuf::from(root))
-}
-
-/// Discover all Steam library paths from `libraryfolders.vdf`.
-///
-/// Returns a list of library root paths (e.g. `D:\SteamLibrary`).
-/// The Steam root itself is always included as the first library.
-pub fn get_steam_library_paths() -> Result<Vec<PathBuf>, SteamError> {
-    let steam_root = get_steam_root()?;
-    let vdf_path = steam_root.join("steamapps").join("libraryfolders.vdf");
-
-    if !vdf_path.exists() {
-        // Fallback: just use the steam root as the only library
-        warn!(
-            target: "rgsm::steam",
-            "libraryfolders.vdf not found at {}, using Steam root as only library",
-            vdf_path.display()
-        );
-        return Ok(vec![steam_root]);
-    }
-
-    let content = std::fs::read_to_string(&vdf_path).map_err(|e| SteamError::VdfRead {
-        path: vdf_path.clone(),
-        source: e,
-    })?;
-
-    let library_folders: HashMap<String, LibraryFolder> = keyvalues_serde::from_str(&content)
-        .map_err(|e| SteamError::VdfParse {
-            path: vdf_path.clone(),
-            reason: e.to_string(),
-        })?;
-
-    let mut libraries = vec![steam_root.clone()];
-    for library in library_folders.into_values().map(|folder| {
-        let p = folder.path.replace('\\', "/");
-        PathBuf::from(p)
-    }) {
-        if library.exists() && !libraries.contains(&library) {
-            libraries.push(library);
-        }
-    }
-
-    debug!(target: "rgsm::steam", "Found {} Steam libraries", libraries.len());
-    Ok(libraries)
 }
 
 /// Scan a single Steam library for installed games via `appmanifest_*.acf` files.

--- a/crates/rgsm-core/src/steam/libraries.rs
+++ b/crates/rgsm-core/src/steam/libraries.rs
@@ -1,0 +1,104 @@
+//! Steam library discovery and lexical path deduplication.
+
+use super::{LibraryFolder, SteamError, get_steam_root};
+use log::{debug, warn};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::PathBuf,
+};
+
+/// Discover all Steam library paths from `libraryfolders.vdf`.
+///
+/// Returns a list of library root paths (e.g. `D:\SteamLibrary`).
+/// The Steam root itself is always included as the first library.
+pub fn get_steam_library_paths() -> Result<Vec<PathBuf>, SteamError> {
+    let steam_root = get_steam_root()?;
+    let vdf_path = steam_root.join("steamapps").join("libraryfolders.vdf");
+
+    if !vdf_path.exists() {
+        // Fallback: just use the steam root as the only library
+        warn!(
+            target: "rgsm::steam",
+            "libraryfolders.vdf not found at {}, using Steam root as only library",
+            vdf_path.display()
+        );
+        return Ok(vec![steam_root]);
+    }
+
+    let content = std::fs::read_to_string(&vdf_path).map_err(|e| SteamError::VdfRead {
+        path: vdf_path.clone(),
+        source: e,
+    })?;
+
+    let library_folders: BTreeMap<String, LibraryFolder> = keyvalues_serde::from_str(&content)
+        .map_err(|e| SteamError::VdfParse {
+            path: vdf_path.clone(),
+            reason: e.to_string(),
+        })?;
+
+    let mut libraries = vec![steam_root.clone()];
+    for library in library_folders.into_values().map(|folder| {
+        let p = folder.path.replace('\\', "/");
+        PathBuf::from(p)
+    }) {
+        if library.exists() {
+            libraries.push(library);
+        }
+    }
+    let libraries = unique_library_paths(libraries);
+
+    debug!(target: "rgsm::steam", "Found {} Steam libraries", libraries.len());
+    Ok(libraries)
+}
+
+fn unique_library_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+    for path in paths {
+        let raw = path.to_string_lossy();
+        let windows_path = is_windows_library_path(&raw);
+        let display = if windows_path {
+            raw.replace('\\', "/")
+        } else {
+            raw.into_owned()
+        };
+        let key = if windows_path {
+            display.to_lowercase()
+        } else {
+            display.clone()
+        };
+        if seen.insert(key.trim_end_matches('/').to_string()) {
+            result.push(PathBuf::from(display));
+        }
+    }
+    result
+}
+
+fn is_windows_library_path(path: &str) -> bool {
+    path.starts_with(r"\\")
+        || path.starts_with("//")
+        || (path.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+            && path.as_bytes().get(1) == Some(&b':')
+            && matches!(path.as_bytes().get(2), Some(b'/' | b'\\')))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn library_paths_use_windows_identity_but_preserve_unix_case() {
+        let paths = [
+            r"c:\program files (x86)\steam",
+            "C:/Program Files (x86)/Steam/",
+            "D:/Games",
+            r"d:\games\",
+            "/games",
+            "/Games",
+        ]
+        .into_iter()
+        .map(PathBuf::from)
+        .collect();
+        assert_eq!(unique_library_paths(paths).len(), 4);
+    }
+}

--- a/crates/rgsm-core/src/updater/cloud_config.rs
+++ b/crates/rgsm-core/src/updater/cloud_config.rs
@@ -1,0 +1,22 @@
+use semver::Version;
+
+use super::{migration::migrate_config_schema, versions::VERSION_1_9_0};
+use crate::{config::Config, preclude::UpdaterError};
+
+/// Decode a V1 cloud configuration without touching this machine's configuration
+/// or discovering its resources. Before 1.9, cloud directories used game names.
+pub(crate) fn decode_legacy_cloud_config(content: &str) -> Result<Config, UpdaterError> {
+    let original: Config = serde_json::from_str(content)?;
+    let version = Version::parse(&original.version)?;
+    if version >= Version::parse(VERSION_1_9_0)? {
+        return Ok(original);
+    }
+    let mut config = migrate_config_schema(content, &version, None, &[])?;
+    for game in &mut config.games {
+        if game.storage_key.is_empty() {
+            game.storage_key = game.name.clone();
+        }
+    }
+    config.bind_legacy_game_references();
+    Ok(config)
+}

--- a/crates/rgsm-core/src/updater/migration.rs
+++ b/crates/rgsm-core/src/updater/migration.rs
@@ -47,7 +47,6 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<bool, UpdaterError> {
     let current = Version::parse(CURRENT_VERSION)?;
     let min_supported = Version::parse(MIN_SUPPORTED_VERSION)?;
     let version_1_6_0 = Version::parse(VERSION_1_6_0)?;
-    let version_1_7_5 = Version::parse(VERSION_1_7_5)?;
     let version_1_8_1 = Version::parse(VERSION_1_8_1)?;
     let version_1_9_0 = Version::parse(VERSION_1_9_0)?;
 
@@ -89,13 +88,11 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<bool, UpdaterError> {
     backup_config(path)?;
 
     // Migrate based on version
-    let mut new_cfg = migrate_config(&content, &version)?;
-    new_cfg = migrate_legacy_cloud_sync(&content, new_cfg)?;
     let detected_steam_roots = crate::steam::detect_game_roots().unwrap_or_default();
-    migrate_path_resource_schema(
+    let mut new_cfg = migrate_config_schema(
         &content,
-        &mut new_cfg,
-        get_current_device_id(),
+        &version,
+        Some(get_current_device_id()),
         &detected_steam_roots,
     )?;
 
@@ -112,11 +109,6 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<bool, UpdaterError> {
         migrate_game_snapshots_to_chain(&backup_path)?;
     }
 
-    // Assign stable IDs to save units if upgrading from before 1.7.5
-    if version < version_1_7_5 {
-        new_cfg = migrate_save_unit_ids(new_cfg);
-    }
-
     // Backfill storage_key for all games if upgrading from before 1.9.0
     if version < version_1_9_0 {
         new_cfg = migrate_storage_keys(new_cfg, &backup_path);
@@ -125,6 +117,27 @@ pub fn update_config<P: AsRef<Path>>(path: P) -> Result<bool, UpdaterError> {
     write_config_transactionally(path, serde_json::to_string_pretty(&new_cfg)?.as_bytes())?;
     info!(target: "rgsm::updater", "Config updated successfully to version {}", CURRENT_VERSION);
     Ok(true)
+}
+
+/// Upgrade configuration fields without reading or writing local/remote files.
+/// Storage identities are assigned separately using each storage layout's rules.
+pub(super) fn migrate_config_schema(
+    content: &str,
+    version: &Version,
+    current_device_id: Option<&str>,
+    detected_steam_roots: &[String],
+) -> Result<Config, UpdaterError> {
+    let mut config = migrate_legacy_cloud_sync(content, migrate_config(content, version)?)?;
+    migrate_path_resource_schema(
+        content,
+        &mut config,
+        current_device_id,
+        detected_steam_roots,
+    )?;
+    if version < &Version::parse(VERSION_1_7_5)? {
+        config = migrate_save_unit_ids(config);
+    }
+    Ok(config)
 }
 
 fn has_legacy_path_schema(content: &str) -> Result<bool, UpdaterError> {
@@ -170,7 +183,7 @@ fn has_legacy_path_schema(content: &str) -> Result<bool, UpdaterError> {
 fn migrate_path_resource_schema(
     content: &str,
     config: &mut Config,
-    current_device_id: &str,
+    current_device_id: Option<&str>,
     detected_steam_roots: &[String],
 ) -> Result<(), UpdaterError> {
     let raw: Value = serde_json::from_str(content)?;
@@ -194,7 +207,7 @@ fn migrate_path_resource_schema(
                 {
                     continue;
                 }
-                let store = if device_id == current_device_id
+                let store = if Some(device_id.as_str()) == current_device_id
                     && detected_steam_roots.contains(&normalized_path_identity(path))
                 {
                     StoreKind::Steam
@@ -1186,7 +1199,7 @@ mod tests {
         migrate_path_resource_schema(
             &raw.to_string(),
             &mut config,
-            "device",
+            Some("device"),
             &["d:/steamlibrary/".to_string()],
         )
         .unwrap();
@@ -1243,7 +1256,7 @@ mod tests {
             }]
         });
 
-        migrate_path_resource_schema(&raw.to_string(), &mut config, &device_id, &[]).unwrap();
+        migrate_path_resource_schema(&raw.to_string(), &mut config, Some(&device_id), &[]).unwrap();
 
         assert!(!config.games[0].device_bindings.contains_key(&device_id));
         assert!(matches!(

--- a/crates/rgsm-core/src/updater/mod.rs
+++ b/crates/rgsm-core/src/updater/mod.rs
@@ -6,10 +6,12 @@
 //! - Backup creation
 //! - Component updates
 
+mod cloud_config;
 pub mod migration;
 pub mod probe;
 
 #[allow(dead_code)]
 pub mod versions;
 
+pub(crate) use cloud_config::decode_legacy_cloud_config;
 pub use migration::update_config;

--- a/locales/en_US.json
+++ b/locales/en_US.json
@@ -189,7 +189,7 @@
         "delete_device_success": "Device removed successfully",
         "delete_device_failed": "Failed to remove device",
         "game_roots_title": "Game Library Roots",
-        "game_roots_hint": "Library folders like SteamLibrary, used to resolve the <root> path variable; Steam libraries are auto-detected when empty",
+        "game_roots_hint": "Add game library folders or detect your Steam libraries",
         "game_roots_path_placeholder": "e.g. D:\\Steam",
         "game_roots_add": "Add Root",
         "game_roots_auto_detect": "Auto-detect",

--- a/locales/zh_SIMPLIFIED.json
+++ b/locales/zh_SIMPLIFIED.json
@@ -189,7 +189,7 @@
         "delete_device_success": "设备已删除",
         "delete_device_failed": "删除设备失败",
         "game_roots_title": "游戏库根目录",
-        "game_roots_hint": "类似 SteamLibrary 的游戏库文件夹,用于解析 <root> 路径变量;留空时将自动检测 Steam 库",
+        "game_roots_hint": "添加游戏库文件夹，或自动检测 Steam 游戏库",
         "game_roots_path_placeholder": "例如 D:\\Steam",
         "game_roots_add": "添加根目录",
         "game_roots_auto_detect": "自动检测",


### PR DESCRIPTION
Fix the released-version cloud upgrade failure and duplicate Steam roots found during dogfooding.

- Decode pre-1.9 cloud configurations through the shared schema migration before cutover. Preserve legacy archive directory names, save-unit types/IDs and explicit device bindings without rewriting V1 objects or inferring this machine's paths.
- Compare Windows library paths consistently across Steam discovery and settings. Merge saved duplicates while retaining resource IDs and retargeting game/installation bindings; keep distinct stores and case-sensitive Unix paths separate.

Upgrade regression coverage now starts from released 1.7/1.8 configurations missing `storage_key`, rather than a 1.9 configuration in a V1 namespace. The browser tests exercise cutover, restore and repeated root detection with persisted bindings.